### PR TITLE
fix(dialog): remove FLAG_LAYOUT_NO_LIMITS from ModalScaffold to allow scrollable popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### Spark
+
+#### Switch
+- 🔧 Reverted the removal of `contentSide` parameter from `SwitchLabelled` components to maintain backward compatibility
+
+#### Modal
+- 🐛 Fixed ModalScaffold by removing `FLAG_LAYOUT_NO_LIMITS` window flag to allow proper scrollable popup behavior when it's used inside it
+
 ## [1.4.0-alpha01]
 
 _2025-07-28_

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
@@ -21,7 +21,6 @@
  */
 package com.adevinta.spark.components.dialog
 
-import android.view.WindowManager
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -440,7 +439,8 @@ private fun SetUpEdgeToEdgeDialog() {
     window.statusBarColor = Color.Transparent.toArgb()
     window.navigationBarColor = Color.Transparent.toArgb()
     window.navigationBarColor = Color.Transparent.toArgb()
-    window.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+    // Displaying a popup with this flag will make it un scrollable if it's bigger that the screen
+    // window.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
     window.setDimAmount(0f)
 }
 


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Remove FLAG_LAYOUT_NO_LIMITS from ModalScaffold

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
`NO_LIMITS` make the window from a popup take its full content height as height. This makes the popup overflow from the device screen and makes it unscrollable.

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.