### PR TITLE
feat(color): add contrast level helpers

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -21,7 +21,6 @@
  */
 package com.adevinta.spark.catalog
 
-import android.app.UiModeManager
 import android.graphics.RenderEffect
 import android.graphics.RuntimeShader
 import android.net.Uri
@@ -70,7 +69,6 @@ import androidx.compose.ui.test.LayoutDirection
 import androidx.compose.ui.test.then
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.core.content.getSystemService
 import com.adevinta.spark.SparkFeatureFlag
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.configurator.ConfiguratorComponentsScreen
@@ -95,6 +93,7 @@ import com.adevinta.spark.catalog.ui.rememberBackdropScaffoldState
 import com.adevinta.spark.catalog.ui.shaders.colorblindness.ColorBlindNessType
 import com.adevinta.spark.catalog.ui.shaders.colorblindness.shader
 import com.adevinta.spark.tokens.asSparkColors
+import com.adevinta.spark.tokens.contrastLevel
 import kotlinx.coroutines.launch
 
 @Composable
@@ -107,13 +106,7 @@ internal fun ComponentActivity.CatalogApp(
 
     val useDark = (theme.themeMode == ThemeMode.System && isSystemInDarkTheme()) || theme.themeMode == ThemeMode.Dark
 
-    // TODO(b/336693596): UIModeManager is not yet supported in preview
-    val contrastLevel = if (isContrastAvailable()) {
-        val uiModeManager = LocalContext.current.getSystemService<UiModeManager>()
-        uiModeManager?.contrast ?: 0f
-    } else {
-        0f
-    }
+    val contrastLevel = contrastLevel(LocalContext.current)
 
     val colors = if (theme.colorMode == ColorMode.Dynamic && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         if (useDark) {

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
@@ -22,8 +22,12 @@
 package com.adevinta.spark.tokens
 
 import android.annotation.SuppressLint
+import android.app.UiModeManager
+import android.content.Context
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.content.res.Configuration.UI_MODE_TYPE_NORMAL
+import android.os.Build
+import androidx.annotation.FloatRange
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -53,7 +57,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.core.content.getSystemService
 import androidx.core.graphics.ColorUtils
+import com.adevinta.spark.ExperimentalSparkApi
 import com.adevinta.spark.InternalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
@@ -1457,6 +1463,39 @@ public fun SparkColors.surfaceColorAtElevation(
     if (elevation > 0.dp && surface.luminance() >= 0.5) return surface
     val alpha = ((4.5f * ln(elevation.value + 1)) + 2f) / 100f
     return surfaceTint.copy(alpha = alpha).compositeOver(surface)
+}
+
+/**
+ * Contrast level is an api available in the [UiModeManager] starting Android 34
+ */
+public val isContrastLevelAvailable: Boolean = Build.VERSION.SDK_INT >= 34
+
+/**
+ * Retrieve the contrast level of the device. This value can be used to adjust the colors of the theme.
+ *
+ * It is available on Android 34 and above. On lower versions, the fallback value will be returned.
+ *
+ * The contrast level is a float value between -1.0 and 1.0. The default value is 0.0.
+ * A value of -1.0 means that the contrast is set to the minimum value, and a value of 1.0 means that the contrast is
+ * set to the maximum value.
+ *
+ * @param context The context to use to retrieve the UiModeManager.
+ * @param fallback The fallback value to return if the contrast level is not available.
+ * @return The contrast level of the device or the fallback if not available.
+ *
+ * @see isContrastLevelAvailable
+ * @see UiModeManager.getContrast
+ */
+@ExperimentalSparkApi
+@FloatRange(from = -1.0, to = 1.0)
+public fun contrastLevel(
+    context: Context,
+    fallback: () -> Float = { 0f },
+): Float = if (isContrastLevelAvailable) {
+    val uiModeManager = context.getSystemService<UiModeManager>()
+    uiModeManager?.contrast?.takeIf { isContrastLevelAvailable } ?: fallback()
+} else {
+    fallback()
 }
 
 /**


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Move the method to get the contrast level from the catalog to spark

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
This utility method is usefullto get the available contrast level and to fallback on a default or a custom value in case the device api is inferior to 34 and we provided a high contrast selector in our application. 

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
