### PR TITLE
 refactor(spark): extend component token layer to TextFields and  IconButtons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Shape (and spacing) resolution for Button, Chip, Tag, TextField, and IconButton 
 
 `TextFieldTokens` exposes a `shape` property. `IconButtonTokens` exposes `resolveShape(fallback)` and `resolveFullShape(fallback)` functions rather than plain properties because icon button composables accept a caller-supplied shape as the legacy fallback, which the token object cannot know without the argument.
 
-> **Note:** This is the initial foundation of a broader component token layer. The pattern is not yet generalised to all components — further components will be migrated in follow-up changes.
+> [!NOTE]
+> This is the initial foundation of a broader component token layer. The pattern is not yet generalised to all components — further components will be migrated in follow-up changes.
 
 ## [2.1.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ Added `KelpInlayPreview` inner classes to `SparkColors`, `SparkShapes`, `SparkTy
 
 Chips, icon buttons, and text fields now participate in the rebranding shape changes introduced in 2.1.0. The feature flag `SparkFeatureFlag.useNewButtonAndTagsShapes` has been renamed to `useRebrandedShapes` to reflect the broader scope.
 
+#### ♻️ Component token objects for shape resolution
+
+Shape (and spacing) resolution for Button, Chip, Tag, TextField, and IconButton components is now centralised in dedicated token objects — `ButtonTokens`, `ChipTokens`, `TagTokens`, `TextFieldTokens`, and `IconButtonTokens` — rather than scattered inline `if (LocalSparkFeatureFlag.current.useRebrandedShapes)` checks inside each composable. No behaviour change; the objects are public so consumers can reference the resolved values directly.
+
+`TextFieldTokens` exposes a `shape` property. `IconButtonTokens` exposes `resolveShape(fallback)` and `resolveFullShape(fallback)` functions rather than plain properties because icon button composables accept a caller-supplied shape as the legacy fallback, which the token object cannot know without the argument.
+
+> **Note:** This is the initial foundation of a broader component token layer. The pattern is not yet generalised to all components — further components will be migrated in follow-up changes.
+
 ## [2.1.1]
 
 _2026-03-31_

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonScreenshot_large_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonScreenshot_large_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c84aeec5b0ff5fc52e2c3a81585a93c590d9125075a8d5e43765b8e3876d860d
-size 434540
+oid sha256:6d9304ce0eeab2a735b0e75c0c80337ea578870033c08a0cd0fe584af1788190
+size 439004

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonScreenshot_large_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonScreenshot_large_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35b95acf84a7be838216bb0de8fe3f331042b32d952f92a36156f1d761e7046a
-size 377408
+oid sha256:cca3713049aef96a4ca89096c1e088d0729cf83e75ce8a9e06bebbbda40e3026
+size 377621

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonScreenshot_medium_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonScreenshot_medium_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a83cc4291ff07d5656acc29334bbdf52e72ad737957ea2b808fe7ec3262915e8
-size 378431
+oid sha256:5c066343d21a0c809b74734b9a4c7a64f3c17a31403a2b16cea14d4cdd6334ee
+size 380306

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonScreenshot_medium_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonScreenshot_medium_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f4edf08d4d279f7bb850ca341405974f45e55578e7bcb492cfe9d4bc042d97fe
-size 330935
+oid sha256:6fcf32073bf10ac5314913e09544bfd3cd0e2e36885819cc512ce7eea4a9467d
+size 330841

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
@@ -248,7 +248,8 @@ public object SparkButtonDefaults {
     )
 
     /**
-     * The default shape of Button
+     * The fallback shape of Button when rebranding is not active.
+     * Use [ButtonTokens.shape] or [ButtonTokens.buttonShape] to get the flag-resolved shape.
      */
     internal val DefaultShape = ButtonShape.Rounded
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonContrast.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonContrast.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
-import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.icons.Chain
@@ -98,11 +97,7 @@ public fun ButtonContrast(
         content = content,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            SparkTheme.shapes.full
-        } else {
-            shape.shape
-        },
+        shape = ButtonTokens.shape,
         enabled = enabled,
         elevation = ButtonDefaults.buttonElevation(),
         colors = buttonColors,
@@ -169,7 +164,7 @@ public fun ButtonContrast(
         text = text,
         modifier = modifier,
         size = size,
-        shape = shape,
+        shape = ButtonTokens.buttonShape,
         enabled = enabled,
         elevation = ButtonDefaults.buttonElevation(),
         colors = buttonColors,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonFilled.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonFilled.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
-import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.icons.IdentityCardOutline
@@ -98,11 +97,7 @@ public fun ButtonFilled(
         onClick = onClick,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            SparkTheme.shapes.full
-        } else {
-            shape.shape
-        },
+        shape = ButtonTokens.shape,
         enabled = enabled,
         elevation = ButtonDefaults.buttonElevation(),
         colors = colors,
@@ -173,11 +168,7 @@ public fun ButtonFilled(
         text = text,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            ButtonShape.Pill
-        } else {
-            shape
-        },
+        shape = ButtonTokens.buttonShape,
         enabled = enabled,
         elevation = ButtonDefaults.buttonElevation(),
         colors = colors,
@@ -245,11 +236,7 @@ public fun ButtonFilled(
         text = text,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            ButtonShape.Pill
-        } else {
-            SparkButtonDefaults.DefaultShape
-        },
+        shape = ButtonTokens.buttonShape,
         enabled = enabled,
         elevation = ButtonDefaults.buttonElevation(),
         colors = colors,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonGhost.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonGhost.kt
@@ -97,11 +97,7 @@ public fun ButtonGhost(
         onClick = onClick,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            SparkTheme.shapes.full
-        } else {
-            shape.shape
-        },
+        shape = ButtonTokens.shape,
         enabled = enabled,
         elevation = ButtonDefaults.buttonElevation(),
         colors = colors,
@@ -170,11 +166,7 @@ public fun ButtonGhost(
         text = text,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            ButtonShape.Pill
-        } else {
-            shape
-        },
+        shape = ButtonTokens.buttonShape,
         enabled = enabled,
         elevation = ButtonDefaults.buttonElevation(),
         colors = colors,
@@ -242,11 +234,7 @@ public fun ButtonGhost(
         text = text,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            ButtonShape.Pill
-        } else {
-            shape
-        },
+        shape = ButtonTokens.buttonShape,
         enabled = enabled,
         elevation = ButtonDefaults.buttonElevation(),
         colors = colors,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonOutlined.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonOutlined.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
-import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.icons.CameraFill
@@ -92,11 +91,7 @@ public fun ButtonOutlined(
         onClick = onClick,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            SparkTheme.shapes.full
-        } else {
-            shape.shape
-        },
+        shape = ButtonTokens.shape,
         enabled = enabled,
         elevation = null,
         border = SparkButtonDefaults.outlinedBorder(if (enabled) contentColor else disabledContentColor),
@@ -160,11 +155,7 @@ public fun ButtonOutlined(
         text = text,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            ButtonShape.Pill
-        } else {
-            shape
-        },
+        shape = ButtonTokens.buttonShape,
         enabled = enabled,
         elevation = null,
         border = SparkButtonDefaults.outlinedBorder(if (enabled) contentColor else disabledContentColor),
@@ -224,11 +215,7 @@ public fun ButtonOutlined(
         text = text,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            ButtonShape.Pill
-        } else {
-            SparkButtonDefaults.DefaultShape
-        },
+        shape = ButtonTokens.buttonShape,
         enabled = enabled,
         elevation = null,
         border = SparkButtonDefaults.outlinedBorder(contentColor),

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTinted.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTinted.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
-import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.icons.IdentityCardOutline
@@ -101,11 +100,7 @@ public fun ButtonTinted(
         onClick = onClick,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            SparkTheme.shapes.full
-        } else {
-            shape.shape
-        },
+        shape = ButtonTokens.shape,
         enabled = enabled,
         elevation = ButtonDefaults.filledTonalButtonElevation(),
         colors = colors,
@@ -178,11 +173,7 @@ public fun ButtonTinted(
         text = text,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            ButtonShape.Pill
-        } else {
-            shape
-        },
+        shape = ButtonTokens.buttonShape,
         enabled = enabled,
         elevation = ButtonDefaults.filledTonalButtonElevation(),
         colors = colors,
@@ -254,11 +245,7 @@ public fun ButtonTinted(
         text = text,
         modifier = modifier,
         size = size,
-        shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            ButtonShape.Pill
-        } else {
-            shape
-        },
+        shape = ButtonTokens.buttonShape,
         enabled = enabled,
         elevation = ButtonDefaults.filledTonalButtonElevation(),
         colors = colors,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTokens.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.buttons
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Shape
+import com.adevinta.spark.LocalSparkFeatureFlag
+import com.adevinta.spark.SparkTheme
+
+/**
+ * Component tokens for button components. Centralises all flag-driven token resolution so that
+ * each button variant reads from a single source of truth instead of inlining the flag check at
+ * every call site. When the rebranding feature flag is eventually removed, only this file changes.
+ */
+public object ButtonTokens {
+
+    /**
+     * The resolved container shape for buttons as a raw [Shape].
+     * Used by overloads that call [BaseSparkButton] directly.
+     */
+    public val shape: Shape
+        @Composable get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
+            SparkTheme.shapes.full
+        } else {
+            SparkButtonDefaults.DefaultShape.shape
+        }
+
+    /**
+     * The resolved container shape for buttons as a [ButtonShape].
+     * Used by overloads that delegate to [SparkButton].
+     */
+    public val buttonShape: ButtonShape
+        @Composable get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
+            ButtonShape.Pill
+        } else {
+            SparkButtonDefaults.DefaultShape
+        }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.kt
@@ -63,7 +63,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.offset
 import androidx.compose.ui.util.fastFirstOrNull
 import com.adevinta.spark.InternalSparkApi
-import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.SparkTheme.colors
@@ -113,11 +112,7 @@ private fun SparkChip(
 ) {
     @Suppress("NAME_SHADOWING")
     val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-    val shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-        SparkTheme.shapes.large
-    } else {
-        SparkTheme.shapes.small
-    }
+    val shape = ChipTokens.shape
     Surface(
         onClick = onClick,
         modifier = modifier
@@ -168,11 +163,7 @@ private fun SparkChipSelectable(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable () -> Unit,
 ) {
-    val shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-        SparkTheme.shapes.large
-    } else {
-        SparkTheme.shapes.small
-    }
+    val shape = ChipTokens.shape
     Surface(
         onClick = onClick,
         modifier = modifier
@@ -508,11 +499,7 @@ private fun ChipContent(
         LocalContentColor provides contentColor,
         LocalTextStyle provides SparkTheme.typography.body2,
     ) {
-        val shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            SparkTheme.shapes.large
-        } else {
-            SparkTheme.shapes.small
-        }
+        val shape = ChipTokens.shape
         Layout(
             modifier = Modifier
                 .ifTrue(style == ChipStyles.Dashed) {
@@ -540,11 +527,7 @@ private fun ChipContent(
                     )
                 }
                 if (label != null) {
-                    val spacing = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-                        8.dp
-                    } else {
-                        4.dp
-                    }
+                    val spacing = ChipTokens.leadingIconSpacing
                     Row(
                         modifier = Modifier
                             .layoutId(LabelLayoutId)

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipTokens.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.chips
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.LocalSparkFeatureFlag
+import com.adevinta.spark.SparkTheme
+
+/**
+ * Component tokens for chip components. Centralises all flag-driven token resolution so that
+ * chip composables read from a single source of truth instead of inlining the flag check at
+ * every call site. When the rebranding feature flag is eventually removed, only this file changes.
+ */
+public object ChipTokens {
+
+    /**
+     * The resolved container shape for chips.
+     */
+    public val shape: Shape
+        @Composable get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
+            SparkTheme.shapes.large
+        } else {
+            SparkTheme.shapes.small
+        }
+
+    /**
+     * The resolved spacing between the leading icon and the label.
+     */
+    public val leadingIconSpacing: Dp
+        @Composable get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
+            8.dp
+        } else {
+            4.dp
+        }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.InternalSparkApi
-import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.buttons.ButtonShape
 import com.adevinta.spark.components.icons.Icon
@@ -113,18 +112,14 @@ internal fun SparkIconButton(
             },
             state = rememberTooltipState(),
         ) {
-            val shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-                ButtonShape.Pill
-            } else {
-                shape
-            }
+            val shape = IconButtonTokens.resolveShape(shape.shape)
             Surface(
                 onClick = onClick,
                 modifier = Modifier
                     .minimumTouchTargetSize()
                     .sparkUsageOverlay(),
                 enabled = enabled,
-                shape = shape.shape,
+                shape = shape,
                 color = colors.containerColor(enabled = enabled).value,
                 contentColor = colors.contentColor(enabled).value,
                 border = border,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonTokens.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.iconbuttons
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Shape
+import com.adevinta.spark.LocalSparkFeatureFlag
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.buttons.ButtonShape
+
+/**
+ * Component tokens for icon button components. Centralises all flag-driven token resolution so that
+ * icon button composables read from a single source of truth instead of inlining the flag check at
+ * every call site. When the rebranding feature flag is eventually removed, only this file changes.
+ *
+ * Because icon button composables accept a caller-supplied [Shape] parameter as the legacy fallback,
+ * tokens are expressed as `resolveShape` functions rather than plain properties.
+ */
+public object IconButtonTokens {
+
+    /**
+     * Resolves the container shape for icon buttons that use [ButtonShape.Pill] when rebranded.
+     * Falls back to [fallback] when rebranding is inactive.
+     */
+    @Composable
+    public fun resolveShape(fallback: Shape): Shape =
+        if (LocalSparkFeatureFlag.current.useRebrandedShapes) ButtonShape.Pill.shape else fallback
+
+    /**
+     * Resolves the container shape for icon buttons that use [SparkTheme.shapes.full] when rebranded.
+     * Falls back to [fallback] when rebranding is inactive.
+     */
+    @Composable
+    public fun resolveFullShape(fallback: Shape): Shape =
+        if (LocalSparkFeatureFlag.current.useRebrandedShapes) SparkTheme.shapes.full else fallback
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButton.kt
@@ -42,13 +42,13 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.InternalSparkApi
-import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.buttons.ButtonShape
 import com.adevinta.spark.components.iconbuttons.IconButtonColors
 import com.adevinta.spark.components.iconbuttons.IconButtonDefaults
 import com.adevinta.spark.components.iconbuttons.IconButtonIntent
 import com.adevinta.spark.components.iconbuttons.IconButtonSize
+import com.adevinta.spark.components.iconbuttons.IconButtonTokens
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.popover.PlainTooltip
 import com.adevinta.spark.components.popover.TooltipBox
@@ -118,11 +118,7 @@ internal fun SparkIconToggleButton(
                 positioning = TooltipAnchorPosition.Above,
             ),
         ) {
-            val shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-                ButtonShape.Pill
-            } else {
-                shape
-            }
+            val shape = IconButtonTokens.resolveShape(shape.shape)
             Surface(
                 checked = checked,
                 onCheckedChange = onCheckedChange,
@@ -131,7 +127,7 @@ internal fun SparkIconToggleButton(
                     .sparkUsageOverlay()
                     .semantics { role = Role.Checkbox },
                 enabled = enabled,
-                shape = shape.shape,
+                shape = shape,
                 border = border,
                 color = colors.containerColor(enabled).value,
                 contentColor = colors.contentColor(enabled).value,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
@@ -35,8 +35,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import com.adevinta.spark.ExperimentalSparkApi
-import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.iconbuttons.IconButtonTokens
 import androidx.compose.material3.FilledIconButton as MaterialFilledIconButton
 import androidx.compose.material3.FilledTonalIconButton as MaterialFilledTonalIconButton
 import androidx.compose.material3.IconButton as MaterialIconButton
@@ -126,11 +126,7 @@ public fun FilledIconButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable () -> Unit,
 ) {
-    val shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-        SparkTheme.shapes.full
-    } else {
-        shape
-    }
+    val shape = IconButtonTokens.resolveFullShape(shape)
     MaterialFilledIconButton(
         onClick = onClick,
         modifier = modifier,
@@ -187,11 +183,7 @@ public fun FilledTonalIconButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable () -> Unit,
 ) {
-    val shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-        SparkTheme.shapes.full
-    } else {
-        shape
-    }
+    val shape = IconButtonTokens.resolveFullShape(shape)
     MaterialFilledTonalIconButton(
         onClick = onClick,
         modifier = modifier,
@@ -251,11 +243,7 @@ public fun OutlinedIconButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable () -> Unit,
 ) {
-    val shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-        SparkTheme.shapes.full
-    } else {
-        shape
-    }
+    val shape = IconButtonTokens.resolveFullShape(shape)
     MaterialOutlinedIconButton(
         onClick = onClick,
         modifier = modifier,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
@@ -33,9 +33,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
-import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.buttons.ButtonShape
+import com.adevinta.spark.components.iconbuttons.IconButtonTokens
 import com.adevinta.spark.tokens.contentColorFor
 import androidx.compose.material3.FilledIconToggleButton as MaterialFilledIconToggleButton
 import androidx.compose.material3.FilledTonalIconToggleButton as MaterialFilledTonalIconToggleButton
@@ -130,11 +130,7 @@ public fun FilledIconToggleButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable () -> Unit,
 ) {
-    val shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-        SparkTheme.shapes.full
-    } else {
-        shape
-    }
+    val shape = IconButtonTokens.resolveFullShape(shape)
     MaterialFilledIconToggleButton(
         checked = checked,
         onCheckedChange = onCheckedChange,
@@ -194,17 +190,13 @@ public fun FilledTonalIconToggleButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable () -> Unit,
 ) {
-    val shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-        ButtonShape.Pill
-    } else {
-        shape
-    }
+    val resolvedShape = IconButtonTokens.resolveShape(shape.shape)
     MaterialFilledTonalIconToggleButton(
         checked = checked,
         onCheckedChange = onCheckedChange,
         modifier = modifier,
         enabled = enabled,
-        shape = shape.shape,
+        shape = resolvedShape,
         colors = colors,
         interactionSource = interactionSource,
         content = content,
@@ -254,11 +246,7 @@ public fun OutlinedIconToggleButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable () -> Unit,
 ) {
-    val shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-        SparkTheme.shapes.full
-    } else {
-        shape
-    }
+    val shape = IconButtonTokens.resolveFullShape(shape)
     MaterialOutlinedIconToggleButton(
         checked = checked,
         onCheckedChange = onCheckedChange,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.InternalSparkApi
-import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.chips.ChipDefaults.LeadingIconEndSpacing
@@ -82,11 +81,7 @@ internal fun BaseSparkTag(
     modifier: Modifier = Modifier,
     border: BorderStroke? = null,
     leadingContent: (@Composable () -> Unit)? = null,
-    shape: Shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-        SparkTheme.shapes.extraSmall
-    } else {
-        SparkTheme.shapes.full
-    },
+    shape: Shape = TagTokens.shape,
     size: TagSize = TagSize.Medium,
     content: @Composable RowScope.() -> Unit,
 ) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagTokens.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.tags
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Shape
+import com.adevinta.spark.LocalSparkFeatureFlag
+import com.adevinta.spark.SparkTheme
+
+/**
+ * Component tokens for tag components. Centralises all flag-driven token resolution so that
+ * tag composables read from a single source of truth instead of inlining the flag check at
+ * every call site. When the rebranding feature flag is eventually removed, only this file changes.
+ *
+ * Note: tag shapes are inverted relative to buttons — the legacy shape is full/pill and the
+ * rebranded shape is extraSmall (nearly square corners).
+ */
+public object TagTokens {
+
+    /**
+     * The resolved container shape for tags.
+     */
+    public val shape: Shape
+        @Composable get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
+            SparkTheme.shapes.extraSmall
+        } else {
+            SparkTheme.shapes.full
+        }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextField.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextField.kt
@@ -82,7 +82,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.InternalSparkApi
-import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.R
 import com.adevinta.spark.SparkTheme
@@ -117,11 +116,7 @@ internal fun SparkTextField(
     maxLines: Int,
     minLines: Int,
     modifier: Modifier = Modifier,
-    shape: Shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-        SparkTheme.shapes.full
-    } else {
-        SparkTheme.shapes.large
-    },
+    shape: Shape = TextFieldTokens.shape,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     val colors = sparkOutlinedTextFieldColors()
@@ -227,11 +222,7 @@ internal fun SparkTextField(
     maxLines: Int,
     minLines: Int,
     modifier: Modifier = Modifier,
-    shape: Shape = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-        SparkTheme.shapes.full
-    } else {
-        SparkTheme.shapes.large
-    },
+    shape: Shape = TextFieldTokens.shape,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     val colors = sparkOutlinedTextFieldColors()

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/TextFieldTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/TextFieldTokens.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.textfields
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Shape
+import com.adevinta.spark.LocalSparkFeatureFlag
+import com.adevinta.spark.SparkTheme
+
+/**
+ * Component tokens for text field components. Centralises all flag-driven token resolution so that
+ * text field composables read from a single source of truth instead of inlining the flag check at
+ * every call site. When the rebranding feature flag is eventually removed, only this file changes.
+ */
+public object TextFieldTokens {
+
+    /**
+     * The resolved container shape for text fields.
+     */
+    public val shape: Shape
+        @Composable get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
+            SparkTheme.shapes.full
+        } else {
+            SparkTheme.shapes.large
+        }
+}


### PR DESCRIPTION
## 📋 Changes

Introduce a component token layer that centralises all `useRebrandedShapes` flag-driven shape (and spacing) resolution. Previously every composable contained an inline `if (LocalSparkFeatureFlag.current.useRebrandedShapes)` check. These are now collected into five dedicated public objects:

| Token object | Package | Tokens |
|---|---|---|
| `ButtonTokens` | `components.buttons` | `shape: Shape`, `buttonShape: ButtonShape` |
| `ChipTokens` | `components.chips` | `shape: Shape`, `leadingIconSpacing: Dp` |
| `TagTokens` | `components.tags` | `shape: Shape` |
| `TextFieldTokens` | `components.textfields` | `shape: Shape` |
| `IconButtonTokens` | `components.iconbuttons` | `resolveShape(fallback)`, `resolveFullShape(fallback)` |

`IconButtonTokens` exposes functions rather than properties because icon button composables accept a caller-supplied shape as the legacy fallback — the token cannot encode it as a constant.

No behaviour change. All objects are `public` so consumers can reference resolved values directly without coupling to the feature flag.

## 🤔 Context

As the rebranding rolls out, the `useRebrandedShapes` flag check is duplicated across every button variant, chip, tag, text field, and icon button composable. When the flag is eventually removed, every one of those sites would need editing.

Collecting the resolution logic into token objects means:
- The flag is referenced in exactly one place per component family
- Removing the flag later is a single-file change per token object
- Consumers building custom layouts can read `ButtonTokens.shape` instead of reimplementing the flag check themselves

This is the **initial foundation** of the component token layer — not yet generalised to all components; further migrations will follow in separate PRs.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.

## 📸 Screenshots

No visual change — pure refactor.

## 🗒️ Other info

Files updated: `ButtonFilled`, `ButtonTinted`, `ButtonGhost`, `ButtonOutlined`, `ButtonContrast`, `Chip`, `Tag`, `SparkTextField`, `iconbuttons/IconButton`, `iconbuttons/toggle/IconToggleButton`, `icons/IconButton`, `icons/IconToggleButton`.
