### PR TITLE
fix(ExceptionHandler): Remove remaining logger naming remains

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
@@ -96,7 +96,7 @@ import com.adevinta.spark.tools.SparkExceptionHandler
  * @param shapes A set of corner shapes to be used as this hierarchy's shape system.
  * @param fontFamily the font family to be applied on [typography].
  * @param sparkFeatureFlag flags that activate debugging features from Spark or features hidden to consumers.
- * @param logger An instance of [SparkExceptionHandler] for handling logs within Spark components.
+ * @param exceptionHandler An instance of [SparkExceptionHandler] for handling logs within Spark components.
  * Defaults to [DefaultSparkExceptionHandler].
  */
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class, ExperimentalMaterial3Api::class)
@@ -110,7 +110,7 @@ public fun SparkTheme(
     fontFamily: SparkFontFamily = sparkFontFamily(
         useSparkTokensHighlighter = sparkFeatureFlag.useSparkTokensHighlighter,
     ),
-    logger: SparkExceptionHandler = if (LocalInspectionMode.current) {
+    exceptionHandler: SparkExceptionHandler = if (LocalInspectionMode.current) {
         NoOpSparkExceptionHandler
     } else {
         DefaultSparkExceptionHandler
@@ -147,7 +147,7 @@ public fun SparkTheme(
         LocalSparkTypography provides typo,
         LocalSparkShapes provides internalShapes,
         LocalSparkFeatureFlag provides sparkFeatureFlag,
-        LocalSparkExceptionHandler provides logger,
+        LocalSparkExceptionHandler provides exceptionHandler,
         LocalWindowSizeClass provides calculateWindowSizeClass(),
         LocalUseFallbackRippleImplementation provides false,
         LocalIndication provides rippleIndication,
@@ -283,7 +283,7 @@ public object SparkTheme {
  * behaviors at consumers
  */
 public val LocalSparkExceptionHandler: ProvidableCompositionLocal<SparkExceptionHandler> =
-    staticCompositionLocalOf { error("SparkLogger not provided") }
+    staticCompositionLocalOf { error("SparkExceptionHandler not provided") }
 
 internal val LocalSparkFeatureFlag: ProvidableCompositionLocal<SparkFeatureFlag> = staticCompositionLocalOf {
     error("SparkFeatureFlag not provided")

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
@@ -105,11 +105,11 @@ public fun SparkImage(
     val emptyStateIcon = remember(emptyIcon) {
         movableContentOf(emptyIcon)
     }
-    val logger = LocalSparkExceptionHandler.current
+    val exceptionHandler = LocalSparkExceptionHandler.current
     SubcomposeAsyncImage(
         modifier = modifier
             .layout { measurable, constraints ->
-                constraints.checkThatImageHasDefinedSize(logger)
+                constraints.checkThatImageHasDefinedSize(exceptionHandler)
 
                 val placeable = measurable.measure(constraints)
                 layout(placeable.width, placeable.height) {
@@ -264,26 +264,26 @@ internal fun ImageIconState(
     }
 }
 
-private fun Constraints.checkThatImageHasDefinedSize(logger: SparkExceptionHandler) {
+private fun Constraints.checkThatImageHasDefinedSize(exceptionHandler: SparkExceptionHandler) {
     val isWidthBounded = hasBoundedWidth
     val isHeightBounded = hasBoundedHeight
     val hasMinWidth = minWidth != 0
     val hasMinHeight = minHeight != 0
     if (!isWidthBounded) {
-        logger.handleException(
+        exceptionHandler.handleException(
             IllegalStateException("Image must have a bounded width but was hasBoundedWidth: $isWidthBounded"),
         )
     }
     if (!isHeightBounded) {
-        logger.handleException(
+        exceptionHandler.handleException(
             IllegalStateException("Image must have a bounded height but was hasBoundedHeight: $isHeightBounded"),
         )
     }
     if (!hasMinWidth) {
-        logger.handleException(IllegalStateException("Image must have a minimum width but has minWidth: $minWidth"))
+        exceptionHandler.handleException(IllegalStateException("Image must have a minimum width but has minWidth: $minWidth"))
     }
     if (!hasMinHeight) {
-        logger.handleException(IllegalStateException("Image must have a minimum height but has minHeight: $minHeight"))
+        exceptionHandler.handleException(IllegalStateException("Image must have a minimum height but has minHeight: $minHeight"))
     }
 }
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
@@ -280,10 +280,14 @@ private fun Constraints.checkThatImageHasDefinedSize(exceptionHandler: SparkExce
         )
     }
     if (!hasMinWidth) {
-        exceptionHandler.handleException(IllegalStateException("Image must have a minimum width but has minWidth: $minWidth"))
+        exceptionHandler.handleException(
+            IllegalStateException("Image must have a minimum width but has minWidth: $minWidth"),
+        )
     }
     if (!hasMinHeight) {
-        exceptionHandler.handleException(IllegalStateException("Image must have a minimum height but has minHeight: $minHeight"))
+        exceptionHandler.handleException(
+            IllegalStateException("Image must have a minimum height but has minHeight: $minHeight"),
+        )
     }
 }
 

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/SparkExceptionHandler.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/SparkExceptionHandler.kt
@@ -22,15 +22,16 @@
 package com.adevinta.spark.tools
 
 /**
- * Log messages within the Spark library.
- * Allows swapping the underlying logging mechanism.
+ * Implementations of this interface provide a centralized mechanism for
+ * dealing with errors and exceptions that may arise when using a Spark component in an unexpected way.
+ * This allows for custom error handling logic, such as log reporting for production or crash in development.
  */
 public fun interface SparkExceptionHandler {
     public fun handleException(throwable: Throwable)
 }
 
 /**
- * Default implementation of [SparkExceptionHandler] that will crash on unexpected states.
+ * Default implementation of [SparkExceptionHandler] that will rethrow the throwable from spark.
  */
 public object DefaultSparkExceptionHandler : SparkExceptionHandler {
     override fun handleException(throwable: Throwable): Unit = throw throwable


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Remove remaining logger naming remains

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
The mentions to the previous name of `SparkExceptionHandler` was not updated in `SparkTheme` argument, in the `Image` Component and in its documentation.
