### PR TITLE
feat(build): update publishing configuration from automatic to user managed

### DIFF
--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
@@ -35,8 +35,6 @@ import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.the
 import org.gradle.plugins.signing.SigningExtension
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.toJavaDuration
 
 internal class SparkPublishingPlugin : Plugin<Project> {
 
@@ -66,8 +64,7 @@ internal class SparkPublishingPlugin : Plugin<Project> {
         publishAllPublicationsToCentralPortal {
             username = System.getenv("CENTRAL_PORTAL_USERNAME")
             password = System.getenv("CENTRAL_PORTAL_PASSWORD")
-            publishingType = "AUTOMATIC"
-            publishingTimeout = 20.minutes.toJavaDuration()
+            publishingType = "USER_MANAGED"
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@
 # SOFTWARE.
 #
 
-version=1.3.0-alpha07
+version=1.3.0-alpha08
 group=com.adevinta.spark
 
 org.gradle.caching=true


### PR DESCRIPTION
We get too much timeout with the automatic publishing type configuration so I'm switching it back to user 