### PR TITLE
fix(Image): prevent image from being downloaded twice

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
@@ -55,7 +55,6 @@ import coil3.asImage
 import coil3.compose.AsyncImagePainter
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
-import coil3.compose.rememberAsyncImagePainter
 import coil3.decode.DataSource
 import coil3.request.ErrorResult
 import coil3.request.ImageRequest
@@ -109,11 +108,6 @@ public fun SparkImage(
     val emptyStateIcon = remember(emptyIcon) {
         movableContentOf(emptyIcon)
     }
-    val painter = rememberAsyncImagePainter(
-        model = model,
-        transform = transform,
-        onState = { onState?.invoke(it.asImageState()) },
-    )
     val exceptionHandler = LocalSparkExceptionHandler.current
     SubcomposeAsyncImage(
         modifier = modifier


### PR DESCRIPTION
## 🤔 Context

When debugging image loading we noticed images displayed from an URL were downloaded twice

<img width="1173" height="75" alt="Screenshot 2025-11-26 at 11 24 04" src="https://github.com/user-attachments/assets/f5cc3333-07fd-4ee7-abb9-46c99c22e418" />

This is because we were manually creating an `AsyncImagePainter` which the `SubcomposeAsyncImage` Composable also does internally. This `AsyncImagePainter` then [internally launches a Job to download the image](https://github.com/coil-kt/coil/blob/f95531d74949f926fe7522507266e7aaa5dad3af/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt#L222).

By removing the manually created `AsyncImagePainter`, the images are only downloaded once.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] I have checked with AppInspection that images are only downloaded once.

