### PR TITLE
feat(rating): add a11y slider semantics, drag gesture, haptic feedback, and testTag API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 <!-- Don't forget to update links at the end of this page! -->
 
+
 ## [Unreleased]
+
+### Spark
+
+#### ♿ RatingInput Accessibility & Interaction Improvements
+
+- ♿ `RatingInput` now behaves like a slider for accessibility, providing improved screen reader support and customizable state descriptions.
+- ♿ Added horizontal drag gesture to change the rating value, with haptic feedback for each change.
+- 🎨 Keyboard support: Shift + Arrow keys increment/decrement the rating for enhanced accessibility while still maintaining focus on a each starts for selection.
+- 🧪 Added `testTag` parameter for robust UI testing and automation.
+
+> [!CAUTION]
+> Like the Stepper If you use custom accessibility semantics or parent components, set `allowSemantics = false` to avoid duplicate announcements.
+
 
 ## [1.4.0]
 
@@ -180,7 +194,7 @@ if (useDarkColors) {
 > ComboBox uses the new TextFieldState API for improved state management.
 
 - ✨ **Major API Upgrade**: ComboBox components now use `TextFieldState` instead of value/onValueChange pattern (#1572)
-- ✨ **Enhanced Single Selection**: `SingleChoiceComboBox` with improved filtering and suggestion capabilities 
+- ✨ **Enhanced Single Selection**: `SingleChoiceComboBox` with improved filtering and suggestion capabilities
 - ✨ **Multi-Selection Support**: `MultiChoiceComboBox` with chip-based selection display and management
 
 **Example: Real-time Filtering ComboBox**
@@ -192,8 +206,8 @@ var searchText by remember { mutableStateOf("") }
 val filteredBooks by remember(searchText) {
     derivedStateOf {
         if (searchText.isBlank()) comboBoxSampleValues
-        else comboBoxSampleValues.filter { 
-            it.title.contains(searchText, ignoreCase = true) 
+        else comboBoxSampleValues.filter {
+            it.title.contains(searchText, ignoreCase = true)
         }
     }
 }
@@ -235,8 +249,8 @@ var searchText by remember { mutableStateOf("") }
 val suggestedBooks by remember(searchText) {
     derivedStateOf {
         if (searchText.isBlank()) emptyList()
-        else comboBoxSampleValues.filter { 
-            it.title.contains(searchText, ignoreCase = true) 
+        else comboBoxSampleValues.filter {
+            it.title.contains(searchText, ignoreCase = true)
         }.take(3) // Limit to top 3 suggestions
     }
 }
@@ -250,9 +264,9 @@ SingleChoiceComboBox(
     state = state,
     expanded = expanded,
     onExpandedChange = { showDropdown = it },
-    onDismissRequest = { 
+    onDismissRequest = {
         searchText = ""
-        showDropdown = false 
+        showDropdown = false
     },
     label = "Search with suggestions",
     placeholder = "Type to see suggestions...",
@@ -352,7 +366,7 @@ _2025-02-19_
 _2025-01-29_
 
 ### Spark
-- 🛠 Use latest and simpler workaround to display a Dialog in fullscreen with support to edge-to-edge. 
+- 🛠 Use latest and simpler workaround to display a Dialog in fullscreen with support to edge-to-edge.
 - 🛠️ Modal `inEdgeToEdge` parameter now default to false.
 
 ## [1.1.2]
@@ -363,7 +377,7 @@ _2025-01-29_
 - 🐛 Conditional modifiers were not working as expected since they returned an empty modifier instead of modifier chain if the condition was not met.
 
 
-## [1.1.1] 
+## [1.1.1]
 
 _2025-01-28_
 
@@ -419,7 +433,7 @@ _2024-12-11_
 ### Spark
 
 - ⬆️ Upgrade Compose BOM to `2024.11.00` since it only contains bugfixes changes.
-- 
+-
 - ## [1.0.1]
 
 _2024-11-07_
@@ -507,7 +521,7 @@ _2024-06-18_
 
 ### Catalog App
 - `ModalScaffold` Added an example that will show the modal with no actions.
- 
+
 ## [0.10.0]
 
 _2024-05-16_
@@ -547,7 +561,7 @@ If you want to make your Chip closable then you will need to add a callback acti
 > [!WARNING]
 > The `BottomSheet` currently only accept M3 snackbars, you won't be able to display a SparkSnackbar
 
---- 
+---
 
 - 🆕 ProgressTracker is now available! it still has a few minor visual bugs but it can be tested by squads on their scope don't hesitate to give us feedbacks!
 - 🆕 `TextLinkButton` will now use `LocalContentColor` when using the Surface intent. This will allow you to have a `onSurface` `TextLink` when needed
@@ -716,7 +730,7 @@ _2023-08-17_
 _2023-07-31_
 
 * 🆕 Added `Basic` and `Accent` intents to all released components.
-* 💄Updated the default color intents to `Basic` for `Tag`, `Chip`, `Spinner`. 
+* 💄Updated the default color intents to `Basic` for `Tag`, `Chip`, `Spinner`.
 * 🗑️ Deprecated `Primary` and `Secondary` intents, `Main` and `Support`should be used instead.
 
 ## [0.3.0]

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingInput.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingInput.kt
@@ -81,16 +81,16 @@ import kotlin.math.roundToInt
 
 /**
  * A rating input component that allows the user to select a rating from 0 to 5.
+ * This component can have it's value changed either by a tap on the star or dragging horizontally.
  *
  * @param value The current rating value [Int].
  * @param onRatingChanged The callback that is called when the rating value changes.
  * @param modifier The modifier to be applied to the layout.
  * @param enabled Whether the rating input is enabled.
  * @param stateDescription Lambda to generate the accessibility state description from the current value.
- *                        Defaults to "$value stars".
  * @param allowSemantics Whether to enable semantic properties for accessibility. Set to false when
- *                      using the component as part of a larger component that handles its own semantics
- *                      to avoid duplicate announcements.
+ * using the component as part of a larger component that handles its own semantics to avoid duplicate announcements.
+ * @param testTag Optional tag for UI testing, if defined then all stars will have a test tag in the format "$testTag Star $index" where index is 0-4.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingInput.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingInput.kt
@@ -23,11 +23,14 @@ package com.adevinta.spark.components.rating
 
 import androidx.annotation.IntRange
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.minimumInteractiveComponentSize
@@ -41,22 +44,53 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.popover.PlainTooltip
 import com.adevinta.spark.components.popover.TooltipBox
+import com.adevinta.spark.components.rating.RatingDefaults.InputFloatRange
 import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.tools.modifiers.ifNotNull
+import com.adevinta.spark.tools.modifiers.ifTrue
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
+import kotlin.math.roundToInt
 
 /**
  * A rating input component that allows the user to select a rating from 0 to 5.
  *
  * @param value The current rating value [Int].
- * @param onRatingChanged The callback that is called when the rating is changed.
+ * @param onRatingChanged The callback that is called when the rating value changes.
  * @param modifier The modifier to be applied to the layout.
  * @param enabled Whether the rating input is enabled.
+ * @param stateDescription Lambda to generate the accessibility state description from the current value.
+ *                        Defaults to "$value stars".
+ * @param allowSemantics Whether to enable semantic properties for accessibility. Set to false when
+ *                      using the component as part of a larger component that handles its own semantics
+ *                      to avoid duplicate announcements.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -65,10 +99,52 @@ public fun RatingInput(
     onRatingChanged: (Int) -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    stateDescription: (Int) -> String = { "$it stars" },
+    allowSemantics: Boolean = true,
+    testTag: String? = null,
 ) {
-    if (value !in 0..5) return
+    if (value !in RatingDefaults.InputIntRange) return
+
+    val haptics = LocalHapticFeedback.current
+    var ratingContainerWidth = 0f
+    var lastDragRating = value
+
     Row(
-        modifier = modifier.sparkUsageOverlay(),
+        modifier = modifier
+            .sparkUsageOverlay()
+            .ifTrue(allowSemantics) {
+                ratingSemantics(
+                    value = value,
+                    onValueChange = onRatingChanged,
+                    enabled = enabled,
+                    stateDescription = stateDescription,
+                )
+            }
+            .focusable(
+                enabled = enabled,
+                interactionSource = remember { MutableInteractionSource() },
+            )
+            .onSizeChanged { size ->
+                ratingContainerWidth = size.width.toFloat()
+            }
+            .pointerInput(enabled) {
+                if (!enabled) return@pointerInput
+                detectHorizontalDragGestures(
+                    onDragStart = { offset ->
+                        lastDragRating = calculateRatingFromPosition(offset.x, ratingContainerWidth)
+                    },
+                    onDragEnd = {},
+                    onDragCancel = {},
+                    onHorizontalDrag = { change, _ ->
+                        val newRating = calculateRatingFromPosition(change.position.x, ratingContainerWidth)
+                        if (newRating != lastDragRating) {
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onRatingChanged(newRating)
+                            lastDragRating = newRating
+                        }
+                    },
+                )
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         var remainingValue = value
@@ -87,7 +163,12 @@ public fun RatingInput(
                 positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
                 tooltip = {
                     PlainTooltip {
-                        Text("$starRatingValue")
+                        Text(
+                            text = "$starRatingValue",
+                            // hardcoded value inside material we need to be able to center the tooltip
+                            modifier = Modifier.width(24.dp),
+                            textAlign = TextAlign.Center,
+                        )
                     }
                 },
                 state = tooltipState,
@@ -96,7 +177,7 @@ public fun RatingInput(
                     modifier = Modifier
                         .minimumInteractiveComponentSize()
                         .clip(SparkTheme.shapes.full)
-                        .size(48.dp)
+                        .size(RatingDefaults.TouchTargetSize)
                         .clickable(
                             onClick = {
                                 onRatingChanged(starRatingValue)
@@ -105,20 +186,114 @@ public fun RatingInput(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = ripple(
                                 bounded = false,
-                                radius = 48.dp / 2,
+                                radius = RatingDefaults.TouchTargetSize / 2,
                             ),
                         )
+                        .ifNotNull(testTag) {
+                            testTag("$it Star $starRatingIndex")
+                        }
                         .padding(4.dp),
                 ) {
                     RatingStar(
                         enabled = enabled,
                         state = RatingStarState(starRating),
-                        size = 40.dp,
+                        size = RatingDefaults.StarSize,
                     )
                 }
             }
         }
     }
+}
+
+/**
+ * Adds semantics to a rating input component to make it behave like a slider for accessibility purposes.
+ *
+ * @param value The current rating value [Int] between 0 and 5.
+ * @param onValueChange The callback that is called when the rating is changed.
+ * @param enabled Whether the rating input is enabled.
+ * @param stateDescription Lambda to generate the state description string from the current value.
+ */
+// TODO-scott.rayapoulle.ext (17-09-2025): Move to spark a11y lib once it's initiated
+private fun Modifier.ratingSemantics(
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    enabled: Boolean,
+    stateDescription: (Int) -> String = { "$it" },
+): Modifier = semantics(mergeDescendants = true) {
+    setProgress { targetValue ->
+        val newValue = targetValue
+            .roundToInt()
+            .coerceIn(RatingDefaults.InputIntRange)
+        if (newValue != value) {
+            onValueChange(newValue)
+            true
+        } else {
+            false
+        }
+    }
+
+    this.stateDescription = stateDescription(value)
+    if (!enabled) disabled()
+}
+    .semantics {
+        progressBarRangeInfo = ProgressBarRangeInfo(
+            current = value.toFloat(),
+            range = InputFloatRange,
+            steps = RatingDefaults.Steps,
+        )
+    }
+    .onKeyEvent {
+        if (!enabled) return@onKeyEvent false
+
+        val isRightKey = it.key == Key.DirectionRight
+        val isLeftKey = it.key == Key.DirectionLeft
+        val isUpKey = it.key == Key.DirectionUp
+        val isDownKey = it.key == Key.DirectionDown
+        val isShiftOnlyPressed = it.isShiftPressed && !it.isCtrlPressed && !it.isAltPressed && !it.isMetaPressed
+
+        if (it.type == KeyEventType.KeyDown && isShiftOnlyPressed) {
+            when {
+                isRightKey || isUpKey -> onValueChange((value + 1).coerceIn(RatingDefaults.InputIntRange))
+                isLeftKey || isDownKey -> onValueChange((value - 1).coerceIn(RatingDefaults.InputIntRange))
+                else -> return@onKeyEvent false
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+/**
+ * Calculates the rating value based on the horizontal drag position.
+ *
+ * @param x The x-coordinate of the drag position
+ * @param width The total width of the rating component
+ * @return The calculated rating value between 0 and 5
+ */
+private fun calculateRatingFromPosition(x: Float, width: Float): Int {
+    if (width <= 0f) return 0
+    val position = x.coerceIn(0f, width)
+    val normalized = (position / width) * 5
+    return normalized.roundToInt().coerceIn(0, 5)
+}
+
+public object RatingDefaults {
+
+    public const val InputMin: Int = 0
+    public const val InputMax: Int = 5
+    public val InputIntRange: ClosedRange<Int> = InputMin..InputMax
+    public val InputFloatRange: ClosedFloatingPointRange<Float> = InputMin.toFloat()..InputMax.toFloat()
+    public const val Steps: Int = InputMax - InputMin
+
+    /**
+     * The size of each star in the rating.
+     */
+    public val StarSize: Dp = 40.dp
+
+    /**
+     * The size of the clickable area for each star.
+     */
+    public val TouchTargetSize: Dp = 48.dp
 }
 
 @Composable
@@ -132,6 +307,7 @@ internal fun RatingInputPreview() {
             mutableIntStateOf(2)
         }
         RatingInput(value = rating, onRatingChanged = { rating = it })
+        RatingInput(value = rating, enabled = false, onRatingChanged = { rating = it })
         RatingInput(value = 0, onRatingChanged = {})
         RatingInput(value = 1, onRatingChanged = {})
         RatingInput(value = 2, onRatingChanged = {})

--- a/spark/src/test/kotlin/com/adevinta/spark/components/rating/RatingInputTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/components/rating/RatingInputTest.kt
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.rating
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasProgressBarRangeInfo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.test.withKeyDown
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RatingInputTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun ratingInput_disabled_doesNotChangeValue() {
+        val testTag = "ratingInputTag"
+        composeTestRule.setContent {
+            var rating by remember { mutableIntStateOf(2) }
+            RatingInput(
+                modifier = Modifier.testTag(testTag),
+                value = rating,
+                onRatingChanged = { rating = it },
+                enabled = false,
+                testTag = testTag,
+            )
+        }
+        composeTestRule.onNodeWithTag("$testTag Star 3").assertIsNotEnabled().performClick()
+        // Value should remain 2
+    }
+
+    @Test
+    fun ratingInput_customStateDescription_isApplied() {
+        val testTag = "ratingInputTag"
+        composeTestRule.setContent {
+            RatingInput(
+                modifier = Modifier.testTag(testTag),
+                value = 4,
+                onRatingChanged = {},
+                stateDescription = { "Custom: $it" },
+                testTag = testTag,
+            )
+        }
+        // Check semantics
+        composeTestRule.onNodeWithTag(testTag).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Custom: 4"),
+        )
+    }
+
+    @Test
+    fun ratingInput_allowSemantics_false_noSemantics() {
+        val testTag = "ratingInputTag"
+        composeTestRule.setContent {
+            RatingInput(
+                modifier = Modifier.testTag(testTag),
+                value = 2,
+                onRatingChanged = {},
+                allowSemantics = false,
+                testTag = testTag,
+            )
+        }
+        // Should not have progressBarRangeInfo
+        composeTestRule.onNode(
+            hasProgressBarRangeInfo(
+                ProgressBarRangeInfo(
+                    current = 2f,
+                    range = 0f..5f,
+                    steps = 0,
+                ),
+            ),
+            useUnmergedTree = true,
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun ratingInput_semantics_stateDescription_and_range() {
+        val min = 0
+        val max = 5
+        val value = 3
+        val testTag = "ratingInputTag"
+        val rangeFloat = min.toFloat()..max.toFloat()
+        val steps = max - min
+        composeTestRule.setContent {
+            RatingInput(
+                modifier = Modifier.testTag(testTag),
+                value = value,
+                onRatingChanged = {},
+                stateDescription = { "$value stars" },
+                testTag = testTag,
+            )
+        }
+        composeTestRule.onNodeWithTag(testTag).assert(
+            hasProgressBarRangeInfo(
+                ProgressBarRangeInfo(
+                    current = value.toFloat(),
+                    range = rangeFloat,
+                    steps = steps,
+                ),
+            ),
+        ).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "3 stars"),
+        )
+    }
+
+    @Test
+    fun ratingInput_semantics_range_and_progress() {
+        val min = 0
+        val max = 5
+        val initialValue = 2
+        val testTag = "ratingInputTag"
+        val rangeFloat = min.toFloat()..max.toFloat()
+        val steps = max - min
+        composeTestRule.setContent {
+            RatingInput(
+                modifier = Modifier.testTag(testTag),
+                value = initialValue,
+                onRatingChanged = {},
+                testTag = testTag,
+            )
+        }
+        composeTestRule.onNodeWithTag(testTag).assert(
+            hasProgressBarRangeInfo(
+                ProgressBarRangeInfo(
+                    current = initialValue.toFloat(),
+                    range = rangeFloat,
+                    steps = steps,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun ratingInput_semantics_progress_setProgress() {
+        val min = 0
+        val max = 5
+        val initialValue = 2
+        val testTag = "ratingInputTag"
+        val rangeFloat = min.toFloat()..max.toFloat()
+        val steps = max - min
+        composeTestRule.setContent {
+            var rating by remember { mutableIntStateOf(initialValue) }
+            RatingInput(
+                modifier = Modifier.testTag(testTag),
+                value = rating,
+                onRatingChanged = { rating = it },
+                testTag = testTag,
+            )
+        }
+        composeTestRule.onNodeWithTag(testTag)
+            .performSemanticsAction(SemanticsActions.SetProgress) { setProgress -> setProgress(4f) }.assert(
+                hasProgressBarRangeInfo(
+                    ProgressBarRangeInfo(
+                        current = 4f,
+                        range = rangeFloat,
+                        steps = steps,
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    fun ratingInput_semantics_disabled_state() {
+        val testTag = "ratingInputTag"
+        composeTestRule.setContent {
+            RatingInput(
+                modifier = Modifier.testTag(testTag),
+                value = 2,
+                onRatingChanged = {},
+                testTag = testTag,
+                enabled = false,
+            )
+        }
+        composeTestRule.onNodeWithTag(testTag).assert(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.Disabled),
+        )
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun ratingInput_keyboard_control_increments_and_decrements() {
+        val min = 0
+        val max = 5
+        val initialValue = 2
+        val testTag = "ratingInputTag"
+        val rangeFloat = min.toFloat()..max.toFloat()
+        val steps = max - min
+        composeTestRule.setContent {
+            var rating by remember { mutableIntStateOf(initialValue) }
+            RatingInput(
+                modifier = Modifier.testTag(testTag),
+                value = rating,
+                onRatingChanged = { rating = it },
+                testTag = testTag,
+            )
+        }
+        composeTestRule.onNodeWithTag(testTag)
+            .requestFocus()
+            .performKeyInput {
+                withKeyDown(Key.ShiftLeft) {
+                    pressKey(Key.DirectionRight)
+                }
+            }.assert(
+                hasProgressBarRangeInfo(
+                    ProgressBarRangeInfo(
+                        current = 3f,
+                        range = rangeFloat,
+                        steps = steps,
+                    ),
+                ),
+            ).performKeyInput {
+                withKeyDown(Key.ShiftLeft) {
+                    pressKey(Key.DirectionLeft)
+                }
+            }.assert(
+                hasProgressBarRangeInfo(
+                    ProgressBarRangeInfo(
+                        current = 2f,
+                        range = rangeFloat,
+                        steps = steps,
+                    ),
+                ),
+            )
+    }
+}


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
- Adds accessibility slider semantics to RatingInput
- Implements drag gesture and haptic feedback for rating selection
- Adds allowSemantics and testTag parameters for a11y and testing
- Refactors constants to RatingDefaults
- Updates and expands RatingInputTest for a11y and interaction coverage


## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
Close [LBCSPARK-298](https://jira.ets.mpi-internal.com/browse/LBCSPARK-298)

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

<!-- Insert your screenshots here -->

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
