### PR TITLE
feat: add new stepper exampel for custom form

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/stepper/StepperExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/stepper/StepperExamples.kt
@@ -21,14 +21,25 @@
  */
 package com.adevinta.spark.catalog.examples.samples.stepper
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.catalog.model.Example
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.stepper.Stepper
 import com.adevinta.spark.components.stepper.StepperForm
+import com.adevinta.spark.components.stepper.stepperSemantics
+import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.textfields.FormFieldStatus
 
 public val StepperExamples: List<Example> = listOf(
@@ -91,13 +102,54 @@ public val StepperExamples: List<Example> = listOf(
             helper = "helper message",
         )
     },
-    // Example(
-    //       name = "Stepper formats",
-    //       description = "Stepper can show a suffix like `%`, `€` or `person•s`.",
-    //       sourceUrl = "$SampleSourceUrl/RatingInputSample.kt",
-    //   ) {
-    //       WipIllustration()
-    //  },
+
+    Example(
+        id = "states",
+        name = "Stepper States",
+        description = "Disabled and all regular states available for the TestField.",
+        sourceUrl = "$SampleSourceUrl/RatingDisplaySample.kt",
+    ) {
+        StepperForm(
+            value = 1,
+            onValueChange = {},
+            status = FormFieldStatus.Error,
+            label = "Label",
+            helper = "helper message",
+            enabled = false,
+        )
+    },
+    Example(
+        id = "custom-form",
+        name = "Custom Stepper form",
+        description = "Stepper can show a suffix like `%`, `€` or `person•s`.",
+        sourceUrl = "$SampleSourceUrl/RatingInputSample.kt",
+    ) {
+        CustomStepper(
+            value = 1,
+            onValueChange = {},
+            title = "Adultes",
+            subtitle = "18 ans et plus",
+        )
+        CustomStepper(
+            value = 0,
+            onValueChange = {},
+            title = "Enfants",
+            subtitle = "De 3 à 17 ans",
+        )
+        CustomStepper(
+            value = 0,
+            onValueChange = {},
+            title = "Bébés",
+            subtitle = "Moins de 3 ans",
+        )
+        CustomStepper(
+            value = 0,
+            onValueChange = {},
+            title = "Animaux",
+            subtitle = "Non acceptés",
+            enabled = false,
+        )
+    },
     //  Example(
     //     name = "Stepper Custom Buttons",
     //     description = "Custom implementation allow used defined button for de-increment.",
@@ -106,3 +158,57 @@ public val StepperExamples: List<Example> = listOf(
     //     WipIllustration()
     // },
 )
+
+@Composable
+private fun CustomStepper(
+    modifier: Modifier = Modifier,
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    title: String,
+    subtitle: String,
+    range: IntRange = 0..10,
+    suffix: String = "",
+    step: Int = 1,
+    enabled: Boolean = true,
+) {
+    Row(
+        modifier = modifier
+            .stepperSemantics(
+                value = value,
+                onValueChange = onValueChange,
+                range = range,
+                step = step,
+                suffix = title,
+                enabled = enabled,
+            )
+            .semantics {
+                text = listOfNotNull(title, subtitle)
+                    .joinToString(separator = " ")
+                    .let(::AnnotatedString)
+            },
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = title)
+            Text(text = subtitle)
+        }
+        Stepper(
+            value = value,
+            onValueChange = {},
+            enabled = enabled,
+            allowSemantics = false,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCustomStepper() {
+    PreviewTheme {
+        CustomStepper(
+            value = 1,
+            onValueChange = {},
+            title = "Adultes",
+            subtitle = "18 ans et plus",
+        )
+    }
+}


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add an example for a custom StepperForm

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
I thought it was already present but that was not the case 😬.
This example should help developers make custom stepper forms with a correct a11y readings & actions

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

<!-- Insert your screenshots here -->
