### PR TITLE
refactor(Catalog): Use Dropdown Enum everywhere it can be used

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/bottomsheet/BottomSheetConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/bottomsheet/BottomSheetConfigurator.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.bottomsheet.BottomSheet
 import com.adevinta.spark.components.bottomsheet.DragHandle
@@ -57,11 +58,9 @@ import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.image.Illustration
 import com.adevinta.spark.components.image.Image
 import com.adevinta.spark.components.list.ListItem
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.spacer.VerticalSpacer
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.text.TextLinkButton
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.toggles.SwitchLabelled
 import com.adevinta.spark.icons.LikeFill
 import com.adevinta.spark.icons.SparkIcons
@@ -115,25 +114,12 @@ private fun ColumnScope.BottomSheetSample() {
         )
     }
 
-    val contentExamples = BottomSheetContentExamples.entries.toTypedArray()
-    var expanded by remember { mutableStateOf(false) }
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = bottomSheetContentExample.name,
-        label = "BottomSheet Content Example",
-        expanded = expanded,
-        onExpandedChange = { expanded = !expanded },
-        onDismissRequest = { expanded = false },
-        dropdownContent = {
-            contentExamples.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        bottomSheetContentExample = it
-                        expanded = false
-                    },
-                )
-            }
+        title = "BottomSheet Content Example",
+        selectedOption = bottomSheetContentExample,
+        onOptionSelect = {
+            bottomSheetContentExample = it
         },
     )
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/ButtonsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/ButtonsConfigurator.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonContrast
@@ -53,10 +54,8 @@ import com.adevinta.spark.components.buttons.ButtonTinted
 import com.adevinta.spark.components.buttons.IconSide
 import com.adevinta.spark.components.iconbuttons.toggle.IconToggleButtonFilled
 import com.adevinta.spark.components.iconbuttons.toggle.IconToggleButtonIcons
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.surface.Surface
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.toggles.SwitchLabelled
 import com.adevinta.spark.icons.LikeFill
@@ -157,29 +156,12 @@ private fun ColumnScope.ButtonSample() {
         onOptionSelect = { shape = it },
     )
 
-    val intents = ButtonIntent.entries.toTypedArray()
-    var expanded by remember { mutableStateOf(false) }
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = "Intent",
-        expanded = expanded,
-        onExpandedChange = {
-            expanded = !expanded
-        },
-        onDismissRequest = {
-            expanded = false
-        },
-        dropdownContent = {
-            intents.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        intent = it
-                        expanded = false
-                    },
-                )
-            }
+        title = "Intent",
+        selectedOption = intent,
+        onOptionSelect = {
+            intent = it
         },
     )
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconButtonsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconButtonsConfigurator.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonShape
@@ -48,10 +49,8 @@ import com.adevinta.spark.components.iconbuttons.IconButtonIntent
 import com.adevinta.spark.components.iconbuttons.IconButtonOutlined
 import com.adevinta.spark.components.iconbuttons.IconButtonSize
 import com.adevinta.spark.components.iconbuttons.IconButtonTinted
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.surface.Surface
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.toggles.SwitchLabelled
 import com.adevinta.spark.icons.LikeFill
@@ -116,30 +115,11 @@ private fun ColumnScope.IconButtonSample() {
         onOptionSelect = { style = it },
     )
 
-    val intents = IconButtonIntent.entries
-    var expanded by remember { mutableStateOf(false) }
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = "Intent",
-        expanded = expanded,
-        onExpandedChange = {
-            expanded = !expanded
-        },
-        onDismissRequest = {
-            expanded = false
-        },
-        dropdownContent = {
-            intents.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        intent = it
-                        expanded = false
-                    },
-                )
-            }
-        },
+        title = "Intent",
+        selectedOption = intent,
+        onOptionSelect = { intent = it },
     )
 
     ButtonGroup(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconToggleButtonsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconToggleButtonsConfigurator.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonShape
@@ -49,10 +50,8 @@ import com.adevinta.spark.components.iconbuttons.toggle.IconToggleButtonGhost
 import com.adevinta.spark.components.iconbuttons.toggle.IconToggleButtonIcons
 import com.adevinta.spark.components.iconbuttons.toggle.IconToggleButtonOutlined
 import com.adevinta.spark.components.iconbuttons.toggle.IconToggleButtonTinted
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.surface.Surface
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.toggles.SwitchLabelled
 import com.adevinta.spark.icons.CarFill
@@ -107,28 +106,12 @@ private fun ColumnScope.IconToggleButtonSample() {
         onOptionSelect = { style = it },
     )
 
-    var expanded by remember { mutableStateOf(false) }
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = "Intent",
-        expanded = expanded,
-        onExpandedChange = {
-            expanded = !expanded
-        },
-        onDismissRequest = {
-            expanded = false
-        },
-        dropdownContent = {
-            IconButtonIntent.entries.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        intent = it
-                        expanded = false
-                    },
-                )
-            }
+        title = "Intent",
+        selectedOption = intent,
+        onOptionSelect = {
+            intent = it
         },
     )
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/popover/PopoverConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/popover/PopoverConfigurator.kt
@@ -45,19 +45,18 @@ import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonOutlined
 import com.adevinta.spark.components.iconbuttons.IconButtonFilled
 import com.adevinta.spark.components.image.Illustration
 import com.adevinta.spark.components.image.Image
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.popover.Popover
 import com.adevinta.spark.components.popover.PopoverIntent
 import com.adevinta.spark.components.spacer.VerticalSpacer
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.text.TextLinkButton
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.toggles.SwitchLabelled
 import com.adevinta.spark.icons.BurgerMenu
 import com.adevinta.spark.icons.SparkIcons
@@ -101,25 +100,12 @@ private fun ColumnScope.PopoverSample() {
         )
     }
 
-    val contentExamples = PopoverContentExamples.entries.toTypedArray()
-    var expanded by remember { mutableStateOf(false) }
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = popoverContentExample.name,
-        label = "Popover Content Example",
-        expanded = expanded,
-        onExpandedChange = { expanded = !expanded },
-        onDismissRequest = { expanded = false },
-        dropdownContent = {
-            contentExamples.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        popoverContentExample = it
-                        expanded = false
-                    },
-                )
-            }
+        title = "Popover Content Example",
+        selectedOption = popoverContentExample,
+        onOptionSelect = {
+            popoverContentExample = it
         },
     )
     ButtonGroup(
@@ -128,25 +114,12 @@ private fun ColumnScope.PopoverSample() {
         onOptionSelect = { popoverTriggerExample = it },
     )
 
-    val intents = PopoverIntent.entries
-    var intentExpanded by remember { mutableStateOf(false) }
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = "Popover Intent",
-        expanded = intentExpanded,
-        onExpandedChange = { intentExpanded = !intentExpanded },
-        onDismissRequest = { intentExpanded = false },
-        dropdownContent = {
-            intents.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        intent = it
-                        intentExpanded = false
-                    },
-                )
-            }
+        title = "Popover Intent",
+        selectedOption = intent,
+        onOptionSelect = {
+            intent = it
         },
     )
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/progressbar/ProgressbarConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/progressbar/ProgressbarConfigurator.kt
@@ -37,16 +37,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.progressbar.Progressbar
 import com.adevinta.spark.components.progressbar.ProgressbarIndeterminate
 import com.adevinta.spark.components.progressbar.ProgressbarIntent
 import com.adevinta.spark.components.slider.Slider
 import com.adevinta.spark.components.spacer.VerticalSpacer
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.textfields.TextFieldState
 import com.adevinta.spark.components.toggles.SwitchLabelled
@@ -67,7 +66,6 @@ private fun ColumnScope.ProgressbarSample() {
     var progress by remember { mutableFloatStateOf(0.5f) }
     val state: TextFieldState? by remember { mutableStateOf(null) }
     val stateMessageText by remember { mutableStateOf("State Message") }
-    var expanded by remember { mutableStateOf(false) }
 
     Text(text = "Progressbar")
 
@@ -86,26 +84,14 @@ private fun ColumnScope.ProgressbarSample() {
         isRounded = isRounded,
     )
 
-    val intents = ProgressbarIntent.entries
     VerticalSpacer(8.dp)
 
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = stringResource(id = R.string.configurator_component_screen_intent_label),
-        expanded = expanded,
-        onExpandedChange = { expanded = !expanded },
-        onDismissRequest = { expanded = false },
-        dropdownContent = {
-            intents.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        intent = it
-                        expanded = false
-                    },
-                )
-            }
+        title = stringResource(id = R.string.configurator_component_screen_intent_label),
+        selectedOption = intent,
+        onOptionSelect = {
+            intent = it
         },
     )
     VerticalSpacer(8.dp)

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/progresstracker/ProgressTrackerConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/progresstracker/ProgressTrackerConfigurator.kt
@@ -42,12 +42,12 @@ import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonIntent
 import com.adevinta.spark.components.buttons.ButtonTinted
 import com.adevinta.spark.components.card.ElevatedCard
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.progress.tracker.ProgressSizes
 import com.adevinta.spark.components.progress.tracker.ProgressStep
 import com.adevinta.spark.components.progress.tracker.ProgressStyles
@@ -55,7 +55,6 @@ import com.adevinta.spark.components.progress.tracker.ProgressTrackerColumn
 import com.adevinta.spark.components.progress.tracker.ProgressTrackerIntent
 import com.adevinta.spark.components.progress.tracker.ProgressTrackerRow
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.toggles.Switch
 import com.adevinta.spark.components.toggles.SwitchLabelled
@@ -124,25 +123,12 @@ private fun ColumnScope.ProgressTrackerSample() {
         selectedStep = selectedStep,
     )
 
-    val intents = ProgressTrackerIntent.entries
-
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = stringResource(id = R.string.configurator_component_screen_intent_label),
-        expanded = expanded,
-        onExpandedChange = { expanded = !expanded },
-        onDismissRequest = { expanded = false },
-        dropdownContent = {
-            intents.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        intent = it
-                        expanded = false
-                    },
-                )
-            }
+        title = stringResource(id = R.string.configurator_component_screen_intent_label),
+        selectedOption = intent,
+        onOptionSelect = {
+            intent = it
         },
     )
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/slider/SliderConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/slider/SliderConfigurator.kt
@@ -43,16 +43,15 @@ import androidx.compose.ui.unit.sp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.iconbuttons.IconButtonFilled
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.slider.RangeSlider
 import com.adevinta.spark.components.slider.Slider
 import com.adevinta.spark.components.slider.SliderIntent
 import com.adevinta.spark.components.spacer.VerticalSpacer
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.toggles.SwitchLabelled
 import com.adevinta.spark.icons.Minus
 import com.adevinta.spark.icons.Plus
@@ -162,23 +161,12 @@ private fun SliderSample() {
             }
         }
 
-        Dropdown(
+        DropdownEnum(
             modifier = Modifier.fillMaxWidth(),
-            value = intent.name,
-            label = stringResource(id = R.string.configurator_component_screen_intent_label),
-            expanded = expanded,
-            onExpandedChange = { expanded = !expanded },
-            onDismissRequest = { expanded = false },
-            dropdownContent = {
-                intents.forEach {
-                    DropdownMenuItem(
-                        text = { Text(it.name) },
-                        onClick = {
-                            intent = it
-                            expanded = false
-                        },
-                    )
-                }
+            title = stringResource(id = R.string.configurator_component_screen_intent_label),
+            selectedOption = intent,
+            onOptionSelect = {
+                intent = it
             },
         )
     }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/snackbar/SnackbarConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/snackbar/SnackbarConfigurator.kt
@@ -36,18 +36,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonSize
 import com.adevinta.spark.components.buttons.ButtonTinted
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.snackbars.Snackbar
 import com.adevinta.spark.components.snackbars.SnackbarHostState
 import com.adevinta.spark.components.snackbars.SnackbarIntent
 import com.adevinta.spark.components.snackbars.SnackbarSparkVisuals
 import com.adevinta.spark.components.snackbars.SnackbarStyle
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.toggles.SwitchLabelled
 import com.adevinta.spark.icons.FlashlightFill
@@ -69,31 +68,17 @@ private fun ColumnScope.SnackbarSample(snackbarHostState: SnackbarHostState) {
     var isIconEnabled by remember { mutableStateOf(false) }
     var style by remember { mutableStateOf(SnackbarStyle.Filled) }
     var actionOnNewLine by remember { mutableStateOf(false) }
-    var expanded by remember { mutableStateOf(false) }
     var intent by remember { mutableStateOf(SnackbarIntent.Basic) }
     var actionText by remember { mutableStateOf("Action") }
     var contentText by remember { mutableStateOf("Just a snackbar") }
     val scope = rememberCoroutineScope()
 
-    val intents = SnackbarIntent.entries
-
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = stringResource(id = R.string.configurator_component_screen_intent_label),
-        expanded = expanded,
-        onExpandedChange = { expanded = !expanded },
-        onDismissRequest = { expanded = false },
-        dropdownContent = {
-            intents.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        intent = it
-                        expanded = false
-                    },
-                )
-            }
+        title = stringResource(id = R.string.configurator_component_screen_intent_label),
+        selectedOption = intent,
+        onOptionSelect = {
+            intent = it
         },
     )
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tabs/TabsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tabs/TabsConfigurator.kt
@@ -35,22 +35,23 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.badge.Badge
 import com.adevinta.spark.components.iconbuttons.IconButtonFilled
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.tab.Tab
 import com.adevinta.spark.components.tab.TabGroup
 import com.adevinta.spark.components.tab.TabIntent
 import com.adevinta.spark.components.tab.TabSize
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.toggles.SwitchLabelled
 import com.adevinta.spark.icons.MessageOutline
 import com.adevinta.spark.icons.Minus
@@ -125,29 +126,12 @@ private fun ColumnScope.TabSample() {
         )
     }
 
-    val intents = TabIntent.entries.toTypedArray()
-    var expanded by remember { mutableStateOf(false) }
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = "Intent",
-        expanded = expanded,
-        onExpandedChange = {
-            expanded = !expanded
-        },
-        onDismissRequest = {
-            expanded = false
-        },
-        dropdownContent = {
-            intents.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        intent = it
-                        expanded = false
-                    },
-                )
-            }
+        title = stringResource(id = R.string.configurator_component_screen_intent_label),
+        selectedOption = intent,
+        onOptionSelect = {
+            intent = it
         },
     )
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/text/TextLinkConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/text/TextLinkConfigurator.kt
@@ -38,17 +38,16 @@ import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonIntent
 import com.adevinta.spark.components.buttons.IconSide
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.snackbars.SnackbarHostState
 import com.adevinta.spark.components.spacer.VerticalSpacer
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.text.TextLink
 import com.adevinta.spark.components.text.TextLinkButton
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.toggles.SwitchLabelled
 import com.adevinta.spark.icons.LikeFill
 import com.adevinta.spark.icons.SparkIcons
@@ -71,8 +70,6 @@ private fun ColumnScope.TextLinkSample(snackbarHostState: SnackbarHostState) {
     var iconSide by remember { mutableStateOf(IconSide.START) }
     val coroutineScope = rememberCoroutineScope()
     var intent by remember { mutableStateOf(ButtonIntent.Basic) }
-    val intents = ButtonIntent.entries
-    var expanded by remember { mutableStateOf(false) }
 
     Text(text = "Text Link Component", style = SparkTheme.typography.headline1)
 
@@ -128,23 +125,12 @@ private fun ColumnScope.TextLinkSample(snackbarHostState: SnackbarHostState) {
         onOptionSelect = { iconSide = it },
     )
 
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = stringResource(id = R.string.configurator_component_screen_intent_label),
-        expanded = expanded,
-        onExpandedChange = { expanded = !expanded },
-        onDismissRequest = { expanded = false },
-        dropdownContent = {
-            intents.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        intent = it
-                        expanded = false
-                    },
-                )
-            }
+        title = stringResource(id = R.string.configurator_component_screen_intent_label),
+        selectedOption = intent,
+        onOptionSelect = {
+            intent = it
         },
     )
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/CheckboxConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/CheckboxConfigurator.kt
@@ -34,11 +34,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.toggles.Checkbox
 import com.adevinta.spark.components.toggles.CheckboxLabelled
@@ -93,24 +92,12 @@ private fun CheckboxSample() {
         selectedOption = state,
         onOptionSelect = { state = it },
     )
-    var expanded by remember { mutableStateOf(false) }
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = stringResource(id = R.string.configurator_component_screen_intent_label),
-        expanded = expanded,
-        onExpandedChange = { expanded = !expanded },
-        onDismissRequest = { expanded = false },
-        dropdownContent = {
-            ToggleIntent.entries.forEach { availableIntent ->
-                DropdownMenuItem(
-                    text = { Text(availableIntent.name) },
-                    onClick = {
-                        intent = availableIntent
-                        expanded = false
-                    },
-                )
-            }
+        title = stringResource(id = R.string.configurator_component_screen_intent_label),
+        selectedOption = intent,
+        onOptionSelect = {
+            intent = it
         },
     )
     ButtonGroup(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/RadioButtonConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/RadioButtonConfigurator.kt
@@ -34,11 +34,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.toggles.ContentSide
 import com.adevinta.spark.components.toggles.RadioButton
@@ -83,24 +82,12 @@ private fun ColumnScope.RadioButtonSample() {
             modifier = Modifier.fillMaxWidth(),
         )
     }
-    var expanded by remember { mutableStateOf(false) }
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = stringResource(id = R.string.configurator_component_screen_intent_label),
-        expanded = expanded,
-        onExpandedChange = { expanded = !expanded },
-        onDismissRequest = { expanded = false },
-        dropdownContent = {
-            ToggleIntent.entries.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        intent = it
-                        expanded = false
-                    },
-                )
-            }
+        title = stringResource(id = R.string.configurator_component_screen_intent_label),
+        selectedOption = intent,
+        onOptionSelect = {
+            intent = it
         },
     )
     ButtonGroup(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/SwitchConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/SwitchConfigurator.kt
@@ -34,11 +34,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.ui.DropdownEnum
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
-import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.toggles.ContentSide
 import com.adevinta.spark.components.toggles.Switch
@@ -81,24 +80,12 @@ private fun ColumnScope.SwitchSample() {
             modifier = Modifier.fillMaxWidth(),
         )
     }
-    var expanded by remember { mutableStateOf(false) }
-    Dropdown(
+    DropdownEnum(
         modifier = Modifier.fillMaxWidth(),
-        value = intent.name,
-        label = stringResource(id = R.string.configurator_component_screen_intent_label),
-        expanded = expanded,
-        onExpandedChange = { expanded = !expanded },
-        onDismissRequest = { expanded = false },
-        dropdownContent = {
-            ToggleIntent.entries.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.name) },
-                    onClick = {
-                        intent = it
-                        expanded = false
-                    },
-                )
-            }
+        title = stringResource(id = R.string.configurator_component_screen_intent_label),
+        selectedOption = intent,
+        onOptionSelect = {
+            intent = it
         },
     )
     ButtonGroup(


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
All Dropdowns that display a selection of enum entries is migrated

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
This is needed for the incoming `DropdownMenu` refactor as it'll impact all `Dropdowns` used in the catalog app.
Also it makes the UI code less verbose to read

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
