### PR TITLE
chore: remove lfs checkout for firebase-app-distribution.yml

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
-          lfs: true
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-gradle
       - uses: ./.github/actions/setup-gradle-properties


### PR DESCRIPTION
as it should not be necessary to build the catalog app and upload it to Firebase.