### PR TITLE
feat: add screenshot tests for `Badge` composable

### DIFF
--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/badge/BadgeScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/badge/BadgeScreenshot.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.badge
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.DeviceConfig
+import com.adevinta.spark.paparazziRule
+import com.adevinta.spark.sparkSnapshot
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode.SHRINK
+import org.junit.Rule
+import org.junit.Test
+
+class BadgeScreenshot {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DeviceConfig.PIXEL_C,
+    )
+
+    @Test
+    fun badge() = paparazzi.sparkSnapshot(drawBackground = false) {
+        Column {
+            BadgeStyle.entries.forEach { style ->
+                Row {
+                    BadgeIntent.entries.forEach { intent ->
+                        Column(
+                            modifier = Modifier.padding(4.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Badge(content = null, intent = intent, badgeStyle = style)
+                            Badge(count = 1, intent = intent, badgeStyle = style)
+                            Badge(count = 42, intent = intent, badgeStyle = style)
+                            Badge(count = 123, intent = intent, badgeStyle = style)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.badge_BadgeScreenshot_badge.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.badge_BadgeScreenshot_badge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ab0e036a631e29e8c41a3710cae306f8859d3db5463948edf66e1817a806f24
+size 56774


### PR DESCRIPTION
- [x] The initial fix was merged as part of https://github.com/leboncoin/spark-android/commit/c4410563fcd9f41771ae7fa2da4269719c330815
- [x] wait for the fix on the extensions incorrectly re-applying the modifier chain
      #1501