### PR TITLE
refactor(toggles): deprecate content side Start and ToggleIntent

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/SparkToggleLabelledContainer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/SparkToggleLabelledContainer.kt
@@ -81,6 +81,7 @@ internal fun SparkToggleLabelledContainer(
             }
         }
 
+        @Suppress("DEPRECATION")
         if (contentSide == ContentSide.Start) {
             label()
             HorizontalSpacer(32.dp)
@@ -94,7 +95,14 @@ internal fun SparkToggleLabelledContainer(
     }
 }
 
-public enum class ContentSide { Start, End }
+public enum class ContentSide {
+    @Deprecated(
+        message = "ContentSide will be removed if a few releases, only the End content side will be used",
+        replaceWith = ReplaceWith("ContentSide.End"),
+    )
+    Start,
+    End,
+}
 
 @Preview(
     group = "Toggles",
@@ -103,6 +111,7 @@ public enum class ContentSide { Start, End }
 @Composable
 internal fun TogglesLabelledSlotPreview() {
     PreviewTheme {
+        @Suppress("DEPRECATION")
         SparkToggleLabelledContainer(
             state = ToggleableState(true),
             toggle = {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/ToggleIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/ToggleIntent.kt
@@ -19,6 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+@file:Suppress("DEPRECATION")
+
 package com.adevinta.spark.components.toggles
 
 import androidx.compose.material3.CheckboxColors
@@ -32,6 +34,9 @@ import com.adevinta.spark.components.IntentColor
 import com.adevinta.spark.components.IntentColors
 import com.adevinta.spark.tokens.disabled
 
+@Deprecated(
+    message = "Intents for toggles have been deprecated in favor of using only the basic color and the error color",
+)
 public enum class ToggleIntent {
     /**
      * The default color of such UI controls as toggles, Slider, etc.


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
