### PR TITLE
fix: disable `allWarningsAsErrors` temporarily

### DIFF
--- a/build-logic/src/main/kotlin/com/adevinta/spark/ProjectExtensions.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/ProjectExtensions.kt
@@ -83,7 +83,7 @@ internal fun Project.getVersionsCatalog(): VersionCatalog = runCatching {
 }.getOrThrow()
 
 internal inline fun <reified T : KotlinTopLevelExtension> Project.configureKotlin(
-    allWarningsAsErrors: Boolean = true,
+    @Suppress("UNUSED_PARAMETER") allWarningsAsErrors: Boolean = true,
     crossinline configure: T.() -> Unit = {},
 ) {
     configure<JavaPluginExtension> {
@@ -98,7 +98,18 @@ internal inline fun <reified T : KotlinTopLevelExtension> Project.configureKotli
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
             // kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
-            this.allWarningsAsErrors.set(allWarningsAsErrors)
+            with(spark().versions.showkase) {
+                if (toString() == "1.0.0-beta17") return@with
+                error(
+                    """
+                    Check if the following fix has been released in version `$this`: https://github.com/airbnb/Showkase/pull/344
+                    > 'newInstance(): T!' is deprecated
+                    If it has been fixed, please remove this check and restore the `allWarningsAsErrors` configuration.
+                    Otherwise, update the version check to `$this`.
+                    """.trimIndent(),
+                )
+            }
+            this.allWarningsAsErrors.set(false /*allWarningsAsErrors*/)
             explicitApiMode.set(ExplicitApiMode.Strict)
         }
     }

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkProperties.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkProperties.kt
@@ -48,6 +48,7 @@ internal class SparkVersions(catalog: VersionCatalog) {
     val `compileSdk` by catalog
     val `kotlin` by catalog
     val `ktlint` by catalog
+    val `showkase` by catalog
 
     private operator fun VersionCatalog.getValue(
         thisRef: Any?,


### PR DESCRIPTION
Because of an incompatibility with Showkase.
See https://github.com/airbnb/Showkase/pull/344