### PR TITLE
feat: show the entire expand/collapse animation in screenshot test

### DIFF
--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/icons/AnimatedIconsScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/icons/AnimatedIconsScreenshot.kt
@@ -65,8 +65,9 @@ internal class AnimatedIconsScreenshot {
         val view = paparazzi.gifView {
             var atEnd by remember { mutableStateOf(false) }
             LaunchedEffect(Unit) {
-                delay(200)
                 atEnd = true
+                delay(200)
+                atEnd = false
             }
             Icon(
                 sparkIcon = SparkAnimatedIcons.CollapseExpand,
@@ -77,6 +78,6 @@ internal class AnimatedIconsScreenshot {
             )
         }
 
-        paparazzi.gif(view, start = 200, end = 800, fps = 60)
+        paparazzi.gif(view, start = 0, end = 400, fps = 60)
     }
 }

--- a/spark-screenshot-testing/src/test/snapshots/videos/com.adevinta.spark.icons_AnimatedIconsScreenshot_collapseExpand.png
+++ b/spark-screenshot-testing/src/test/snapshots/videos/com.adevinta.spark.icons_AnimatedIconsScreenshot_collapseExpand.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94343c1d4cf6e675b13f8ac1bfed7b584cac171d23f17068dbee9cfcee312855
-size 19229
+oid sha256:ffbc22964d67b44b81879895144c2294abeb99b1e6691ed7d237cfbdec79ee50
+size 32286


### PR DESCRIPTION
The current implementation only showed half of the animation (and not the reverse part).
I also removed the unnecessary delay, and match the exact animation duration.