### PR TITLE
feat(publish): Migrate publish from ossrh to Central Portal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: '📦 Publish to OSSRH'
+name: '📦 Publish to Central Portal'
 
 on:
   push:
@@ -15,12 +15,12 @@ jobs:
       - uses: ./.github/actions/setup-gradle
       - uses: ./.github/actions/setup-gradle-properties
 
-      - name: '📦 Publish'
-        run: ./gradlew publish --no-configuration-cache
+      - name: '📦 Publish to Central Portal'
+        run: ./gradlew publishAllPublicationsToCentralPortal --no-configuration-cache
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          CENTRAL_PORTAL_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSWORD }}
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ SparkTheme {
 
 ## Installation
 
-Add the main Spark dependency: [![Maven Central](https://img.shields.io/maven-central/v/com.adevinta.spark/spark-bom?label=%20&color=success)](https://central.sonatype.com/namespace/com.adevinta.spark) [![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/com.adevinta.spark/spark-bom?label=%20&color=lightgrey&server=https%3A%2F%2Fs01.oss.sonatype.org%2F)](https://s01.oss.sonatype.org/content/repositories/snapshots/com/adevinta/spark/spark-bom/)
+Add the main Spark dependency: [![Maven Central](https://img.shields.io/maven-central/v/com.adevinta.spark/spark-bom?label=%20&color=success)](https://central.sonatype.com/namespace/com.adevinta.spark)
 
 ```kotlin
 dependencies {

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,9 +2,10 @@
 
 ## Pre-release
 
-> This porcess will apply for the versions starting 1.4.0.
+> [!NOTE]
+> This process will apply for the versions starting 1.4.0.
 
-Before each release, we will publish one or more alpha version and publish pre-releases on [Github Release page](https://github.com/leboncoin/spark-android/releases) with the changes
+Before each release, we will publish one or more alpha versions and publish pre-releases on [Github Release page](https://github.com/leboncoin/spark-android/releases).
 
 Consumers will be able to test new features and report breaking changes & bugs that can be fixed before it’s considered for a stable release.
 
@@ -16,8 +17,8 @@ For example, they could set up hooks to post the changelog in their monitoring S
 3. Remove logs from `@dependabot` except if they mention big version upgrades for libraries used by our consumers (like Compose or Kotlin). 
 4. Reformat the changelog to be as close as possible to the format we describe in the [CHANGELOG STYLE GUIDE](./docs/CHANGELOG%20STYLE%20GUIDE.md).
 5. If we’re satisfied with the draft, release it but make sure **`⚠️ Set as a pre-release`** is checked.
-7. If we need to create a fix from feedbacks, then this cycle repeats.
-8. Otherwise, follow the [stable release process](./RELEASING.md#Release)
+6. If we need to create a fix from feedbacks, then this cycle repeats.
+7. Otherwise, follow the [stable release process](./RELEASING.md#Release)
 
 ## Release
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,25 +2,26 @@
 
 ## Pre-release
 
-Before each release, we will publish a Snapshot version of it and use it to create a pre-release on [Github Release page](https://github.com/leboncoin/spark-android/releases)
+> This porcess will apply for the versions starting 1.4.0.
 
-During a period of ~2 weeks, consumers will be able to test it and report bugs that can be fixed before it’s considered stable.
+Before each release, we will publish one or more alpha version and publish pre-releases on [Github Release page](https://github.com/leboncoin/spark-android/releases) with the changes
+
+Consumers will be able to test new features and report breaking changes & bugs that can be fixed before it’s considered for a stable release.
 
 Using the Github pre-release feature will allow Spark users to be notified that a new release is being prepared and test against it.
 For example, they could set up hooks to post the changelog in their monitoring Slack channel or trigger a CI build to validate that this new release doesn’t break their build.
 
-1. [Create a draft release](https://github.com/leboncoin/spark-android/releases/new?tag=X.Y.Z-SNAPSHOT&title=X.Y.Z-SNAPSHOT&prerelease=1) with a `*.*.*-SNAPSHOT` version tag.
+1. [Create a draft release](https://github.com/leboncoin/spark-android/releases/new?tag=X.Y.Z-alpha01&title=X.Y.Z-alpha01&prerelease=1) with a `*.*.*-alpha01` version tag.
 2. Click on `Generate release notes` to automatically add all the merged pull requests from this diff and contributors of this release.
 3. Remove logs from `@dependabot` except if they mention big version upgrades for libraries used by our consumers (like Compose or Kotlin). 
 4. Reformat the changelog to be as close as possible to the format we describe in the [CHANGELOG STYLE GUIDE](./docs/CHANGELOG%20STYLE%20GUIDE.md).
 5. If we’re satisfied with the draft, release it but make sure **`⚠️ Set as a pre-release`** is checked.
-6. Wait **at least 2 weeks** for feedback from consumers on the stability of this release.
 7. If we need to create a fix from feedbacks, then this cycle repeats.
 8. Otherwise, follow the [stable release process](./RELEASING.md#Release)
 
 ## Release
 
-1. Update the `version` in [gradle.properties](gradle.properties) to a non-`SNAPSHOT`.
+1. Update the `version` in [gradle.properties](gradle.properties) to a non-`alpha`.
 2. Update [CHANGELOG.md](CHANGELOG.md)
    - Add the new version section and move the *unreleased changes* into it.
    - Update the links at the end of the page.
@@ -36,7 +37,7 @@ For example, they could set up hooks to post the changelog in their monitoring S
    git push origin X.Y.Z
    ```
 5. Wait for the [publishing workflow](https://github.com/leboncoin/spark-android/actions/workflows/publish.yml) to build and publish the release.
-6. Update the `version` in [gradle.properties](gradle.properties) to the next `SNAPSHOT` version.
+6. Update the `version` in [gradle.properties](gradle.properties) to the next `alpha` version.
 7. Commit and push the changes to a new PR
   ```bash
   git commit -am "chore: prepare next development version"

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     compileOnly(libs.gradlePlugins.dependencyGuard)
     compileOnly(libs.gradlePlugins.dokka)
     compileOnly(libs.gradlePlugins.spotless)
+    compileOnly(libs.gradlePlugins.nmcp)
     implementation(libs.dokka.base)
 }
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -27,14 +27,14 @@ plugins {
     alias(libs.plugins.spotless)
 }
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 kotlin {
     compilerOptions {
         allWarningsAsErrors = true
-        jvmTarget = JvmTarget.JVM_11
+        jvmTarget = JvmTarget.JVM_17
     }
     explicitApi()
 }

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
@@ -22,6 +22,7 @@
 package com.adevinta.spark
 
 import com.android.build.gradle.LibraryExtension
+import com.gradleup.nmcp.NmcpExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
@@ -41,8 +42,10 @@ internal class SparkPublishingPlugin : Plugin<Project> {
         with(target) {
             apply(plugin = "org.gradle.maven-publish")
             apply(plugin = "org.gradle.signing")
+            apply(plugin = "com.gradleup.nmcp")
 
             configureRepository()
+            configureNMCP()
             registerPublication()
             configureSigning()
         }
@@ -54,17 +57,14 @@ internal class SparkPublishingPlugin : Plugin<Project> {
                 name = "Local"
                 url = uri(rootProject.layout.buildDirectory.dir(".m2/repository"))
             }
-            maven {
-                name = "OSSRH"
-                url = when (version.toString().endsWith("-SNAPSHOT")) {
-                    true -> "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-                    false -> "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-                }.let(::uri)
-                credentials {
-                    username = System.getenv("OSSRH_USERNAME")
-                    password = System.getenv("OSSRH_TOKEN")
-                }
-            }
+        }
+    }
+
+    private fun Project.configureNMCP() = configure<NmcpExtension> {
+        centralPortal {
+            username = System.getenv("CENTRAL_PORTAL_USERNAME")
+            password = System.getenv("CENTRAL_PORTAL_PASSWORD")
+            publishingType = "USER_MANAGED"
         }
     }
 

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
@@ -64,7 +64,7 @@ internal class SparkPublishingPlugin : Plugin<Project> {
         centralPortal {
             username = System.getenv("CENTRAL_PORTAL_USERNAME")
             password = System.getenv("CENTRAL_PORTAL_PASSWORD")
-            publishingType = "USER_MANAGED"
+            publishingType = "AUTOMATIC"
         }
     }
 

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
@@ -22,7 +22,7 @@
 package com.adevinta.spark
 
 import com.android.build.gradle.LibraryExtension
-import com.gradleup.nmcp.NmcpExtension
+import nmcp.NmcpExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
     alias(libs.plugins.dependencyGuard) apply false
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.compose) apply false
+    alias(libs.plugins.nmcp) apply false
 
     alias(libs.plugins.spark.root)
     alias(libs.plugins.spark.dokka)

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@
 # SOFTWARE.
 #
 
-version=1.3.0-SNAPSHOT
+version=1.3.0-alpha01
 group=com.adevinta.spark
 
 org.gradle.caching=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ dokka = "1.9.20"
 kotlin = "2.1.20"
 lint = "31.10.1"
 minCompileSdk = "24"
+nmcp = "0.1.5"
 spotless = "7.0.4"
 targetSdk = "35"
 
@@ -83,6 +84,7 @@ gradlePlugins-dependencyGuard = { module = "com.dropbox.dependency-guard:com.dro
 gradlePlugins-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 gradlePlugins-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 gradlePlugins-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
+gradlePlugins-nmcp = { module = "com.gradleup.nmcp:com.gradleup.nmcp.gradle.plugin", version.ref = "nmcp" }
 
 junit = "junit:junit:4.13.2"
 
@@ -124,6 +126,7 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+nmcp = { id = "com.gradleup.nmcp", version.ref = "nmcp" }
 
 
 # Plugins defined by this project


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Changes the GitHub Actions workflow to publish to the Central Portal instead of OSSRH. 
We also use Central publishing through the NMCP library from GradleUp  to stay with a simple publishing logic.
The necessary environment variables have also been updated to use the  Central Portal credentials instead of the OSSRH credentials.

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
See https://central.sonatype.org/news/20250326_ossrh_sunset/

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
