### PR TITLE
chore: exclude dependency files from spotless

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -101,6 +101,7 @@ spotless {
     val licenseHeader = rootProject.file("./../spotless/spotless.kt")
     format("misc") {
         target("**/*.md", "**/.gitignore")
+        targetExclude("**/dependencies/*.txt")
         endWithNewline()
     }
     kotlin {

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkSpotlessPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkSpotlessPlugin.kt
@@ -37,6 +37,7 @@ internal class SparkSpotlessPlugin : Plugin<Project> {
                 val licenseHeader = rootProject.file("spotless/spotless.kt")
                 format("misc") {
                     target("**/*.md", "**/.gitignore")
+                    targetExclude("**/dependencies/*.txt")
                     endWithNewline()
                 }
                 kotlin {


### PR DESCRIPTION
to prevent these errors:

```
    Reason: Task ':spark:spotlessMisc' uses this output of task ':spark:dependencyGuard' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

