### PR TITLE
fix(buttons): use contentColor.disabled for disabledContentColor in B…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Spark
 
+- 🎨 Refactor `ButtonFilled` and `ButtonTinted` to resolve `intent.colors()` once per composition instead of multiple times, reducing redundant allocations per recomposition
 - 🗑️ `Basic` intent has been deprecated across all components (`ButtonIntent`, `BadgeIntent`, `ChipIntent`, `TagIntent`, `ToggleIntent`, etc.) and replaced with `Support`, which was already identical in value. Usages of `Basic` will produce a compile error with an automatic migration hint to `Support`.
 
 #### 🔧 Kelp IDE plugin support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Spark
 
+- 🐛 Fix `ButtonFilled` disabled content colour using the wrong token (`dim3` instead of `disabled`), causing the disabled state to appear too faint on non-white backgrounds
 - 🎨 Refactor `ButtonFilled` and `ButtonTinted` to resolve `intent.colors()` once per composition instead of multiple times, reducing redundant allocations per recomposition
 - 🗑️ `Basic` intent has been deprecated across all components (`ButtonIntent`, `BadgeIntent`, `ChipIntent`, `TagIntent`, `ToggleIntent`, etc.) and replaced with `Support`, which was already identical in value. Usages of `Basic` will produce a compile error with an automatic migration hint to `Support`.
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonFilled.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonFilled.kt
@@ -40,7 +40,6 @@ import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.icons.IdentityCardOutline
 import com.adevinta.spark.icons.LeboncoinIcons
 import com.adevinta.spark.icons.SparkIcon
-import com.adevinta.spark.tokens.dim3
 import com.adevinta.spark.tokens.disabled
 
 /**
@@ -93,7 +92,7 @@ public fun ButtonFilled(
         containerColor = backgroundColor,
         contentColor = contentColor,
         disabledContainerColor = backgroundColor.disabled,
-        disabledContentColor = contentColor.dim3,
+        disabledContentColor = contentColor.disabled,
     )
     BaseSparkButton(
         onClick = onClick,
@@ -238,6 +237,8 @@ public fun ButtonFilled(
     val colors = ButtonDefaults.buttonColors(
         containerColor = backgroundColor,
         contentColor = contentColor,
+        disabledContainerColor = backgroundColor.disabled,
+        disabledContentColor = contentColor.disabled,
     )
     SparkButton(
         onClick = onClick,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonFilled.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonFilled.kt
@@ -80,12 +80,13 @@ public fun ButtonFilled(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable RowScope.() -> Unit,
 ) {
+    val intentColors = intent.colors()
     val backgroundColor by animateColorAsState(
-        targetValue = intent.colors().color,
+        targetValue = intentColors.color,
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onColor,
+        targetValue = intentColors.onColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(
@@ -153,12 +154,13 @@ public fun ButtonFilled(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     atEnd: Boolean = false,
 ) {
+    val intentColors = intent.colors()
     val backgroundColor by animateColorAsState(
-        targetValue = intent.colors().color,
+        targetValue = intentColors.color,
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onColor,
+        targetValue = intentColors.onColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(
@@ -224,12 +226,13 @@ public fun ButtonFilled(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     atEnd: Boolean = false,
 ) {
+    val intentColors = intent.colors()
     val backgroundColor by animateColorAsState(
-        targetValue = intent.colors().color,
+        targetValue = intentColors.color,
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onColor,
+        targetValue = intentColors.onColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTinted.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTinted.kt
@@ -88,7 +88,7 @@ public fun ButtonTinted(
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onContainerColor,
+        targetValue = intentColors.onContainerColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(
@@ -164,7 +164,7 @@ public fun ButtonTinted(
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onContainerColor,
+        targetValue = intentColors.onContainerColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(
@@ -240,7 +240,7 @@ public fun ButtonTinted(
         label = "background color",
     )
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().onContainerColor,
+        targetValue = intentColors.onContainerColor,
         label = "content color",
     )
     val colors = ButtonDefaults.buttonColors(


### PR DESCRIPTION
## 📋 Changes

- Replace `contentColor.dim3` with `contentColor.disabled` for `disabledContentColor` in the first `ButtonFilled` overload
- Add missing `disabledContainerColor` and `disabledContentColor` to the `AnnotatedString` overload, which had no disabled colours at all
- Remove the now-unused `dim3` import

## 🤔 Context

The first `ButtonFilled` overload was using `dim3` (35% opacity) instead of `disabled` (38% opacity) for the disabled content colour, making the disabled state appear slightly too faint, particularly visible on non-white backgrounds. The other overloads already used `.disabled` correctly. The `AnnotatedString` overload was silently falling back to Material3 defaults for disabled colours, which don't match the Spark token contract.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.

## 📸 Screenshots

<!-- Disabled state on non-white background before/after -->