### PR TITLE
feat(Tab): remove duplicate content description for tab icon

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/Tab.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/Tab.kt
@@ -156,7 +156,7 @@ internal fun SparkTab(
                                     }
                                 },
                             sparkIcon = it,
-                            contentDescription = if (text == null) contentDescription else null,
+                            contentDescription = null,
                         )
                     }
                 },


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Remove the content description from the internal icon component

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
Closes [LBCSPARK-119](https://jira.ets.mpi-internal.com/browse/LBCSPARK-119)

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

### Before
https://github.com/user-attachments/assets/07fb3577-e76a-46e1-9443-05dd82923211

### After
https://github.com/user-attachments/assets/2167a86f-c46b-444a-8b28-d55d075b613d
