### PR TITLE
chore(lint): rename issue id MaterialComposableUsageDetector

### DIFF
--- a/spark-lint/src/main/kotlin/com/adevinta/spark/lint/MaterialComposableUsageDetector.kt
+++ b/spark-lint/src/main/kotlin/com/adevinta/spark/lint/MaterialComposableUsageDetector.kt
@@ -73,7 +73,7 @@ public class MaterialComposableUsageDetector :
 
     internal companion object {
         val ISSUE = Issue.create(
-            id = "MaterialComposableUsageDetector",
+            id = "MaterialComposableHasSparkReplacement",
             briefDescription = "A Spark replacement is available for this Composable",
             explanation = "Material or any other third party Composable should be replaced with a Spark Composable.",
             category = CORRECTNESS,


### PR DESCRIPTION
## 📋 Changes

Rename lint issue ID from `MaterialComposableUsageDetector` to `MaterialComposableHasSparkReplacement` in order to avoid using the suffix Detector but most importantly to precisely define the reason of this detector. The original name was not meaningful.

## 🗒️ Other info

Suppressions will have to be update as well on the consumer side as there is no way to create aliases.
