### PR TITLE
chore: Bump version to 1.3.0-alpha09

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@
 # SOFTWARE.
 #
 
-version=1.3.0-alpha08
+version=1.3.0-alpha09
 group=com.adevinta.spark
 
 org.gradle.caching=true


### PR DESCRIPTION
The aggregation should solve our issue with having 2 artifacts out of 3 to be published with #1612 