### PR TITLE
fix(Combobox): An example did not open the dropdown on edit

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/combobox/ComboboxExample.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/combobox/ComboboxExample.kt
@@ -82,7 +82,6 @@ private val MultipleComboBox = Example(
         onValueChange = { newValue ->
             value = newValue
             expanded = true // Keep dropdown open while typing
-
         },
         expanded = expanded,
         onExpandedChange = { expanded = it },

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/combobox/ComboboxExample.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/combobox/ComboboxExample.kt
@@ -79,7 +79,11 @@ private val MultipleComboBox = Example(
     MultiChoiceComboBox(
         modifier = Modifier.fillMaxWidth(),
         value = value,
-        onValueChange = { newValue -> value = newValue },
+        onValueChange = { newValue ->
+            value = newValue
+            expanded = true // Keep dropdown open while typing
+
+        },
         expanded = expanded,
         onExpandedChange = { expanded = it },
         onDismissRequest = { expanded = false },
@@ -139,6 +143,7 @@ private val FilteringComboBox = Example(
         onValueChange = { newValue ->
             value = newValue
             searchText = newValue // Update search text when value changes
+            expanded = true // Keep dropdown open while typing
         },
         expanded = expanded,
         onExpandedChange = { expanded = it },


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add the missing `expanded = true` in all examples

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
Close [SPA-607](https://jira.ets.mpi-internal.com/browse/SPA-607)

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

<!-- Insert your screenshots here -->

https://github.com/user-attachments/assets/e7b4cb75-00b8-4aaf-8cc5-8d0bbfdd8eb7
