### PR TITLE
fix(modal): Always disable usePlatformDefaultWidth and add a composition local to get the edge-to-edge value

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -129,9 +129,9 @@ internal fun ComponentActivity.CatalogApp(
         shapes = shapes,
         typography = typography,
         sparkFeatureFlag = SparkFeatureFlag(
-            useLegacyStyle = theme.useLegacyTheme,
             useSparkTokensHighlighter = theme.highlightSparkTokens,
             useSparkComponentsHighlighter = theme.highlightSparkComponents,
+            isContainingActivityEdgeToEdge = true,
         ),
     ) {
         val layoutDirection = when (theme.textDirection) {

--- a/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
@@ -295,11 +295,10 @@ internal val LocalSparkFeatureFlag: ProvidableCompositionLocal<SparkFeatureFlag>
  * makes the text in cursive, colors in red/green/blue and shapes in full cut corners.
  * @property useSparkComponentsHighlighter Highlight visually with an overlay where the spark components are used
  * or not. Setting it to true show an overlay on spark components.
- * @property useLegacyStyle Makes the components use the legacy style from the previous DS to make it easier for the
- * Leboncoin teams to migrate their screens to spark.
+ * @property isContainingActivityEdgeToEdge
  */
 public data class SparkFeatureFlag(
     val useSparkTokensHighlighter: Boolean = false,
     val useSparkComponentsHighlighter: Boolean = false,
-    val useLegacyStyle: Boolean = false,
+    val isContainingActivityEdgeToEdge: Boolean = false,
 )

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.window.DialogWindowProvider
 import androidx.window.core.layout.WindowSizeClass.Companion.HEIGHT_DP_MEDIUM_LOWER_BOUND
 import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND
 import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.R
 import com.adevinta.spark.SparkTheme
@@ -123,7 +124,7 @@ public fun ModalScaffold(
     supportButton: (@Composable (Modifier) -> Unit)? = null,
     title: @Composable () -> Unit = {},
     actions: @Composable RowScope.() -> Unit = {},
-    inEdgeToEdge: Boolean = false,
+    inEdgeToEdge: Boolean = LocalSparkFeatureFlag.current.isContainingActivityEdgeToEdge,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     val size = LocalWindowSizeClass.current
@@ -132,7 +133,7 @@ public fun ModalScaffold(
     val isFoldableOrTablet = size.isAtLeastBreakpoint(WIDTH_DP_MEDIUM_LOWER_BOUND, HEIGHT_DP_MEDIUM_LOWER_BOUND)
 
     val properties = DialogProperties(
-        usePlatformDefaultWidth = !inEdgeToEdge,
+        usePlatformDefaultWidth = false,
         decorFitsSystemWindows = !inEdgeToEdge,
     )
 


### PR DESCRIPTION
…

<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Fixing `usePlatformDefaultWidth` to false everytime with the new google fix for a fullscreen dialog as the new config will apply the plateformWidth.
Use a `CompositionLocal` as a default value for the `inEdgeToEdge` param

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
The modal would appear with a gigantic padding horizontally when the `inEdgeToEdge` parameter was false.
Also add a new way with `CompositionLocal` to set the value for `inEdgeToEdge` which should make configuration of it app wise simpler

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

<!-- Insert your screenshots here -->
![image](https://github.com/user-attachments/assets/0ee86f1d-ec0b-4828-a64a-0b471529bd3b)
