### PR TITLE
fix(Combobox): Changed Check icon position from end to start

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
@@ -482,7 +482,7 @@ public fun DropdownMenuItemColumnScope.DropdownMenuItem(
  * @param selected - whether this item is selected or not
  * @param onClick called when this menu item is clicked
  * @param modifier the [Modifier] to be applied to this menu item
- * @param leadingIcon optional leading icon to be displayed at the beginning of the item's text
+ * @param trailingIcon optional trailing icon to be displayed at the end of the item's text
  * @param enabled controls the enabled state of this menu item. When `false`, this component will
  * not respond to user input, and it will appear visually disabled and disabled to accessibility
  * services.
@@ -498,7 +498,7 @@ public fun SingleChoiceDropdownItemColumnScope.DropdownMenuItem(
     selected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
     enabled: Boolean = true,
     contentPadding: PaddingValues = PaddingValues(
         horizontal = 16.dp,
@@ -518,8 +518,8 @@ public fun SingleChoiceDropdownItemColumnScope.DropdownMenuItem(
             )
             .semantics { role = Role.RadioButton },
         contentPadding = contentPadding,
-        leadingIcon = leadingIcon,
-        trailingIcon = if (selected) {
+        trailingIcon = trailingIcon,
+        leadingIcon = if (selected) {
             @Composable {
                 Icon(
                     sparkIcon = SparkIcons.Check,
@@ -547,7 +547,7 @@ public fun SingleChoiceDropdownItemColumnScope.DropdownMenuItem(
  * @param onCheckedChange callback to be invoked when the item is clicked. therefore the change of
  *   checked state in requested.
  * @param modifier the [Modifier] to be applied to this menu item
- * @param leadingIcon optional leading icon to be displayed at the beginning of the item's text
+ * @param trailingIcon optional trailing icon to be displayed at the end of the item's text
  * @param enabled controls the enabled state of this menu item. When `false`, this component will
  * not respond to user input, and it will appear visually disabled and disabled to accessibility
  * services.
@@ -563,7 +563,7 @@ public fun MultiChoiceDropdownItemColumnScope.DropdownMenuItem(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
-    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
     enabled: Boolean = true,
     contentPadding: PaddingValues = PaddingValues(
         horizontal = 16.dp,
@@ -582,8 +582,8 @@ public fun MultiChoiceDropdownItemColumnScope.DropdownMenuItem(
                 indication = ripple(true),
             ),
         contentPadding = contentPadding,
-        leadingIcon = leadingIcon,
-        trailingIcon = if (checked) {
+        trailingIcon = trailingIcon,
+        leadingIcon = if (checked) {
             @Composable {
                 Icon(
                     sparkIcon = SparkIcons.Check,


### PR DESCRIPTION

<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Changed the check icon position from trailing to leading position and adapted the documention accordingly

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
Closes [SPA-608](https://jira.ets.mpi-internal.com/browse/SPA-608)

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

<!-- Insert your screenshots here -->
<img width="327" alt="image" src="https://github.com/user-attachments/assets/5a2b27e5-1d56-4aaf-ab55-71f53c304ebf" />
