### PR TITLE
ci: add `publishToMavenLocal` task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       - run: pip install -r .github/requirements.txt
 
       - name: 📋 Build Dokka
-        run: ./gradlew dokkaGeneratePublicationHtml nmcpPublishAggregationToMavenLocal
+        run: ./gradlew dokkaGeneratePublicationHtml publishToMavenLocal
       - name: 📦 Archive Dokka
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
To ensure the aggregated publication compiles and is valid.

This would have been helpful to catch a regression on the `javaDocReleaseGeneration` task.