### PR TITLE
feat(popover): Expose positionProvider to customize the spacing between the popover and its anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ _2025-08-01_
 
 #### Animations
 
-##### Add new `pulse` modifier animation
+##### 🆕 Add new `pulse` modifier animation
 
 This animation display a pulsating wave from the component to catch the attention of the user eyes.
 THe color, scales, duration and shape are customizable.
@@ -26,7 +26,7 @@ ButtonTinted(
 )
 ```
 
-##### Add new `shake` modifier animation
+##### 🆕 Add new `shake` modifier animation
 
 This animation display a transformative animations using a spring animation spec.
 It's ideal to indicate validation on user interaction.
@@ -47,6 +47,8 @@ ButtonTinted(
     text = "Vibrate me",
 )
 ```
+
+- 🔧 Add a `positionProvider` argument to change the spacing between a `Popover` and its anchor
 
 ## [1.4.0-alpha02]
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupPositionProvider
 import com.adevinta.spark.ExperimentalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
@@ -88,6 +89,7 @@ import kotlinx.coroutines.launch
 public fun Popover(
     popover: @Composable () -> Unit,
     modifier: Modifier = Modifier,
+    positionProvider: PopupPositionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
     intent: PopoverIntent = PopoverIntent.Surface,
     isDismissButtonEnabled: Boolean = false,
     popoverState: TooltipState = rememberTooltipState(isPersistent = true),
@@ -99,7 +101,7 @@ public fun Popover(
 
     TooltipBox(
         modifier = modifier,
-        positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
+        positionProvider = positionProvider,
         focusable = focusable,
         enableUserInput = enableUserInput,
         tooltip = {


### PR DESCRIPTION

<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Expose `positionProvider` on Popover api

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
This api might help position the popover which is positioned currently on some screen in the top section while we need/want it to be on the bottom side

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
