### PR TITLE
fix: disable HTML reports until Paparazzi supports Gradle 9.3+ APIs

### DIFF
--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkUnitTests.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkUnitTests.kt
@@ -105,6 +105,11 @@ internal object SparkUnitTests {
                 exceptionFormat = FULL
                 events(STARTED, PASSED, FAILED, SKIPPED)
             }
+            reports {
+                // Disable HTML reports until Paparazzi supports Gradle 9.3+ APIs
+                // https://github.com/cashapp/paparazzi/issues/2182
+                html.required.set(false)
+            }
         }
     }
 }


### PR DESCRIPTION
- https://github.com/cashapp/paparazzi/issues/2182