### PR TITLE
chore(ci): Remove forced `org.gradle.workers.max` on CI

### DIFF
--- a/.github/gradle.properties
+++ b/.github/gradle.properties
@@ -22,5 +22,4 @@
 
 org.gradle.daemon=false
 org.gradle.parallel=true
-org.gradle.workers.max=2
 org.gradle.logging.stacktrace=full


### PR DESCRIPTION
GHA already has 4 CPUs that can be used.
One worker on each CPU is the default value.

- https://docs.github.com/en/actions/how-tos/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
- https://docs.gradle.org/current/userguide/build_environment.html#gradle_properties_reference