### PR TITLE
chore: upgrade version to 1.3.0-alpha07

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@
 # SOFTWARE.
 #
 
-version=1.3.0-alpha06
+version=1.3.0-alpha07
 group=com.adevinta.spark
 
 org.gradle.caching=true


### PR DESCRIPTION
This is to test the new version upgrade of nmcp that might help with the failing publishing task when the validation takes ages
