### PR TITLE
feat(catalog): Add french string res

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Catalog
+* 💬🇫🇷 The catalog app can now be used with a french locale.
+
 ## [1.2.0]
 
 _2025-03-19_

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/ComponentsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/ComponentsScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.onClick
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDeepLink
 import androidx.navigation.compose.rememberNavController
@@ -151,7 +150,7 @@ internal fun ComponentsListScreen(
             contentType = { ComponentsItemType.Component },
             itemContent = { component ->
                 ComponentItem(
-                    modifier = Modifier.semantics { onClick("Aller aux exemples", null) },
+                    // modifier = Modifier.semantics { onClick("Aller aux exemples", null) },
                     component = component,
                     countIndicator = component.examples.size,
                     onClick = {

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -62,6 +61,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
@@ -149,14 +149,14 @@ public fun IconsScreen(
         ) {
             ChipSelectable(
                 selected = showIcons,
-                text = "Icon",
+                text = stringResource(R.string.icons_filter_icon),
                 onClick = { showIcons = !showIcons },
                 style = ChipStyles.Tinted,
                 leadingIcon = if (showIcons) SparkIcons.Check else null,
             )
             ChipSelectable(
                 selected = showAnimatedIcons,
-                text = "Animated Icon",
+                text = stringResource(R.string.icons_filter_icon_animated),
                 onClick = { showAnimatedIcons = !showAnimatedIcons },
                 style = ChipStyles.Tinted,
                 leadingIcon = if (showAnimatedIcons) SparkIcons.Check else null,
@@ -166,14 +166,7 @@ public fun IconsScreen(
             modifier = modifier
                 .consumeWindowInsets(contentPadding)
                 .fillMaxSize()
-                .padding(horizontal = 16.dp)
-                .clickable(
-                    // no ripple effect is needed as this onClick is just to clear the focus of the search field
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() },
-                ) {
-                    focusManager.clearFocus()
-                },
+                .padding(horizontal = 16.dp),
             contentPadding = contentPadding,
             columns = GridCells.Adaptive(minSize = 60.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -193,10 +186,13 @@ public fun IconsScreen(
                             .clip(SparkTheme.shapes.small)
                             .combinedClickable(
                                 onLongClick = { copyToClipboard(context, iconName) },
+                                onLongClickLabel = stringResource(R.string.icons_item_long_click_a11y),
                                 onClick = {
                                     onIconClick(drawableRes, iconName, isAnimated)
                                 },
+                                onClickLabel = stringResource(R.string.icons_item_click_a11y),
                             )
+                            .semantics(mergeDescendants = true) {}
                             .padding(8.dp)
                             .animateItem(),
                         horizontalAlignment = Alignment.CenterHorizontally,

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
@@ -163,7 +163,7 @@ private val Dialogs = Component(
 )
 
 private val Dividers = Component(
-    id = "dividerss",
+    id = "dividers",
     name = "Dividers",
     description = R.string.component_divider_description,
     guidelinesUrl = "$ComponentGuidelinesUrl/p/867b47-divider",
@@ -174,7 +174,7 @@ private val Dividers = Component(
 )
 
 private val Dropdowns = Component(
-    id = "dropdownss",
+    id = "dropdowns",
     name = "Dropdowns",
     description = R.string.component_dropdowns_description,
     guidelinesUrl = "$ComponentGuidelinesUrl/p/1186e1705/p/323b83-dropdown",
@@ -185,7 +185,7 @@ private val Dropdowns = Component(
 )
 
 private val Icons = Component(
-    id = "iconss",
+    id = "icons",
     name = "Icons",
     illustration = R.drawable.illu_component_iconbutton,
     tintIcon = false,

--- a/catalog/src/main/res/values-fr/strings.xml
+++ b/catalog/src/main/res/values-fr/strings.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright (c) 2025 Adevinta
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+  -->
+<resources xmlns:tools="http://schemas.android.com/tools" tools:locale="fr">
+    <string name="app_name">Spark</string>
+
+    <string name="brand">Sélectionner une marque</string>
+    <string name="pro">Utiliser le thème Pro</string>
+
+    <string name="example_tokens_elevation_label">Valeur d’élévation : %d</string>
+    <string name="themepicker_navigation_label">Animation de la navigation</string>
+
+    <string name="description">Description</string>
+    <string name="examples">Exemples</string>
+    <string name="no_examples">Pas d’exemples</string>
+
+    <string name="theme_picker_mode_title">Mode</string>
+    <string name="theme_picker_theme_title" description="Thème de marque Spark. [CHAR_LIMIT=NONE]">Thème</string>
+    <string name="theme_picker_text_direction_title" description="Simuler la direction du texte du système en LTR ou RTL. [CHAR_LIMIT=NONE]">Sens du texte</string>
+    <string name="theme_picker_font_scale_title" description="Simuler la mise à l'échelle de la police a11y. [CHAR_LIMIT=NONE]">Échelle de la police</string>
+    <string name="examples_component_screen_title">Exemples de composants</string>
+    <string name="examples_component_screen_description">Voici les exemples que l’on peut trouver dans les échantillons de la javadoc ou dans les fichiers README.md. Ils montrent l’utilisation des composants avec les paramètres par défaut dans différents scénarios qui devraient représenter des cas d’utilisation réels.</string>
+    <string name="component_button_description">Les boutons aident les utilisateurs à exécuter des actions, comme envoyer un e-mail, partager un document ou aimer une publication.</string>
+    <!--region Toggle-->
+    <string name="component_toggle_vertical_group_title">Groupe de checkbox vertical</string>
+    <string name="component_toggle_horizontal_group_title">Regroupement de bascules avec alignement horizontal</string>
+    <string name="configurator_component_checkbox_toggleable_state_label">État de coche</string>
+    <string name="configurator_component_toggle_content_side_label">Côté du contenu</string>
+    <string name="configurator_component_toggle_placeholder_label">Titre de la case</string>
+    <!--endregion-->
+    <!--region Checkbox-->
+    <string name="component_checkbox_description">Les cases à cocher sont utilisées lorsqu’il y a plusieurs éléments à sélectionner dans une liste. Les utilisateurs peuvent sélectionner zéro, un ou plusieurs éléments.</string>
+    <string name="component_checkbox_content_side_example_label">Ceci est un exemple de texte multiligne qui est très long et dans lequel l’utilisateur doit lire toutes les informations.</string>
+    <string name="component_checkbox_group_example_group_label">Notifications et e-mails</string>
+    <string name="component_checkbox_group_example_option1_label">Notifications</string>
+    <string name="component_checkbox_group_example_option2_label">E-mail</string>
+    <!--endregion-->
+    <!--Chips example-->
+    <string name="component_chips_description">Les chips aident les utilisateurs à reconnaître rapidement une information importante qu’ils ont saisie, à déclencher des actions, à faire des sélections ou à filtrer du contenu.</string>
+    <!--endregion-->
+
+    <string name="component_dialog_description">Une boîte de dialogue est une fenêtre modale (qui survol l\'affichage principal) qui apparaît devant le contenu pour fournir des informations essentielles ou demander une décision.</string>
+    <!--Dropdowns example-->
+    <string name="component_dropdowns_description">Une liste déroulante est un élément interactif qui permet aux utilisateurs de sélectionner une option dans une liste de choix présentée dans un menu pliable. Elle permet de gagner de la place sur l’interface en masquant les options jusqu’à ce que l’utilisateur interagisse avec le composant.</string>
+    <!--endregion-->
+
+    <string name="component_tab_description">Les onglets sont utilisés pour regrouper des contenus différents mais connexes, ce qui permet aux utilisateurs de naviguer dans les vues sans quitter la page. Ils contiennent toujours au moins deux éléments et un seul onglet est actif à la fois.</string>
+    <string name="component_textfield_description">Le composant champ de saisie / champ de texte permet aux utilisateurs d’écrire dans l’espace prévu à cet effet.</string>
+    <string name="component_tokens_description">Les tokens/jetons sont la base de ce système de design et permettent à chaque marque de choisir ses couleurs, formes, typos et icônes.</string>
+    <string name="component_popovers_description">Fournit un message descriptif ou une information pour un élément d’ancrage.</string>
+    <string name="component_bottomsheets_description">Une Bottom sheet est un composant d’interface utilisateur couramment utilisé dans les applications mobiles pour présenter du contenu ou des options supplémentaires à partir du bas de l’écran.</string>
+    <!--region Icon button-->
+    <string name="component_iconbutton_description">Les icône boutons aident les utilisateurs à effectuer des actions supplémentaires d’un simple toucher. Elles sont utilisées lorsqu’un bouton compact est nécessaire, par exemple dans une barre d’outils ou une liste d’images.</string>
+    <!--endregion-->
+    <!--region Icon Toggle button-->
+    <string name="component_icontogglebutton_description">Les icône boutons à selectionner aident les utilisateurs à effectuer des actions de selection supplémentaires d’un simple toucher. Ils sont utilisés lorsqu’un bouton compact est nécessaire, par exemple dans une barre d’outils ou une liste d’images.</string>
+    <!--endregion-->
+    <!--region image -->
+    <string name="component_image_description">Le composant Image est utilisé pour afficher des images avec une prise en charge de d\'image ou icône de secours en cas de problème de chargment.</string>
+    <string name="component_image_narrow_description">Photographie de rue d’une personne marchant dans une ruelle pavée après la pluie avec des lumières blanches/dorées brillantes sur le côté et la couleur bleue foncée au centre avec un parapluie</string>
+    <string name="component_image_wide_description">Un immense portrait de la statue grandeur nature de l’Unicorn Gundam à l’Odaiba’s DiverCity Tokyo Plaza.</string>
+    <string name="component_image_content_scale_crop_description">Mettre l’image à l’échelle pour remplir à 100 % les limites du composant Image, mais sans modifier son rapport</string>
+    <string name="component_image_content_scale_fit_description">Mettre à l’échelle pour s’assurer que l’image n’est pas rognée et que les limites du composant d’image sont remplies dans au moins une direction</string>
+    <string name="component_image_content_scale_fill_height_description">Mettre l’image à l’échelle pour remplir la hauteur de ses limites tout en conservant son rapport hauteur/largeur, mais peut remplir ou non la largeur en rognant</string>
+    <string name="component_image_content_scale_fill_width_description">Mettre l’image à l’échelle pour remplir la largeur de ses limites tout en conservant son rapport hauteur/largeur, mais peut remplir ou non la hauteur en rognant</string>
+    <string name="component_image_content_scale_inside_description">Identique à <b>Ajuster</b>, sauf qu’elle ne la met à l’échelle que si elle est plus grande que le composant image, sinon elle restera <i>plus petite</i> que les limites</string>
+    <string name="component_image_content_scale_none_description">Pas de mise à l’échelle, l’image reste à sa taille d’origine</string>
+    <string name="component_image_content_scale_fill_bounds_description">Étirer l’image pour remplir 100 % des limites du composant d’image</string>
+    <!--endregion-->
+    <!--region Radio button-->
+    <string name="component_radiobutton_description">Composant utilisé lorsqu’un seul choix peut être sélectionné dans une série d’options.</string>
+    <!--endregion-->
+    <!--region rating-->
+    <string name="component_ratingdisplay_description">Les évaluations / notes permettent aux utilisateurs de voir et/ou de définir une note en étoiles pour un utilisateur ou une expérience.</string>
+    <!--endregion-->
+    <!--region Switch-->
+    <string name="component_switch_description">Le composant Switch permet à l’utilisateur d’activer ou de désactiver l’état d’un élément ou d’un concept. Il est également utilisé pour contrôler les options binaires (Activé/Désactivé ou Vrai/Faux).</string>
+
+    <!--endregion-->
+    <!--region Stepper-->
+    <string name="component_stepper_description">Le Stepper permet aux utilisateurs de spécifier rapidement une valeur dans une plage donnée.</string>
+
+    <!--endregion-->
+    <string name="component_progressbar_description">Le composant barre de progression est utilisé pour afficher la longueur et votre progression à l’intérieur du processus ou pour exprimer un temps d’attente. Ce temps d’attente peut être déterminé ou indéterminé.</string>
+    <string name="component_tag_description">Les tags/étiquettes sont utilisées pour étiqueter le contenu et aider les utilisateurs à reconnaître rapidement des informations les concernant : Catégories, État… Peuvent être appliquées avec différentes couleurs et différents designs qui sont associés à un contenu en raison de ses caractéristiques : nouveau contenu, contenu non visité, contenu en vedette… Les utilisateurs ne peuvent pas interagir avec les étiquettes.</string>
+
+    <!--region Progress Tracker-->
+    <string name="component_progresstracker_description">Un composant de suivi de la progression est un élément de navigation visuelle généralement utilisé pour afficher la progression ou guider l’utilisateur à travers un processus à plusieurs étapes.</string>
+    <!--endregion-->
+
+    <string name="component_textlink_description">Un lien textuelle est une référence à une ressource. Elle peut être externe (par exemple, une autre page Web) ou interne (par exemple, un élément spécifique de la page actuelle).</string>
+
+    <string name="component_slider_description">Un slider/curseur est un composant interactif qui permet aux utilisateurs de définir des valeurs en déplaçant une poignée dans une plage définie.</string>
+
+    <string name="configurator_component_screen_title">Configurations des composants</string>
+    <string name="configurator_component_screen_description">Le configurateur permet de visualiser un composant dans tous les états possibles disponibles en personnalisant chaque propriété pour chaque composant.</string>
+    <string name="configurator_component_screen_enabled_label">Activé</string>
+    <string name="configurator_component_screen_rounded_label">Coins arrondis</string>
+    <string name="configurator_component_screen_textfield_label">Titre</string>
+    <string name="configurator_component_screen_intent_label">Intention</string>
+
+    <string name="component_menu_guidlines">Voir les directives de conception</string>
+    <string name="component_menu_dev_docs">Voir la documentation pour développeur</string>
+    <string name="component_menu_source">Voir le code source</string>
+    <string name="component_menu_issue">Signaler un problème</string>
+
+    <string name="icons_screen_search_helper">Rechercher une icône Spark</string>
+
+    <string name="spark_text_link_paragraph_example_"><annotation color="neutral" typography="body1">Ceci est la </annotation><annotation color="main" typography="body1"><u><b>Politique de confidentialité</b></u></annotation><annotation color="neutral" typography="body1">d’Adevinta ainsi que de nombreuses informations supplémentaires qui pourraient vous intéresser ou dont je devrais vous informer et que vous ignorez peut-être</annotation></string>
+
+    <string name="spark_text_link_short_example_"><annotation color="neutral" typography="display2">Apprendre la programmation Kotlin </annotation><annotation color="success" typography="display3"><u><b>https://kotlinlang.org</b></u></annotation></string>
+
+    <!--region Divider-->
+    <string name="component_divider_description">Le composant Divider/Séparateur fournit une ligne fine et discrète qui sépare et distingue les sections de contenu afin de renforcer la hiérarchie visuelle.\\u2028Voici quelques utilisations courantes:\nSéparer les sections sur une page.\nSéparer les éléments d’une liste.\nCréer un contraste visuel entre les deux côtés d’une page.</string>
+    <!--endregion-->
+
+    <string name="component_snackbar_description">Un composant snackbar/barre de notification est une brève notification non intrusive qui apparaît en bas d’un écran, fournissant un retour d’information ou des informations concises sur les actions de l’utilisateur.</string>
+    <string name="icons_item_long_click_a11y">Copier dans le presse-papier</string>
+    <string name="icons_item_click_a11y">Accéder aux détails</string>
+    <string name="icons_filter_icon_animated">Icône animée</string>
+    <string name="icons_filter_icon">Icône</string>
+
+</resources>

--- a/catalog/src/main/res/values/strings.xml
+++ b/catalog/src/main/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="brand">Select a brand</string>
     <string name="pro">Use the pro theme</string>
 
-    <string name="scale">%.1f</string>
+    <string name="scale" translatable="false">%.1f</string>
     <string name="example_tokens_elevation_label">Elevation value: %d</string>
     <string name="themepicker_navigation_label">Navigation Motion</string>
 
@@ -77,7 +77,7 @@
     <string name="component_icontogglebutton_description">Icon toggle buttons help people take supplementary actions with a single tap. They’re used when a compact button is required, such as in a toolbar or image list.</string>
     <!--endregion-->
     <!--region image -->
-    <string name="component_image_description">The Image component is used to display images with support for fallback.</string>
+    <string name="component_image_description">The Image component is used to display images with support for fallback in case of issues when loading them.</string>
     <string name="component_image_narrow_description">Street photography of a person walking in a paved alley after a rain with bright white/golden lights on the side and the center deep blue color with an umbrella</string>
     <string name="component_image_wide_description">A huge portrait of the Unicorn Gundam fullscale statue at the Odaiba’s DiverCity Tokyo Plaza.</string>
     <string name="component_image_content_scale_crop_description">Scale the image to fill 100% the bounds of the Image component but without changing its ratio</string>
@@ -139,5 +139,9 @@
     <!--endregion-->
 
     <string name="component_snackbar_description">A snackbar component is a brief, non-intrusive notification that appears at the bottom of a screen, delivering concise feedback or information about user actions.</string>
+    <string name="icons_item_long_click_a11y">Copy to clipboard</string>
+    <string name="icons_item_click_a11y">Navigate to details</string>
+    <string name="icons_filter_icon_animated">Animated Icon</string>
+    <string name="icons_filter_icon">Icon</string>
 
 </resources>


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add generated translations from english to french for the catalog app ressources.
Add a few new a11y content strings to make the app more navigable with a screen reader.

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
When testing a11y with a screen reader in Android we would get english text read as french which is not ideal.

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

