### PR TITLE
chore(ci): migrate to single aggregation publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: ./.github/actions/setup-gradle-properties
 
       - name: '📦 Publish to Central Portal'
-        run: ./gradlew publishAllPublicationsToCentralPortal --no-configuration-cache
+        run: ./gradlew publishAggregationToCentralPortal --no-configuration-cache
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublication.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublication.kt
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package com.adevinta.spark
 
 import com.android.build.gradle.LibraryExtension
@@ -69,7 +68,6 @@ internal object SparkPublication {
         registerPublication()
         configureSigning()
     }
-
 
     private fun Project.configureRepository() = configure<PublishingExtension> {
         repositories {

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublication.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublication.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark
+
+import com.android.build.gradle.LibraryExtension
+import nmcp.NmcpAggregationExtension
+import nmcp.NmcpAggregationPlugin
+import nmcp.NmcpPlugin
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.assign
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.the
+import org.gradle.plugins.signing.SigningExtension
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
+
+internal object SparkPublication {
+
+    fun configureRootProject(project: Project) = with(project) {
+        apply<NmcpAggregationPlugin>()
+        configure<NmcpAggregationExtension> {
+            centralPortal {
+                username = System.getenv("CENTRAL_PORTAL_USERNAME")
+                password = System.getenv("CENTRAL_PORTAL_PASSWORD")
+                publishingType = "AUTOMATIC"
+                publishingTimeout = 20.minutes.toJavaDuration()
+            }
+        }
+        dependencies {
+            add("nmcpAggregation", project(":spark-bom"))
+            add("nmcpAggregation", project(":spark-icons"))
+            add("nmcpAggregation", project(":spark"))
+        }
+    }
+
+    fun configureSubproject(project: Project) = with(project) {
+        apply(plugin = "org.gradle.maven-publish")
+        apply(plugin = "org.gradle.signing")
+        apply<NmcpPlugin>()
+
+        configureRepository()
+        registerPublication()
+        configureSigning()
+    }
+
+
+    private fun Project.configureRepository() = configure<PublishingExtension> {
+        repositories {
+            mavenLocal {
+                name = "Local"
+                url = uri(rootProject.layout.buildDirectory.dir(".m2/repository"))
+            }
+        }
+    }
+
+    private fun Project.registerPublication() = configure<PublishingExtension> {
+        publications {
+            register<MavenPublication>("maven") {
+                when {
+                    isAndroidLibrary -> configureAndroidPublication(this)
+                    isJavaPlatform -> from(components["javaPlatform"])
+                    else -> TODO("Unsupported project type $this")
+                }
+                configurePom()
+            }
+        }
+    }
+
+    private fun Project.configureAndroidPublication(publication: MavenPublication) {
+        configure<LibraryExtension> {
+            publishing {
+                singleVariant("release") {
+                    withSourcesJar()
+                    withJavadocJar()
+                }
+            }
+        }
+        // AGP creates software components during the afterEvaluate callback step...
+        afterEvaluate {
+            publication.from(components.getByName("release"))
+        }
+    }
+
+    private fun MavenPublication.configurePom() = pom {
+        name = "Spark"
+        description = "Spark Design System"
+        url = "https://github.com/leboncoin/spark-android"
+        licenses {
+            license {
+                name = "MIT License"
+                url = "https://opensource.org/licenses/MIT"
+            }
+        }
+        scm {
+            url = "https://github.com/leboncoin/spark-android"
+        }
+        developers {
+            developer {
+                name = "Adevinta Engineers"
+                email = "engineers@adevinta.com"
+            }
+        }
+    }
+
+    private fun Project.configureSigning() = configure<SigningExtension> signing@{
+        val signingKey: String? by project
+        val signingPassword: String? by project
+        if (signingKey == null || signingPassword == null) return@signing
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(the<PublishingExtension>().publications)
+    }
+}

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
@@ -29,5 +29,4 @@ internal class SparkPublishingPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         SparkPublication.configureSubproject(target)
     }
-
 }

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
@@ -21,98 +21,13 @@
  */
 package com.adevinta.spark
 
-import com.android.build.gradle.LibraryExtension
-import nmcp.NmcpPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.assign
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.provideDelegate
-import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.the
-import org.gradle.plugins.signing.SigningExtension
 
 internal class SparkPublishingPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
-        with(target) {
-            apply(plugin = "org.gradle.maven-publish")
-            apply(plugin = "org.gradle.signing")
-            apply<NmcpPlugin>()
-
-            configureRepository()
-            registerPublication()
-            configureSigning()
-        }
+        SparkPublication.configureSubproject(target)
     }
 
-    private fun Project.configureRepository() = configure<PublishingExtension> {
-        repositories {
-            mavenLocal {
-                name = "Local"
-                url = uri(rootProject.layout.buildDirectory.dir(".m2/repository"))
-            }
-        }
-    }
-
-    private fun Project.registerPublication() = configure<PublishingExtension> {
-        publications {
-            register<MavenPublication>("maven") {
-                when {
-                    isAndroidLibrary -> configureAndroidPublication(this)
-                    isJavaPlatform -> from(components["javaPlatform"])
-                    else -> TODO("Unsupported project type $this")
-                }
-                configurePom()
-            }
-        }
-    }
-
-    private fun Project.configureAndroidPublication(publication: MavenPublication) {
-        configure<LibraryExtension> {
-            publishing {
-                singleVariant("release") {
-                    withSourcesJar()
-                    withJavadocJar()
-                }
-            }
-        }
-        // AGP creates software components during the afterEvaluate callback step...
-        afterEvaluate {
-            publication.from(components.getByName("release"))
-        }
-    }
-
-    private fun MavenPublication.configurePom() = pom {
-        name = "Spark"
-        description = "Spark Design System"
-        url = "https://github.com/leboncoin/spark-android"
-        licenses {
-            license {
-                name = "MIT License"
-                url = "https://opensource.org/licenses/MIT"
-            }
-        }
-        scm {
-            url = "https://github.com/leboncoin/spark-android"
-        }
-        developers {
-            developer {
-                name = "Adevinta Engineers"
-                email = "engineers@adevinta.com"
-            }
-        }
-    }
-
-    private fun Project.configureSigning() = configure<SigningExtension> signing@{
-        val signingKey: String? by project
-        val signingPassword: String? by project
-        if (signingKey == null || signingPassword == null) return@signing
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(the<PublishingExtension>().publications)
-    }
 }

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublishingPlugin.kt
@@ -22,7 +22,7 @@
 package com.adevinta.spark
 
 import com.android.build.gradle.LibraryExtension
-import nmcp.NmcpExtension
+import nmcp.NmcpPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
@@ -35,8 +35,6 @@ import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.the
 import org.gradle.plugins.signing.SigningExtension
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.toJavaDuration
 
 internal class SparkPublishingPlugin : Plugin<Project> {
 
@@ -44,10 +42,9 @@ internal class SparkPublishingPlugin : Plugin<Project> {
         with(target) {
             apply(plugin = "org.gradle.maven-publish")
             apply(plugin = "org.gradle.signing")
-            apply(plugin = "com.gradleup.nmcp")
+            apply<NmcpPlugin>()
 
             configureRepository()
-            configureNMCP()
             registerPublication()
             configureSigning()
         }
@@ -59,15 +56,6 @@ internal class SparkPublishingPlugin : Plugin<Project> {
                 name = "Local"
                 url = uri(rootProject.layout.buildDirectory.dir(".m2/repository"))
             }
-        }
-    }
-
-    private fun Project.configureNMCP() = configure<NmcpExtension> {
-        publishAllPublicationsToCentralPortal {
-            username = System.getenv("CENTRAL_PORTAL_USERNAME")
-            password = System.getenv("CENTRAL_PORTAL_PASSWORD")
-            publishingType = "AUTOMATIC"
-            publishingTimeout = 20.minutes.toJavaDuration()
         }
     }
 

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkRootPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkRootPlugin.kt
@@ -21,40 +21,14 @@
  */
 package com.adevinta.spark
 
-import nmcp.NmcpAggregationExtension
-import nmcp.NmcpAggregationPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.assign
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.dependencies
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.toJavaDuration
 
 internal class SparkRootPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             SparkUnitTests.configureRootProject(project)
-
-            configureNmcpPublication()
-        }
-    }
-
-    private fun Project.configureNmcpPublication() {
-        apply<NmcpAggregationPlugin>()
-        configure<NmcpAggregationExtension> {
-            centralPortal {
-                username = System.getenv("CENTRAL_PORTAL_USERNAME")
-                password = System.getenv("CENTRAL_PORTAL_PASSWORD")
-                publishingType = "AUTOMATIC"
-                publishingTimeout = 20.minutes.toJavaDuration()
-            }
-        }
-        dependencies {
-            add("nmcpAggregation", project(":spark-bom"))
-            add("nmcpAggregation", project(":spark-icons"))
-            add("nmcpAggregation", project(":spark"))
+            SparkPublication.configureRootProject(project)
         }
     }
 }

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkRootPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkRootPlugin.kt
@@ -21,13 +21,40 @@
  */
 package com.adevinta.spark
 
+import nmcp.NmcpAggregationExtension
+import nmcp.NmcpAggregationPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.assign
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
 
 internal class SparkRootPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             SparkUnitTests.configureRootProject(project)
+
+            configureNmcpPublication()
+        }
+    }
+
+    private fun Project.configureNmcpPublication() {
+        apply<NmcpAggregationPlugin>()
+        configure<NmcpAggregationExtension> {
+            centralPortal {
+                username = System.getenv("CENTRAL_PORTAL_USERNAME")
+                password = System.getenv("CENTRAL_PORTAL_PASSWORD")
+                publishingType = "AUTOMATIC"
+                publishingTimeout = 20.minutes.toJavaDuration()
+            }
+        }
+        dependencies {
+            add("nmcpAggregation", project(":spark-bom"))
+            add("nmcpAggregation", project(":spark-icons"))
+            add("nmcpAggregation", project(":spark"))
         }
     }
 }


### PR DESCRIPTION
## 📋 Changes

Migrate from multiple nmcp publications to a single aggregation nmcp publication.

This should prevent accumulating timeouts on each publication task.