### PR TITLE
fix: spotless not being able to parse file

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Example.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Example.kt
@@ -32,7 +32,5 @@ public data class Example(
     val name: String,
     val description: String,
     val sourceUrl: String,
-    val content:
-    @Composable()
-    ColumnScope.(SnackbarHostState) -> Unit,
+    val content: @Composable ColumnScope.(SnackbarHostState) -> Unit,
 )


### PR DESCRIPTION
Because of the `@Composable()` syntax...

> Format was not able to resolve all violations which (theoretically) can be autocorrected in file spark-android/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Example.kt