### PR TITLE
feat(image): Ensure image has defined size

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
@@ -105,6 +105,15 @@ public fun SparkImage(
     }
     SubcomposeAsyncImage(
         modifier = modifier
+            .layout { measurable, constraints ->
+
+                constraints.checkThatImageHasDefinedSize()
+
+                val placeable = measurable.measure(constraints)
+                layout(placeable.width, placeable.height) {
+                    placeable.placeRelative(0, 0)
+                }
+            }
             .sparkUsageOverlay()
             .ifNotNull(contentDescription) { description ->
                 clearAndSetSemantics {
@@ -250,6 +259,25 @@ internal fun ImageIconState(
                 },
             )
         }
+    }
+}
+
+private fun Constraints.checkThatImageHasDefinedSize() {
+    val isWidthBounded = hasBoundedWidth
+    val isHeightBounded = hasBoundedHeight
+    val hasMinWidth = minWidth != 0
+    val hasMinHeight = minHeight != 0
+    check(isWidthBounded) {
+        "Image must have a bounded width but was hasBoundedWidth: $isWidthBounded"
+    }
+    check(isHeightBounded) {
+        "Image must have a bounded height but was hasBoundedHeight: $isHeightBounded"
+    }
+    check(hasMinWidth) {
+        "Image must have a minimum width but has minWidth: $minWidth"
+    }
+    check(hasMinHeight) {
+        "Image must have a minimum height but has minHeight: $minHeight"
     }
 }
 


### PR DESCRIPTION
These changes ensure that the image component has a defined size, which is important for the correct rendering and layout of the image.

<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add a new check when the `Image` is layout that ensure it has a defined size

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
This change is needed to ensure we don't get bad behaviours as mentioned in [here](https://github.com/leboncoin/spark-android/pull/1514#issuecomment-2758702162).

Once it's merged and we can verify that it works we can merge #1514 

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
