### PR TITLE
chore: rewrite Gradle plugins dependencies in build-logic

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -42,17 +42,26 @@ kotlin {
 repositories {
     google()
     mavenCentral()
+    gradlePluginPortal()
 }
 
 dependencies {
+    fun DependencyHandlerScope.plugin(plugin: Provider<PluginDependency>) = plugin.map {
+        "${it.pluginId}:${it.pluginId}.gradle.plugin:${it.version.requiredVersion}"
+    }
     compileOnly(gradleApi())
-    compileOnly(libs.gradlePlugins.android)
-    compileOnly(libs.gradlePlugins.kotlin)
-    compileOnly(libs.gradlePlugins.compose)
-    compileOnly(libs.gradlePlugins.dependencyGuard)
-    compileOnly(libs.gradlePlugins.dokka)
-    compileOnly(libs.gradlePlugins.spotless)
-    compileOnly(libs.gradlePlugins.nmcp)
+    implementation(plugin(libs.plugins.android.application))
+    implementation(plugin(libs.plugins.android.kotlin))
+    implementation(plugin(libs.plugins.android.library))
+    implementation(plugin(libs.plugins.android.lint))
+    implementation(plugin(libs.plugins.android.test))
+    implementation(plugin(libs.plugins.compose))
+    implementation(plugin(libs.plugins.dependencyGuard))
+    implementation(plugin(libs.plugins.dokka))
+    implementation(plugin(libs.plugins.kotlin.jvm))
+    implementation(plugin(libs.plugins.nmcp))
+    implementation(plugin(libs.plugins.paparazzi))
+    implementation(plugin(libs.plugins.spotless))
     implementation(libs.dokka.base)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.android.lint) apply false
     alias(libs.plugins.android.kotlin) apply false
+    alias(libs.plugins.android.test) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.paparazzi) apply false
     alias(libs.plugins.dokka) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,13 @@
 [versions]
 accompanist = "0.36.0"
-android-gradlePlugin = "8.11.0"
+agp = "8.11.0"
 androidx-activity = "1.10.1"
 androidx-appCompat = "1.7.1"
 compileSdk = "35"
-dependencyGuard = "0.5.0"
 dokka = "1.9.20"
 kotlin = "2.2.0"
 lint = "31.11.0"
 minCompileSdk = "24"
-nmcp = "0.2.1"
-spotless = "7.0.4"
 targetSdk = "35"
 
 [libraries]
@@ -79,14 +76,6 @@ desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.1.5"
 dokka-android-documentation-plugin = { module = "org.jetbrains.dokka:android-documentation-plugin", version.ref = "dokka" }
 dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
 
-gradlePlugins-android = { module = "com.android.tools.build:gradle", version.ref = "android-gradlePlugin" }
-gradlePlugins-compose = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
-gradlePlugins-dependencyGuard = { module = "com.dropbox.dependency-guard:com.dropbox.dependency-guard.gradle.plugin", version.ref = "dependencyGuard" }
-gradlePlugins-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
-gradlePlugins-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-gradlePlugins-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
-gradlePlugins-nmcp = { module = "com.gradleup.nmcp:com.gradleup.nmcp.gradle.plugin", version.ref = "nmcp" }
-
 junit = "junit:junit:4.13.2"
 
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
@@ -115,19 +104,19 @@ slack-lint-compose = "com.slack.lint.compose:compose-lint-checks:1.4.2"
 testParameterInjector = "com.google.testparameterinjector:test-parameter-injector:1.18"
 
 [plugins]
-android-application = { id = "com.android.application", version.ref = "android-gradlePlugin" }
+android-application = { id = "com.android.application", version.ref = "agp" }
 android-kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-android-library = { id = "com.android.library", version.ref = "android-gradlePlugin" }
-android-lint = { id = "com.android.lint", version.ref = "android-gradlePlugin" }
-android-test = { id = "com.android.test", version.ref = "android-gradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+android-lint = { id = "com.android.lint", version.ref = "agp" }
+android-test = { id = "com.android.test", version.ref = "agp" }
 compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-paparazzi = "app.cash.paparazzi:1.3.5"
-dependencyGuard = { id = "com.dropbox.dependency-guard", version.ref = "dependencyGuard" }
+dependencyGuard = "com.dropbox.dependency-guard:0.5.0"
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-nmcp = { id = "com.gradleup.nmcp", version.ref = "nmcp" }
+nmcp = "com.gradleup.nmcp:0.2.1"
+paparazzi = "app.cash.paparazzi:1.3.5"
+spotless = "com.diffplug.spotless:7.0.4"
 
 
 # Plugins defined by this project


### PR DESCRIPTION
## 📋 Changes

Add missing plugins that should match the declaration from the root build.gradle.kts file.
And rename `android-gradlePlugin` into short form `agp`.

## 🤔 Context

Removes the need of additional dependencies by using the Gradle Plugin Marker Artifacts.