### PR TITLE
fix(popover): fix hidden close button

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
@@ -118,7 +118,8 @@ public fun Popover(
                 Row {
                     Box(
                         modifier = Modifier
-                            .padding(all = PopoverContentPadding),
+                            .padding(all = PopoverContentPadding)
+                            .weight(1f, fill = true),
                     ) {
                         CompositionLocalProvider(
                             content = popover,


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

- Applied `Modifier.weight` to ensure popover content fills remaining space
<!-- Describe your changes in details -->

## 🤔 Context

The change is required because the close button was being pushed out of view when the popover content was too large. 

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
Closes #1569 

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

<!-- Insert your screenshots here -->

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
