### PR TITLE
feat(dropdown): add animated collapse/expand icon

### DIFF
--- a/spark-icons/src/main/kotlin/com/adevinta/spark/icons/SparkAnimatedIcons.kt
+++ b/spark-icons/src/main/kotlin/com/adevinta/spark/icons/SparkAnimatedIcons.kt
@@ -25,6 +25,9 @@ import com.adevinta.spark.icons.SparkIcon.AnimatedDrawableRes
 
 public object SparkAnimatedIcons
 
+public val SparkAnimatedIcons.CollapseExpand: AnimatedDrawableRes
+    get() = AnimatedDrawableRes(R.drawable.spark_icons_animated_collapse_expand)
+
 public val SparkAnimatedIcons.BellShake: AnimatedDrawableRes
     get() = AnimatedDrawableRes(R.drawable.spark_icons_animated_bell_shake)
 

--- a/spark-icons/src/main/res/drawable/spark_icons_animated_collapse_expand.xml
+++ b/spark-icons/src/main/res/drawable/spark_icons_animated_collapse_expand.xml
@@ -1,0 +1,33 @@
+<animated-vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group
+                android:name="group"
+                android:pivotX="24"
+                android:pivotY="24">
+                <path
+                    android:name="path"
+                    android:pathData="M 2.33 7.3 C 2.76 6.9 3.46 6.9 3.9 7.3 L 12 14.78 L 20.1 7.3 C 20.54 6.9 21.24 6.9 21.67 7.3 C 22.11 7.7 22.11 8.36 21.67 8.77 L 13.33 16.47 C 13 16.81 12.5 17 12 17 C 11.5 17 11.01 16.8 10.67 16.47 L 2.33 8.77 C 1.89 8.37 1.89 7.71 2.33 7.3 Z"
+                    android:fillColor="#000000"/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="path">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:propertyName="pathData"
+                android:duration="200"
+                android:valueFrom="M 12 14.78 C 12.378 14.431 12.756 14.082 13.134 13.733 L 20.1 7.3 C 20.54 6.9 21.24 6.9 21.67 7.3 C 22.11 7.7 22.11 8.36 21.67 8.77 L 13.33 16.47 C 13 16.81 12.5 17 12 17 L 12 14.78 M 12 14.78 L 12 17 C 12 17 12 17 12 17 C 11.5 17 11.01 16.8 10.67 16.47 L 2.33 8.77 C 1.89 8.37 1.89 7.71 2.33 7.3 L 2.33 7.3 C 2.76 6.9 3.46 6.9 3.9 7.3 L 10.853 13.721 C 11.236 14.074 11.618 14.427 12 14.78 C 12 14.78 12 14.78 12 14.78 M 12 14.78 L 12 14.78"
+                android:valueTo="M 12 7 C 12.47 7 13 7.2 13.33 7.52 L 21.67 15.25 C 22.11 15.65 22.11 16.3 21.67 16.7 C 21.24 17.1 20.54 17.1 20.1 16.7 L 13.266 10.373 C 12.844 9.982 12.422 9.591 12 9.2 L 12 7 M 12 7 L 12 9.2 C 12 9.2 12 9.2 12 9.2 C 11.651 9.523 11.302 9.846 10.953 10.169 L 3.9 16.7 C 3.46 17.1 2.76 17.1 2.33 16.7 L 2.33 16.7 C 1.89 16.3 1.89 15.65 2.33 15.25 L 10.67 7.52 C 10.967 7.232 11.401 7.042 11.849 7.006 C 11.899 7.002 11.949 7 12 7 M 12 14.78 L 12 14.78"
+                android:valueType="pathType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/icons/AnimatedIconsScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/icons/AnimatedIconsScreenshot.kt
@@ -59,4 +59,24 @@ internal class AnimatedIconsScreenshot {
 
         paparazzi.gif(view, "bellShake", start = 500, end = 1500, fps = 60)
     }
+
+    @Test
+    fun collapseExpand() {
+        val view = paparazzi.gifView {
+            var atEnd by remember { mutableStateOf(false) }
+            LaunchedEffect(Unit) {
+                delay(200)
+                atEnd = true
+            }
+            Icon(
+                sparkIcon = SparkAnimatedIcons.CollapseExpand,
+                contentDescription = SparkAnimatedIcons.CollapseExpand.toString(),
+                size = IconSize.ExtraLarge,
+                tint = Color.Black,
+                atEnd = atEnd,
+            )
+        }
+
+        paparazzi.gif(view, "collapseExpand", start = 200, end = 800, fps = 60)
+    }
 }

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.badge_BadgeScreenshot_badge.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.badge_BadgeScreenshot_badge.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ab0e036a631e29e8c41a3710cae306f8859d3db5463948edf66e1817a806f24
-size 56774
+oid sha256:b05f04666577e3ac9d3af889d6f7a53f18d5e255f89319bbdbbeacd36741d94d
+size 56964

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_DropdownScreenshot_expanded.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_DropdownScreenshot_expanded.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86c86b2dcbe63f7a9e33125a4964aae4d88b7fe8723efc3db0fcf4699cef84c5
-size 25612
+oid sha256:9deb91f39c3c2a17ffb9c522c8a27d5cc9d95cdeca7777f68ef4451b18ce813c
+size 25079

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_selectTextFieldShowcase__dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_selectTextFieldShowcase__dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f5ed7e3e4ce42b1950189ebabadde28b87c17b6bbcddfe657d4acf6f1fc6358
-size 103395
+oid sha256:497d6506a850537601bb49496ee80f699c0ff6f4896ce9101c4ff2bec818f346
+size 104025

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_selectTextFieldShowcase__light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_selectTextFieldShowcase__light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82c310dee1c093e87be8c3ca1a08a9bbd76c8863655dc9acada1c84a83948463
-size 101242
+oid sha256:4dcb4dcfa93c40281d2116e2e841ebb09229831fa7782c355f190e4d96588b2d
+size 101812

--- a/spark-screenshot-testing/src/test/snapshots/videos/com.adevinta.spark.icons_AnimatedIconsScreenshot_collapseExpand_collapseexpand.png
+++ b/spark-screenshot-testing/src/test/snapshots/videos/com.adevinta.spark.icons_AnimatedIconsScreenshot_collapseExpand_collapseexpand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94343c1d4cf6e675b13f8ac1bfed7b584cac171d23f17068dbee9cfcee312855
+size 19229

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/Dropdown.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/Dropdown.kt
@@ -42,7 +42,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
@@ -63,8 +62,8 @@ import com.adevinta.spark.components.popover.PlainTooltip
 import com.adevinta.spark.components.popover.TooltipBox
 import com.adevinta.spark.components.surface.Surface
 import com.adevinta.spark.components.text.Text
-import com.adevinta.spark.icons.ArrowHorizontalDown
-import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.icons.CollapseExpand
+import com.adevinta.spark.icons.SparkAnimatedIcons
 import com.adevinta.spark.tokens.SparkTypography
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 import kotlinx.coroutines.launch

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/Dropdown.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/Dropdown.kt
@@ -522,12 +522,11 @@ public fun SparkSelectTrailingIcon(
     // expand the menu on icon click in a11y mode only esp. if using their own custom
     // trailing icon.
     Icon(
-        sparkIcon = SparkIcons.ArrowHorizontalDown,
+        sparkIcon = SparkAnimatedIcons.CollapseExpand,
         size = IconSize.Medium,
         contentDescription = null,
-        modifier = modifier.rotate(
-            if (expanded) 180f else 0f,
-        ),
+        atEnd = expanded,
+        modifier = modifier,
     )
 }
 


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add new animated Icon and use it for Dropdown

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
Replace the rotating expand / collapse icon by a dedicated animated one for the `Dropdown` and `Combobox` component

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

