### PR TITLE
refactor(buttons): resolve intent.colors() once per composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Spark
 
+- 🎨 Refactor `ButtonFilled` and `ButtonTinted` to resolve `intent.colors()` once per composition instead of multiple times, reducing redundant allocations per recomposition
 - 🗑️ `Basic` intent has been deprecated across all components (`ButtonIntent`, `BadgeIntent`, `ChipIntent`, `TagIntent`, `ToggleIntent`, etc.) and replaced with `Support`, which was already identical in value. Usages of `Basic` will produce a compile error with an automatic migration hint to `Support`.
 
 #### 🔧 Kelp IDE plugin support

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonFilled.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonFilled.kt
@@ -80,12 +80,13 @@ public fun ButtonFilled(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable RowScope.() -> Unit,
 ) {
+    val intentColors = intent.colors()
     val backgroundColor by animateColorAsState(
-        targetValue = intent.colors().color,
+        targetValue = intentColors.color,
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onColor,
+        targetValue = intentColors.onColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(
@@ -153,12 +154,13 @@ public fun ButtonFilled(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     atEnd: Boolean = false,
 ) {
+    val intentColors = intent.colors()
     val backgroundColor by animateColorAsState(
-        targetValue = intent.colors().color,
+        targetValue = intentColors.color,
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onColor,
+        targetValue = intentColors.onColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(
@@ -224,12 +226,13 @@ public fun ButtonFilled(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     atEnd: Boolean = false,
 ) {
+    val intentColors = intent.colors()
     val backgroundColor by animateColorAsState(
-        targetValue = intent.colors().color,
+        targetValue = intentColors.color,
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onColor,
+        targetValue = intentColors.onColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTinted.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTinted.kt
@@ -88,7 +88,7 @@ public fun ButtonTinted(
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onContainerColor,
+        targetValue = intentColors.onContainerColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(
@@ -164,7 +164,7 @@ public fun ButtonTinted(
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onContainerColor,
+        targetValue = intentColors.onContainerColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(
@@ -240,7 +240,7 @@ public fun ButtonTinted(
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onContainerColor,
+        targetValue = intentColors.onContainerColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(


### PR DESCRIPTION
## 📋 Changes

Resolve `intent.colors()` once per composition in `ButtonFilled` and `ButtonTinted` by storing the result in a local `val intentColors`, instead of calling it multiple times per overload.

## 🤔 Context

Each button overload was calling `intent.colors()` twice — once for the background color and once for the content color. This caused redundant allocations on every recomposition. The fix was already consistently applied in `ButtonGhost` and `ButtonContrast`; this aligns the remaining variants.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.
