### PR TITLE
docs(spark): add documentation screenshots infrastructure and component guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+> For step-by-step migration code covering each breaking change, see [UPGRADING.md](UPGRADING.md).
+
 <!-- Don't forget to update links at the end of this page! -->
 
 ## [Unreleased]
@@ -46,7 +48,7 @@ _2026-03-12_
 #### 💄 Buttons and Tags have new shapes!
 
 The **buttons** now have a full rounded shape and the **tags** use `SparkTheme.shapes.extraSmall`.
-This chanmge can be toggled via the `SparkFeatureFlag.useNewButtonAndTagsShapes` feature flag.
+This change can be toggled via the `SparkFeatureFlag.useNewButtonAndTagsShapes` feature flag (renamed to `useRebrandedShapes` in a subsequent release).
 
 #### 🆕 New Card specs
 
@@ -54,12 +56,12 @@ Card is now defined by clear variants discoverable on the `Card` object. Use `Ca
 
 #### 🆕 Component Generator Script
 
-We now have a helper script to simplify the creation of a new components. To use it invoki it like this `./scripts/generate-component.main.kts [component-name] [package-name] [-v Variant1] [-v Variant2]`
+We now have a helper script to simplify the creation of a new components. To use it invoke it like this `./scripts/generate-component.main.kts [component-name] [package-name] [-v Variant1] [-v Variant2]`
 
 ### 📝 Documentation
 
-We're testing newways to better represent the components in our [documentation](https://leboncoin.github.io/spark-android/) by including dedicated screenshots generated from screenshot tests to ensure that you always get the up to date visuals.
-We're also tesing including these new screenshots in the kdoc direclty.
+We're testing new ways to better represent the components in our [documentation](https://leboncoin.github.io/spark-android/) by including dedicated screenshots generated from screenshot tests to ensure that you always get the up to date visuals.
+We're also testing including these new screenshots in the kdoc directly.
 
 ## [2.1.0-alpha01]
 
@@ -70,7 +72,7 @@ _2026-03-11_
 #### 💄 Buttons and Tags have new shapes!
 
 The **buttons** now have a full rounded shape and the **tags** use `SparkTheme.shapes.extraSmall`.
-This chanmge can be toggled via the `SparkFeatureFlag.useNewButtonAndTagsShapes` feature flag.
+This change can be toggled via the `SparkFeatureFlag.useNewButtonAndTagsShapes` feature flag (renamed to `useRebrandedShapes` in a subsequent release).
 
 #### 🆕 New Card specs
 
@@ -78,7 +80,7 @@ Card is now defined by clear variants discoverable on the `Card` object. Use `Ca
 
 #### 🆕 Component Generator Script
 
-We now have a helper script to simplify the creation of a new components. To use it invoki it like this `./scripts/generate-component.main.kts [component-name] [package-name] [-v Variant1] [-v Variant2]`
+We now have a helper script to simplify the creation of a new components. To use it invoke it like this `./scripts/generate-component.main.kts [component-name] [package-name] [-v Variant1] [-v Variant2]`
 
 ## [2.0.1]
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,73 @@ dependencies {
 }
 ```
 
+## Usage
+
+### Applying the theme
+
+Wrap your content in `SparkTheme`. Any Spark composable used outside it throws a runtime error.
+
+```kotlin
+SparkTheme {
+    // Your composable hierarchy
+}
+```
+
+### Custom colour palette
+
+Pass `lightSparkColors` and `darkSparkColors` to override the default palette. Supply only the tokens you want to change; the rest fall back to Spark defaults.
+
+```kotlin
+val myLightColors = lightSparkColors(
+    accent = Color(0xFF6200EE),
+    onAccent = Color.White,
+)
+val myDarkColors = darkSparkColors(
+    accent = Color(0xFFBB86FC),
+    onAccent = Color.Black,
+)
+
+SparkTheme(
+    colors = if (isSystemInDarkTheme()) myDarkColors else myLightColors,
+) {
+    // content
+}
+```
+
+### Feature flags
+
+`SparkFeatureFlag` gates opt-in behaviour such as rebranded shapes and development highlighters. Construct it once and pass it to `SparkTheme`.
+
+```kotlin
+SparkTheme(
+    colors = myColors,
+    sparkFeatureFlag = SparkFeatureFlag(
+        useRebrandedShapes = true,
+        isContainingActivityEdgeToEdge = true,
+    ),
+) {
+    // content
+}
+```
+
+### Icons module
+
+The `spark-icons` artifact ships separately from the core module. Add both in the same BoM block:
+
+```kotlin
+dependencies {
+    implementation(platform("com.adevinta.spark:spark-bom:<version>"))
+    implementation("com.adevinta.spark:spark")
+    implementation("com.adevinta.spark:spark-icons")
+}
+```
+
+### API reference
+
+Full KDoc is published at [adevinta.github.io/spark-android](https://adevinta.github.io/spark-android/).
+
+---
+
 ## Contributing
 
 Please take a look at the [contribution guide](docs/CONTRIBUTING.md) to setup your dev environment and get a list of common tasks used in this project, as well as the [Code of conduct](docs/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ find
 the design specifications and technical information for supported platforms by Adevinta on
 [spark.adevinta.com](https://spark.adevinta.com).
 
-The demo app is not currently available, but we plan to publish it in the near future.
+Build and install the catalog app locally to browse all components:
+
+```bash
+./gradlew :catalog:installDebug
+```
 
 ## 🚀 Getting Started
 

--- a/README.md
+++ b/README.md
@@ -113,11 +113,20 @@ dependencies {
 }
 ```
 
+### Theming and tokens
+
+A full guide to the colour intent system, custom palettes, shape and typography tokens, and
+`SparkFeatureFlag` is in [docs/theming.md](docs/theming.md).
+
 ### API reference
 
 Full KDoc is published at [adevinta.github.io/spark-android](https://adevinta.github.io/spark-android/).
 
 ---
+
+## Upgrading
+
+See [UPGRADING.md](UPGRADING.md) for migration guides when updating across breaking versions.
 
 ## Contributing
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,38 +2,6 @@
 
 Migration guides for breaking changes, newest first. For a full list of changes see [CHANGELOG.md](CHANGELOG.md).
 
----
-
-## Upgrading to 3.0 (unreleased)
-
-### `Basic` intent removed across all components
-
-> **Status: in progress** - `Basic` entries currently compile with `DeprecationLevel.ERROR`. A follow-up release will delete them entirely.
-
-`Basic` was identical in value to `Support` and has been removed from the rebranding. The IDE provides an automatic quick-fix via `ReplaceWith`.
-
-Affected intent enums: `ButtonIntent`, `BadgeIntent`, `ChipIntent`, `TagIntent`, `ToggleIntent`, and any other intent enum in the `spark` module.
-
-**Before:**
-
-```kotlin
-ButtonFilled(intent = ButtonIntent.Basic)
-Chip(intent = ChipIntent.Basic)
-Tag(intent = TagIntent.Basic)
-```
-
-**After:**
-
-```kotlin
-ButtonFilled(intent = ButtonIntent.Support)
-Chip(intent = ChipIntent.Support)
-Tag(intent = TagIntent.Support)
-```
-
-Apply all instances at once: in Android Studio, place the cursor on any red `Basic` reference and choose **Replace with 'Support'**, or run **Code > Inspect Code** to batch-apply all `ReplaceWith` suggestions.
-
----
-
 ## Upgrading to 2.0
 
 ### Snackbar API redesigned
@@ -190,7 +158,7 @@ Material3 1.3 introduces its own compile-level and visual breaking changes. Veri
 
 ## Upgrading to 0.11
 
-### Snackbar API introduced (first migration step toward 2.0)
+### Snackbar API introduced
 
 `SnackbarColors` and all per-color Snackbar overrides were deprecated at `DeprecationLevel.ERROR` in 0.11. Migrate to `SnackbarStyle` and `SnackbarIntent` here before upgrading to 2.0, where `SnackbarStyle` itself is removed.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,244 @@
+# Upgrading Spark Android
+
+Migration guides for breaking changes, newest first. For a full list of changes see [CHANGELOG.md](CHANGELOG.md).
+
+---
+
+## Upgrading to 3.0 (unreleased)
+
+### `Basic` intent removed across all components
+
+> **Status: in progress** - `Basic` entries currently compile with `DeprecationLevel.ERROR`. A follow-up release will delete them entirely.
+
+`Basic` was identical in value to `Support` and has been removed from the rebranding. The IDE provides an automatic quick-fix via `ReplaceWith`.
+
+Affected intent enums: `ButtonIntent`, `BadgeIntent`, `ChipIntent`, `TagIntent`, `ToggleIntent`, and any other intent enum in the `spark` module.
+
+**Before:**
+
+```kotlin
+ButtonFilled(intent = ButtonIntent.Basic)
+Chip(intent = ChipIntent.Basic)
+Tag(intent = TagIntent.Basic)
+```
+
+**After:**
+
+```kotlin
+ButtonFilled(intent = ButtonIntent.Support)
+Chip(intent = ChipIntent.Support)
+Tag(intent = TagIntent.Support)
+```
+
+Apply all instances at once: in Android Studio, place the cursor on any red `Basic` reference and choose **Replace with 'Support'**, or run **Code > Inspect Code** to batch-apply all `ReplaceWith` suggestions.
+
+---
+
+## Upgrading to 2.0
+
+### Snackbar API redesigned
+
+The Snackbar visual style was consolidated: `SnackbarStyle` (`Filled`/`Tinted`) is removed, the `actionOnNewLine` parameter is removed, and `SnackbarIntent` is reduced from 10 values to 4 (`Success`, `Alert`, `Error`, `Info`). Removed intents: `Neutral`, `Main`, `Basic`, `Support`, `Accent`, `SurfaceInverse`.
+
+The default intent changed from `SnackbarIntent.Neutral` to `SnackbarIntent.Info`.
+
+#### Composable call-site
+
+**Before:**
+
+```kotlin
+Snackbar(
+    style = SnackbarStyle.Tinted,
+    intent = SnackbarIntent.Success,
+    actionLabel = "Retry",
+    actionOnNewLine = true,
+) {
+    Text("Upload complete")
+}
+```
+
+**After:**
+
+```kotlin
+Snackbar(
+    intent = SnackbarIntent.Success,
+    actionLabel = "Retry",
+    onActionClick = { /* handle */ },
+) {
+    Text("Upload complete")
+}
+```
+
+The `style` and `actionOnNewLine` parameters are removed. The action is now always placed below the message when present. Pass `onDismissClick` to show a dismiss icon.
+
+#### Optional title
+
+A new `title` parameter displays a bold heading above the message body.
+
+```kotlin
+Snackbar(
+    intent = SnackbarIntent.Error,
+    title = "Upload failed",
+    onDismissClick = { /* handle */ },
+) {
+    Text("Check your connection and try again.")
+}
+```
+
+#### `showSnackbar` / `SnackbarHostState`
+
+**Before:**
+
+```kotlin
+snackbarHostState.showSnackbar(
+    message = "Saved",
+    style = SnackbarStyle.Filled,
+    actionOnNewLine = false,
+)
+```
+
+**After:**
+
+```kotlin
+snackbarHostState.showSnackbar(
+    message = "Saved",
+    intent = SnackbarIntent.Info,
+)
+```
+
+For full control, pass a `SnackbarSparkVisuals` directly:
+
+```kotlin
+snackbarHostState.showSnackbar(
+    SnackbarSparkVisuals(
+        message = "Saved",
+        intent = SnackbarIntent.Success,
+        title = "Done",
+        withDismissAction = true,
+    )
+)
+```
+
+#### Removed intent values
+
+Replace removed `SnackbarIntent` values as follows:
+
+| Removed | Use instead |
+|---|---|
+| `Neutral` | `Info` |
+| `Main` | `Info` |
+| `Basic` | `Info` |
+| `Support` | `Info` |
+| `Accent` | `Info` |
+| `SurfaceInverse` | `Info` |
+
+---
+
+## Upgrading to 1.4
+
+### `Checkbox` and `RadioButton` `intent` parameter deprecated
+
+The `intent: ToggleIntent` parameter on `Checkbox` and `RadioButton` is deprecated. Only `Support` (default) and error styling are kept to improve visual consistency. Use the new `error: Boolean` parameter for validation state.
+
+**Before:**
+
+```kotlin
+Checkbox(
+    checked = checked,
+    onClick = { checked = !checked },
+    intent = ToggleIntent.Danger,
+)
+```
+
+**After:**
+
+```kotlin
+Checkbox(
+    checked = checked,
+    onClick = { checked = !checked },
+    error = true,
+)
+```
+
+If you were using any intent other than `Basic`/`Support` or `Danger`/`Error`, replace it with `error = false` (the default) and align your design with the Spark team.
+
+### `ToggleIntent` enum deprecated
+
+`ToggleIntent` itself is deprecated alongside the `intent` parameter. The `ToggleIntent.Basic` entry additionally carries `DeprecationLevel.ERROR` - replace it with `ToggleIntent.Support` while the enum is still accessible, then migrate away from `ToggleIntent` entirely.
+
+---
+
+## Upgrading to 1.0
+
+### Legacy and Brikke-era APIs removed
+
+All code marked deprecated in the pre-1.0 releases (originating from the Brikke design system) was deleted. This is a hard compile break.
+
+Common removals:
+
+- Deprecated `SparkIcons` aliases removed - use the current `SparkIcons.*` names.
+- `Button` small size removed - use `ButtonSize.Medium` or `ButtonSize.Large`.
+- `Divider` deprecated in 0.11 - use `HorizontalDivider`.
+- `Primary` and `Secondary` intents removed (deprecated since 0.3.1) - use `Main` and `Support`.
+- `SnackbarColors` and per-color Snackbar overrides removed (deprecated as errors in 0.11) - migrate to the `SnackbarStyle` + `SnackbarIntent` API introduced in 0.11 before upgrading to 1.0, then proceed to the 2.0 migration above.
+
+### Compose BOM upgraded to Material3 1.3 / Compose 1.7
+
+Material3 1.3 introduces its own compile-level and visual breaking changes. Verify your UI after upgrading, particularly any screens using `Scaffold`, dialogs, or bottom sheets.
+
+---
+
+## Upgrading to 0.11
+
+### Snackbar API introduced (first migration step toward 2.0)
+
+`SnackbarColors` and all per-color Snackbar overrides were deprecated at `DeprecationLevel.ERROR` in 0.11. Migrate to `SnackbarStyle` and `SnackbarIntent` here before upgrading to 2.0, where `SnackbarStyle` itself is removed.
+
+### `Divider` deprecated
+
+`Divider` is deprecated in favour of `HorizontalDivider`. The new component accepts `outline` and `outlineHigh` color tokens and an optional label slot.
+
+```kotlin
+// Before
+Divider()
+
+// After
+HorizontalDivider()
+```
+
+---
+
+## Upgrading to 0.9
+
+### `BottomSheet` API replaced
+
+The Spark fork of the alpha Material2 `BottomSheet` was replaced by the Material3 `BottomSheet`. Most of the API has changed. Consult the [M3 BottomSheet documentation](https://m3.material.io/components/bottom-sheets) alongside the Spark KDoc.
+
+> **Note:** `BottomSheet` in 0.9 accepts only M3 snackbars. Spark `Snackbar` inside a `BottomSheet` is not supported until this restriction is lifted in a later release.
+
+### Chip `Filled` style removed
+
+`ChipStyle.Filled` was removed. Use `Chip` or `ChipSelectable` and pass the appropriate style argument.
+
+---
+
+## `TextFieldState` / `FormFieldStatus` naming (all versions)
+
+> **Status: in progress** - the rename is not yet complete.
+
+Compose introduced its own `TextFieldState` class, which collides with `com.adevinta.spark.components.textfields.TextFieldState`. A `typealias FormFieldStatus = TextFieldState` was added to provide a migration path. The `@Deprecated` annotation on `TextFieldState` itself is currently commented out pending completion of the rename across the codebase.
+
+**Recommended action now:** use `FormFieldStatus` in new code to avoid the name collision with the Compose `TextFieldState`.
+
+```kotlin
+// Prefer this in new code
+var status: FormFieldStatus? = FormFieldStatus.Error
+
+TextField(
+    value = text,
+    onValueChange = { text = it },
+    state = status,
+)
+```
+
+Using `TextFieldState` directly still compiles, but risks ambiguity with `androidx.compose.foundation.text.input.TextFieldState` if both are imported.

--- a/docs/COMPONENT_CREATION_GUIDE.md
+++ b/docs/COMPONENT_CREATION_GUIDE.md
@@ -1,0 +1,566 @@
+# Component Development Standards
+
+This document establishes the architectural patterns, implementation standards, and contribution
+workflows for extending the Spark Design System. These guidelines ensure consistency,
+maintainability, and adherence to established design system principles across all component
+implementations.
+
+> [!NOTE]
+> **See also:** [`CONTRIBUTING.md`](./CONTRIBUTING.md) — covers environment setup, the PR workflow, feature flags, the release process, and how to get support. This guide focuses on the technical standards; refer to `CONTRIBUTING.md` for the contribution process.
+
+## Overview
+
+The Spark Design System follows a layered architecture approach, similar to Material Design and
+other enterprise design systems, where components are built as composable abstractions over
+foundational design tokens. This guide codifies the standards for contributing to this system.
+
+## 🧩 Component Architecture
+
+### 📁 Component Module Organization
+
+Each component in the Spark Design System follows a standardized module structure that promotes
+separation of concerns and maintainability. This pattern is consistent with industry best practices
+from systems like Material Design Components and Ant Design.
+
+#### 📄 Standard File Structure
+
+```text/plain
+spark/src/main/kotlin/com/adevinta/spark/components/{component-name}/
+├── Component.kt                 # Public API surface
+├── ComponentDefaults.kt         # Design token mappings and default values
+├── ComponentIntent.kt           # Semantic color variants
+├── ComponentSize.kt            # Size specifications
+├── ComponentState.kt           # Behavioral state management
+└── Component.md                # API documentation and usage guidelines
+```
+
+This structure ensures:
+
+- **Clear API boundaries** between public and internal implementations
+- **Centralized design token management** through defaults
+- **Semantic abstraction** of visual properties through intents
+- **Consistent sizing systems** across components
+- **Self-documenting** code organization
+
+#### Reference Implementation: Button Component
+
+The Button component exemplifies this structure:
+
+- `Button.kt` - Composable API surface with five style variants
+- `ButtonDefaults.kt` - Color mappings, elevation tokens, and shape definitions
+- `ButtonIntent.kt` - Semantic color intentions (Basic, Main, Support, etc.)
+- `ButtonSize.kt` - Standardized sizing scale (Small, Medium, Large)
+- `ButtonShape.kt` - Shape abstractions (Square, Rounded, Pill)
+- `Buttons.md` - Component documentation with usage examples
+
+### API Design Principles
+
+Component APIs in the Spark Design System follow established conventions from the Compose ecosystem
+and enterprise design systems. These patterns ensure predictable developer experience and consistent
+behavior across all components.
+
+#### Parameter Ordering Convention
+
+All component APIs must adhere to the following parameter ordering, which aligns with Material
+Design Components and Jetpack Compose standards:
+
+```kotlin
+@Composable
+public fun ComponentName(
+    // 1. Required behavioral parameters
+    onClick: () -> Unit,
+    
+    // 2. Standard Compose parameters
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    
+    // 3. Design system parameters (semantic abstractions)
+    intent: ComponentIntent = ComponentIntent.Support,
+    size: ComponentSize = ComponentSize.Medium,
+    
+    // 4. Advanced behavioral parameters
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+
+    // 5. Content slots (always last)
+    content: @Composable () -> Unit,
+)
+```
+
+This ordering provides:
+
+- **Immediate API clarity** for required vs. optional parameters
+- **Consistent learning curve** across all system components
+- **Optimal auto-completion** experience in IDEs
+- **Backward compatibility** for parameter additions
+
+#### Layered Implementation Architecture
+
+Components implement a two-layer architecture separating public APIs from internal implementations:
+
+```kotlin
+// Public API Layer - Semantic abstractions
+@Composable
+public fun ComponentName(
+    intent: ComponentIntent = ComponentIntent.Support,
+    size: ComponentSize = ComponentSize.Medium,
+    // ... other semantic parameters
+) {
+    val colors = ComponentDefaults.colors(intent)
+    val dimensions = ComponentDefaults.dimensions(size)
+    
+    SparkComponent(
+        colors = colors,
+        dimensions = dimensions,
+        // ... mapped parameters
+    )
+}
+
+// Internal Implementation Layer - Design token integration
+@InternalSparkApi
+@Composable
+internal fun SparkComponent(
+    colors: ComponentColors,
+    dimensions: ComponentDimensions,
+    // ... resolved design tokens
+) {
+    // Material3 integration with Spark theming
+}
+```
+
+#### API Stability Annotations
+
+Component APIs utilize Kotlin's opt-in requirement annotations to communicate stability guarantees:
+
+- **`@InternalSparkApi`** - Internal implementations not intended for external consumption
+- **`@ExperimentalSparkApi`** - Public APIs under active development with potential breaking changes
+- **Unmarked** - Stable public APIs with semantic versioning guarantees
+
+This annotation strategy allows for iterative component development while maintaining clear
+stability contracts for consumers.
+
+### Testing Strategy
+
+The Spark Design System employs a comprehensive testing strategy that ensures visual consistency,
+behavioral correctness, and accessibility compliance. This multi-layered approach is essential for
+maintaining quality at scale in design systems. 🛡️
+
+#### 📸 Visual Regression Testing (Mandatory)
+
+Visual regression testing using Paparazzi prevents unintended visual changes and ensures consistent
+rendering across devices. This approach is standard practice in common compose design systems.
+
+```kotlin
+// spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/{component}/
+class ComponentScreenshot {
+    @get:Rule
+    val paparazzi = paparazziRule(
+        deviceConfig = DefaultTestDevices.Tablet,
+        renderingMode = RenderingMode.SHRINK,
+    )
+
+    @Test
+    fun componentVariants() {
+        paparazzi.sparkSnapshot {
+            ComponentShowcase()
+        }
+    }
+    
+    @Test
+    fun componentStates() {
+        paparazzi.sparkSnapshotNightMode {
+            ComponentStateShowcase()
+        }
+    }
+}
+```
+
+**Coverage Requirements:**
+
+- All visual variants (intents, sizes, shapes)
+- Interactive states (default, hover, pressed, disabled)
+- Theme variations (light/dark mode)
+- Edge cases (empty content, overflow scenarios)
+
+#### ♿ Accessibility Testing (Required for Interactive Components)
+
+Accessibility tests ensure components
+meet [RAAM](https://accessibilite.public.lu/fr/raam1.1/index.html) guidelines and integrate properly
+with assistive technologies. 🌐
+
+```kotlin
+@Test
+fun `Stepper semantics suffix`() {
+    val minRange = 0
+    val maxRange = 10
+    val step = 2
+    val initialValue = 4
+    val stepperTestTag = "myStepper"
+
+    composeTestRule.setContent {
+        PreviewTheme {
+            var value by remember { mutableIntStateOf(initialValue) }
+            Stepper(
+                value = value,
+                onValueChange = { value = it },
+                modifier = Modifier.testTag(stepperTestTag),
+                range = minRange..maxRange,
+                step = step,
+                suffix = " €",
+                testTag = stepperTestTag,
+            )
+        }
+    }
+    // Verify that the suffix is read by accessibility services
+    composeTestRule.onNodeWithTag(stepperTestTag)
+        .assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "4 €"),
+        )
+}
+```
+
+#### Behavioral Testing (Optional)
+
+Unit tests verify component behavior, state management, and callback handling. These tests ensure
+components integrate correctly with the Compose runtime that can't be tested with snapshots.
+
+```kotlin
+// spark/src/test/kotlin/com/adevinta/spark/{component}/
+class ComponentTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `component responds to user interactions correctly`() {
+        var clicked = false
+        
+        composeTestRule.setContent {
+            ComponentName(onClick = { clicked = true })
+        }
+        
+        composeTestRule.onNode(hasClickAction())
+            .performClick()
+            
+        assertTrue(clicked)
+    }
+    
+    @Test
+    fun `component reflects state changes`() {
+        // Test state management and recomposition behavior
+    }
+}
+```
+
+### 📚 Documentation Standards
+
+Documentation is critical for adoption and serves as the interface between the system and its
+consumers. Spark follows documentation patterns established by successful enterprise design systems
+by publishing technical documentation, functional documentaion and a test application.
+
+#### 📖 Component Documentation Structure
+
+Each component requires structured documentation that balances comprehensive reference material with
+practical usage guidance:
+
+```markdown
+# Package com.adevinta.spark.components.{component}
+
+[Component Name](https://spark.adevinta.com/guidelines/component-path) serves as [primary purpose] in [context of use]. This component implements [relevant design principles] and provides [key benefits].
+
+## When to Use
+- [Primary use case]
+- [Secondary use case]
+- [Edge case consideration]
+
+## API Overview
+
+```kotlin
+@Composable
+fun ComponentName(
+    required: RequiredType,
+    modifier: Modifier = Modifier,
+    intent: ComponentIntent = ComponentIntent.Support,
+    // ... other parameters
+)
+```
+
+## Variants
+
+The component supports the following semantic variants:
+
+|         | Light Theme                        | Dark Theme                        |
+|---------|------------------------------------|-----------------------------------|
+| Support | ![](screenshots/support-light.png) | ![](screenshots/support-dark.png) |
+| Main    | ![](screenshots/main-light.png)    | ![](screenshots/main-dark.png)    |
+
+// We reccomend to create screenshots test specific for documentation so that they're always up to
+date with the documention and they're not bloated by the other tests that are too exhaustive.
+
+## Usage Examples
+
+### Basic Implementation
+
+```kotlin
+ComponentName(
+    onClick = { /* Handle action */ },
+    text = "Primary action"
+)
+```
+
+### Advanced Configuration
+
+```kotlin
+ComponentName(
+    onClick = viewModel::handleAction,
+    intent = ComponentIntent.Main,
+    size = ComponentSize.Large,
+    enabled = state.isActionEnabled
+)
+```
+
+## Accessibility
+
+- [Screen reader considerations]
+- [Keyboard navigation behavior]
+- [Semantic markup details]
+
+## Design Guidelines
+
+Refer to the [official design specifications](design-system-url) for detailed visual and interaction
+guidelines.
+
+### API Documentation Standards
+
+All public APIs must include comprehensive KDoc documentation following Kotlin documentation
+conventions:
+
+```kotlin
+/**
+ * [Component] provides [functional description] following [design principle].
+ *
+ * This component implements [Material Design pattern] adapted for Spark's 
+ * visual language and supports [key capabilities].
+ *
+ * @param required describing the primary data/behavior requirement
+ * @param modifier [Modifier] to be applied to the component layout
+ * @param intent [ComponentIntent] defining the semantic color treatment
+ * @param enabled Controls interactive state and visual presentation
+ * @param interactionSource [MutableInteractionSource] for observing user interactions
+ * 
+ * @sample ComponentBasicSample
+ * @sample ComponentAdvancedSample
+ */
+@Composable
+public fun ComponentName(/* parameters */) { /* implementation */ }
+```
+
+#### Documentation quality requirements
+
+- 🎯 **Functional clarity** - Clearly articulate the component's purpose and appropriate usage
+  contexts
+- 📖 **Complete API coverage** - Document all public parameters with type information and behavioral
+  implications
+- 💻 **Practical examples** - Provide working code samples for common and specific use cases
+- 🔗 **Design system integration** - Link to official design specifications and related components
+- ♿ **Accessibility guidance** - Document screen reader behavior and keyboard interaction patterns
+
+### Component Catalog App integration
+
+The Spark Design System includes a comprehensive component catalog that serves as both a development
+tool and a reference implementation showcase. 📱
+
+#### Example Implementation Requirements
+
+Each component must provide interactive examples that demonstrate core functionality and edge cases.
+These examples serve multiple purposes:
+
+- 🎓 **Developer onboarding** through working code samples showing actual usecases and how to use the
+  component
+- 🎨 **Design validation** via visual component showcase showing all the variants and states
+- 🔧 **Integration testing** in realistic usage contexts showing how the component can be used in a
+  real app
+
+```kotlin
+// catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/{component}/
+public val ComponentExamples: ImmutableList<Example> = persistentListOf(
+    Example(
+        id = "basic-usage",
+        name = "Basic Implementation",
+        description = "Demonstrates default component behavior with minimal configuration",
+        sourceUrl = "$SampleSourceUrl/ComponentSamples.kt",
+    ) {
+        BasicComponentExample()
+    },
+    Example(
+        id = "variant-showcase",
+        name = "Style Variants",
+        description = "Shows all available visual styles and semantic intents",
+        sourceUrl = "$SampleSourceUrl/ComponentSamples.kt",
+    ) {
+        ComponentVariantsExample()
+    },
+    Example(
+        id = "interactive-states",
+        name = "Interactive States",
+        description = "Demonstrates component behavior across different interaction states",
+        sourceUrl = "$SampleSourceUrl/ComponentSamples.kt",
+    ) {
+        ComponentInteractiveExample()
+    },
+    Example(
+        id = "specific-usecase",
+        name = "Specific Usecase",
+        description = "Demonstrates a specific usecase for the component",
+        sourceUrl = "$SampleSourceUrl/ComponentSamples.kt",
+    ) {
+        ComponentSpecificUsecaseExample()
+    },
+)
+```
+
+💡 **Tip:** If you want to plan your examples before doing the implementation you can use the
+WipIllustration component that shows an illustration with a work in progress text. 🚧
+
+#### Component registry integration
+
+Components must be registered in the central catalog system to appear in the developer showcase
+application:
+
+```kotlin
+// catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
+private val ComponentName = Component(
+    id = "component-name",
+    name = "Component Display Name",
+    description = R.string.component_description,
+    illustration = R.drawable.component_illustration, // Optional, it'll use the spark logo by default
+    guidelinesUrl = "$ComponentGuidelinesUrl/component-path",
+    docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.component/index.html",
+    sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/component/Component.kt",
+    examples = ComponentExamples,
+    configurators = listOf(ComponentConfigurator),
+)
+
+// Add to the main components list at the bottom of the file
+public val Components: List<Component> = listOf(
+    // ... existing components
+    ComponentName,
+).sortedBy { it.name }
+```
+
+#### Interactive configuration support aka the Configurator 😈
+
+For components with multiple configuration options, provide interactive configurators that allow
+real-time parameter adjustment:
+
+```kotlin
+// catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/{component}/
+public val ComponentConfigurator = Configurator(
+    id = "component-configurator",
+    name = "Component Configuration",
+    description = "Interactive component customization",
+    sourceUrl = "$ConfiguratorSourceUrl/ComponentConfigurator.kt",
+) {
+    ConfiguratorComponentExample()
+}
+
+// If you need to add more configurators you can add them to the list
+public val ComponentConfigurators: List<Configurator> = listOf(
+    ComponentConfigurator,
+    // ... other configurators
+)
+```
+
+### Code quality and standards enforcement
+
+The Spark Design System enforces consistent code quality through automated tooling and custom lint
+rules. This approach ensures maintainability and consistency across all component implementations.
+🔧
+
+#### 📏 Custom Lint Rules
+
+The system includes custom Android Lint rules that enforce design system best practices:
+
+**Material Component Usage Detection**
+
+```kotlin
+// ❌ Prohibited - Direct Material3 usage in public APIs
+@Composable
+fun MyButton() {
+    Button(onClick = {}) { Text("Click me") }
+}
+
+// ✅ Correct - Spark component usage
+@Composable
+fun MyButton() {
+    ButtonFilled(onClick = {}, text = "Click me")
+}
+```
+
+**API Consistency Enforcement**
+
+- Component naming must follow established patterns (`ComponentFilled`, `ComponentOutlined`,
+  `ComponentGhost`) to make varaition/styles easier to discover
+- Import statements must reference Spark packages (`com.adevinta.spark.*`)
+
+#### 🎨 Automated code formatting
+
+Code formatting is enforced through Spotless with KtLint integration:
+
+```bash
+# Apply formatting automatically
+./gradlew spotlessApply
+
+# Verify formatting compliance
+./gradlew spotlessCheck
+```
+
+or run it directly from your IDE with the provided run configuration.
+
+#### Architectural compliance
+
+All components must adhere to the established architectural patterns:
+
+**Parameter Ordering**
+
+1. Required behavioral parameters
+2. Standard Compose parameters (`modifier`, `enabled`)
+3. Design system semantic parameters (`intent`, `size`)
+4. Advanced behavioral parameters (`interactionSource`)
+5. Content slots (always last)
+
+**API Stability Annotations**
+
+- 🔒 Use `@InternalSparkApi` for internal implementations (not intended for external consumption
+  unless it's needed for very specific usecase that would result in dramatic breaking changes)
+- 🧪 Use `@ExperimentalSparkApi` for unstable public APIs
+- ✅ Leave stable public APIs unmarked
+
+## Contribution Workflow
+
+### Development Process
+
+1. **Design Review** - Ensure component aligns with design system principles
+2. **API Design** - Draft public API following established patterns
+3. **Implementation** - Build component following architectural guidelines
+4. **Testing** - Implement comprehensive test coverage
+5. **Documentation** - Create complete API and usage documentation
+6. **Catalog Integration** - Add interactive examples and configurators
+7. **Review Process** - Submit PR with complete implementation
+
+### Quality Gates
+
+All component contributions must pass automated quality checks:
+
+- **Visual regression tests** pass without unintended changes
+- **Lint checks** enforce architectural compliance
+- **Code formatting** meets established standards
+- **Documentation** includes comprehensive API coverage
+- **Accessibility** meets WCAG 2.1 AA guidelines
+
+### Design System Governance
+
+Component additions and modifications follow the design system governance process:
+
+- **Design approval** from design system team
+- **API review** for namings, slots or restrictive api, etc.
+- **Breaking change assessment** for existing component modifications
+- **Documentation review** for clarity and completeness

--- a/docs/COMPONENT_CREATION_GUIDE.md
+++ b/docs/COMPONENT_CREATION_GUIDE.md
@@ -24,34 +24,36 @@ from systems like Material Design Components and Ant Design.
 
 #### 📄 Standard File Structure
 
+The `generate-component.main.kts` script scaffolds this layout:
+
 ```text/plain
-spark/src/main/kotlin/com/adevinta/spark/components/{component-name}/
-├── Component.kt                 # Public API surface
-├── ComponentDefaults.kt         # Design token mappings and default values
-├── ComponentIntent.kt           # Semantic color variants
-├── ComponentSize.kt            # Size specifications
-├── ComponentState.kt           # Behavioral state management
-└── Component.md                # API documentation and usage guidelines
+spark/src/main/kotlin/com/adevinta/spark/components/{package}/
+├── Component.kt                 # Public API object with variant functions
+├── SparkComponent.kt            # @InternalSparkApi implementation
+├── ComponentDefaults.kt         # Default values, constants, helper functions
+└── Component.md                 # Component documentation
+
+spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/{package}/
+└── ComponentScreenshot.kt       # Paparazzi regression + documentation screenshots
+
+catalog/src/main/kotlin/com/adevinta/spark/catalog/
+├── configurator/samples/{package}/ComponentConfigurator.kt
+└── examples/samples/{package}/ComponentExamples.kt
 ```
 
-This structure ensures:
-
-- **Clear API boundaries** between public and internal implementations
-- **Centralized design token management** through defaults
-- **Semantic abstraction** of visual properties through intents
-- **Consistent sizing systems** across components
-- **Self-documenting** code organization
+> **Tip:** Run `kotlin scripts/generate-component.main.kts` to scaffold all seven files at once.
+> Pass `--variants Elevated Outlined` to pre-populate variant stubs.
 
 #### Reference Implementation: Button Component
 
 The Button component exemplifies this structure:
 
-- `Button.kt` - Composable API surface with five style variants
+- `Button.kt` - Public API object with `Filled`, `Outlined`, `Ghost`, `Tinted`, `Contrast` variants
 - `ButtonDefaults.kt` - Color mappings, elevation tokens, and shape definitions
-- `ButtonIntent.kt` - Semantic color intentions (Basic, Main, Support, etc.)
+- `ButtonIntent.kt` - Semantic color intentions (Main, Support, etc.)
 - `ButtonSize.kt` - Standardized sizing scale (Small, Medium, Large)
 - `ButtonShape.kt` - Shape abstractions (Square, Rounded, Pill)
-- `Buttons.md` - Component documentation with usage examples
+- `Buttons.md` - Component documentation with screenshots and usage examples
 
 ### API Design Principles
 
@@ -95,35 +97,45 @@ This ordering provides:
 
 #### Layered Implementation Architecture
 
-Components implement a two-layer architecture separating public APIs from internal implementations:
+Components implement a two-layer architecture separating public APIs from internal implementations.
+
+`Component.kt` — public API object, one function per variant:
 
 ```kotlin
-// Public API Layer - Semantic abstractions
-@Composable
-public fun ComponentName(
-    intent: ComponentIntent = ComponentIntent.Support,
-    size: ComponentSize = ComponentSize.Medium,
-    // ... other semantic parameters
-) {
-    val colors = ComponentDefaults.colors(intent)
-    val dimensions = ComponentDefaults.dimensions(size)
-    
-    SparkComponent(
-        colors = colors,
-        dimensions = dimensions,
-        // ... mapped parameters
-    )
+public object ComponentName {
+    /**
+     * ComponentName Filled variant.
+     *
+     * @param modifier the Modifier to be applied to this componentname
+     */
+    @Composable
+    public fun Filled(
+        modifier: Modifier = Modifier,
+    ) {
+        SparkComponentName(modifier = modifier)
+    }
 }
+```
 
-// Internal Implementation Layer - Design token integration
+`SparkComponent.kt` — internal implementation, annotated `@InternalSparkApi`:
+
+```kotlin
 @InternalSparkApi
 @Composable
-internal fun SparkComponent(
-    colors: ComponentColors,
-    dimensions: ComponentDimensions,
-    // ... resolved design tokens
+internal fun SparkComponentName(
+    modifier: Modifier = Modifier,
 ) {
-    // Material3 integration with Spark theming
+    Box(modifier = modifier.sparkUsageOverlay()) {
+        // TODO: Add component implementation
+    }
+}
+```
+
+`ComponentDefaults.kt` — constants, helpers, and token mappings:
+
+```kotlin
+public object ComponentNameDefaults {
+    // TODO: Add default values, helper functions, and constants
 }
 ```
 
@@ -147,39 +159,96 @@ maintaining quality at scale in design systems. 🛡️
 #### 📸 Visual Regression Testing (Mandatory)
 
 Visual regression testing using Paparazzi prevents unintended visual changes and ensures consistent
-rendering across devices. This approach is standard practice in common compose design systems.
+rendering across devices. Each component needs **two kinds** of screenshot test class, both in
+`spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/{component}/`.
+
+The generator scaffolds a single `ComponentScreenshot.kt` file containing both classes:
+
+##### Regression screenshots (`*Screenshot`)
+
+Groups all states and variants into compact grid-style tests on `PIXEL_C` with `SHRINK`. These
+are **not committed** — CI regenerates goldens automatically on every run.
 
 ```kotlin
-// spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/{component}/
-class ComponentScreenshot {
+internal class ComponentNameScreenshot {
+
     @get:Rule
     val paparazzi = paparazziRule(
-        deviceConfig = DefaultTestDevices.Tablet,
-        renderingMode = RenderingMode.SHRINK,
+        renderingMode = SHRINK,
+        deviceConfig = DeviceConfig.PIXEL_C,
     )
 
     @Test
-    fun componentVariants() {
-        paparazzi.sparkSnapshot {
-            ComponentShowcase()
+    fun componentNameVariants() = paparazzi.sparkSnapshotNightMode {
+        Column {
+            ComponentNameIntent.entries.forEach { intent ->
+                Row {
+                    ComponentName.Filled(intent = intent)
+                    ComponentName.Outlined(intent = intent)
+                }
+            }
         }
     }
-    
+
     @Test
-    fun componentStates() {
-        paparazzi.sparkSnapshotNightMode {
-            ComponentStateShowcase()
+    fun componentNameStates() = paparazzi.sparkSnapshotNightMode {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            ComponentName.Filled(enabled = true)
+            ComponentName.Filled(enabled = false)
         }
     }
 }
 ```
 
-**Coverage Requirements:**
+The template starts with a minimal stub — fill in all intents, sizes, and states as you implement
+the component.
 
-- All visual variants (intents, sizes, shapes)
-- Interactive states (default, hover, pressed, disabled)
-- Theme variations (light/dark mode)
-- Edge cases (empty content, overflow scenarios)
+##### Documentation screenshots (`*DocumentationScreenshots`)
+
+One test per variant, rendered light/dark side-by-side using `sparkDocSnapshot` on
+`DefaultTestDevices.DocPhone` (compact landscape). These **are committed** to the repo and
+referenced directly from the component's `.md` file.
+
+```kotlin
+internal class ComponentNameDocumentationScreenshots {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DefaultTestDevices.DocPhone,
+    )
+
+    @Test
+    fun componentNameFilled() = paparazzi.sparkDocSnapshot {
+        ComponentName.Filled()
+    }
+
+    @Test
+    fun componentNameOutlined() = paparazzi.sparkDocSnapshot {
+        ComponentName.Outlined()
+    }
+}
+```
+
+If a variant needs a non-default background (e.g. a contrast variant only visible on coloured
+surfaces), pass a `color` lambda:
+
+```kotlin
+@Test
+fun componentNameContrast() = paparazzi.sparkDocSnapshot(
+    color = { SparkTheme.colors.backgroundVariant },
+) {
+    ComponentName.Contrast()
+}
+```
+
+The generated filename follows Paparazzi's convention:
+`<package>_<ClassName>_<testMethodName>.png`
+
+Reference it from the `.md` file as:
+```markdown
+![](../../images/com.adevinta.spark.components.componentname_ComponentNameDocumentationScreenshots_componentNameFilled.png)
+```
 
 #### ♿ Accessibility Testing (Required for Interactive Components)
 
@@ -258,75 +327,43 @@ by publishing technical documentation, functional documentaion and a test applic
 
 #### 📖 Component Documentation Structure
 
-Each component requires structured documentation that balances comprehensive reference material with
-practical usage guidance:
+Each component's `.md` file lives alongside the source in the component package. The generator
+scaffolds this structure:
 
 ```markdown
-# Package com.adevinta.spark.components.{component}
+# Package com.adevinta.spark.components.{package}
 
-[Component Name](https://spark.adevinta.com/guidelines/component-path) serves as [primary purpose] in [context of use]. This component implements [relevant design principles] and provides [key benefits].
+[ComponentName](https://spark.adevinta.com/...) TODO: Add component description.
 
-## When to Use
-- [Primary use case]
-- [Secondary use case]
-- [Edge case consideration]
+![](../../images/com.adevinta.spark.components.{package}_{ComponentName}DocumentationScreenshots_{variantMethodName}.png)
 
-## API Overview
+The minimal usage of the component is:
 
 ```kotlin
-@Composable
-fun ComponentName(
-    required: RequiredType,
-    modifier: Modifier = Modifier,
-    intent: ComponentIntent = ComponentIntent.Support,
-    // ... other parameters
-)
+ComponentName.FirstVariant()
 ```
 
-## Variants
+#### ComponentName.FirstVariant
 
-The component supports the following semantic variants:
+![](../../images/com.adevinta.spark.components.{package}_{ComponentName}DocumentationScreenshots_{variantMethodName}.png)
 
-|         | Light Theme                        | Dark Theme                        |
-|---------|------------------------------------|-----------------------------------|
-| Support | ![](screenshots/support-light.png) | ![](screenshots/support-dark.png) |
-| Main    | ![](screenshots/main-light.png)    | ![](screenshots/main-dark.png)    |
-
-// We reccomend to create screenshots test specific for documentation so that they're always up to
-date with the documention and they're not bloated by the other tests that are too exhaustive.
-
-## Usage Examples
-
-### Basic Implementation
+TODO: Add description for FirstVariant variant.
 
 ```kotlin
-ComponentName(
-    onClick = { /* Handle action */ },
-    text = "Primary action"
-)
+ComponentName.FirstVariant()
+```
 ```
 
-### Advanced Configuration
+Each image is a side-by-side light/dark screenshot generated by `sparkDocSnapshot`.
+See [Documentation Screenshots](CONTRIBUTING.md#documentation-screenshots) for how to produce them.
 
-```kotlin
-ComponentName(
-    onClick = viewModel::handleAction,
-    intent = ComponentIntent.Main,
-    size = ComponentSize.Large,
-    enabled = state.isActionEnabled
-)
+The filename pattern is Paparazzi's standard convention:
+`<package>_<ClassName>_<testMethodName>.png`
+
+For example:
 ```
-
-## Accessibility
-
-- [Screen reader considerations]
-- [Keyboard navigation behavior]
-- [Semantic markup details]
-
-## Design Guidelines
-
-Refer to the [official design specifications](design-system-url) for detailed visual and interaction
-guidelines.
+../../images/com.adevinta.spark.components.chips_ChipDocumentationScreenshots_chipOutlined.png
+```
 
 ### API Documentation Standards
 
@@ -380,39 +417,26 @@ These examples serve multiple purposes:
   real app
 
 ```kotlin
-// catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/{component}/
-public val ComponentExamples: ImmutableList<Example> = persistentListOf(
+// catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/{package}/
+private const val ComponentNameExampleDescription = "ComponentName examples"
+private const val ComponentNameExampleSourceUrl = "$SampleSourceUrl/ComponentNameSamples.kt"
+
+public val ComponentNameExamples: ImmutableList<Example> = persistentListOf(
     Example(
-        id = "basic-usage",
-        name = "Basic Implementation",
-        description = "Demonstrates default component behavior with minimal configuration",
-        sourceUrl = "$SampleSourceUrl/ComponentSamples.kt",
+        id = "filled",
+        name = "Filled ComponentName",
+        description = ComponentNameExampleDescription,
+        sourceUrl = ComponentNameExampleSourceUrl,
     ) {
-        BasicComponentExample()
+        ComponentName.Filled()
     },
     Example(
-        id = "variant-showcase",
-        name = "Style Variants",
-        description = "Shows all available visual styles and semantic intents",
-        sourceUrl = "$SampleSourceUrl/ComponentSamples.kt",
+        id = "outlined",
+        name = "Outlined ComponentName",
+        description = ComponentNameExampleDescription,
+        sourceUrl = ComponentNameExampleSourceUrl,
     ) {
-        ComponentVariantsExample()
-    },
-    Example(
-        id = "interactive-states",
-        name = "Interactive States",
-        description = "Demonstrates component behavior across different interaction states",
-        sourceUrl = "$SampleSourceUrl/ComponentSamples.kt",
-    ) {
-        ComponentInteractiveExample()
-    },
-    Example(
-        id = "specific-usecase",
-        name = "Specific Usecase",
-        description = "Demonstrates a specific usecase for the component",
-        sourceUrl = "$SampleSourceUrl/ComponentSamples.kt",
-    ) {
-        ComponentSpecificUsecaseExample()
+        ComponentName.Outlined()
     },
 )
 ```
@@ -452,21 +476,22 @@ For components with multiple configuration options, provide interactive configur
 real-time parameter adjustment:
 
 ```kotlin
-// catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/{component}/
-public val ComponentConfigurator = Configurator(
-    id = "component-configurator",
-    name = "Component Configuration",
-    description = "Interactive component customization",
-    sourceUrl = "$ConfiguratorSourceUrl/ComponentConfigurator.kt",
-) {
-    ConfiguratorComponentExample()
-}
-
-// If you need to add more configurators you can add them to the list
-public val ComponentConfigurators: List<Configurator> = listOf(
-    ComponentConfigurator,
-    // ... other configurators
+// catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/{package}/
+public val ComponentNameConfigurator: ImmutableList<Configurator> = persistentListOf(
+    Configurator(
+        id = "componentname",
+        name = "ComponentName",
+        description = "ComponentName configuration",
+        sourceUrl = "$SampleSourceUrl/ComponentNameSamples.kt",
+    ) { _, _ ->
+        ComponentNameSample()
+    },
 )
+
+@Composable
+private fun ColumnScope.ComponentNameSample() {
+    // TODO: Add configurator implementation
+}
 ```
 
 ### Code quality and standards enforcement

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -273,6 +273,45 @@ This pattern saves disk space (Git LFS storage on [GitHub incurs costs](https://
 
 You can also add different variants like `sparkSnapshotDevices` to generate screenshots for mobile, foldable, and tablet layouts. Use `sparkSnapshotNightMode` for light and dark mode screenshots, and `sparkSnapshotHighContrast` for high contrast mode. However, high contrast mode is more commonly used for tokens rather than individual components.
 
+#### Documentation Screenshots
+
+In addition to regression screenshots, components should have **documentation screenshots** — side-by-side light/dark images embedded in the component's `.md` file. These follow Material Design's approach of showing one variant per image.
+
+Use `sparkDocSnapshot` (backed by `DefaultTestDevices.DocPhone` — a compact landscape config) and name the class `*DocumentationScreenshots`:
+
+```kotlin
+internal class ChipDocumentationScreenshots {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DefaultTestDevices.DocPhone,
+    )
+
+    @Test
+    fun chipOutlined() = paparazzi.sparkDocSnapshot {
+        ChipOutlined(text = "Outlined chip", onClick = {})
+    }
+}
+```
+
+`sparkDocSnapshot` renders the composable twice (light left, dark right) with the theme surface as background. Pass a custom `color` lambda to override the background for components that need contrast:
+
+```kotlin
+// ButtonContrast needs a darker background to be visible
+fun buttonContrast() = paparazzi.sparkDocSnapshot(color = { SparkTheme.colors.backgroundVariant }) {
+    ButtonContrast(text = "Contrast button", onClick = {})
+}
+```
+
+Reference the generated images in the component's `.md` file using the relative path:
+
+```markdown
+![](../../images/com.adevinta.spark.components.chips_ChipDocumentationScreenshots_chipOutlined.png)
+```
+
+The image filename follows Paparazzi's convention: `<package>_<ClassName>_<testMethodName>.png`. Unlike regression screenshots, **documentation screenshots should be committed** — they are referenced directly by the `.md` files and must be present in the repository.
+
 #### Running Screenshot Tests
 
 Snapshot tests will run on CI and compare them to the stored golden images. However, if you want to debug or verify your tests locally, you can run tests as usual via Android Studio for the default variant and check the output.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Once you have a compatible environment as described above, you can set up the pr
 The Spark Design System follows a standardized architecture for all components. This section walks you through creating a new component from scratch.
 
 > [!NOTE]
-> This section contains all the architectural standards and patterns you need to follow.
+> **See also:** [`COMPONENT_CREATION_GUIDE.md`](./COMPONENT_CREATION_GUIDE.md) — the detailed reference for component architecture, parameter conventions, Paparazzi test structure, and catalog integration standards. The sections below summarise the key patterns; follow the guide for the full specification.
 
 ### Component Structure
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -36,11 +36,11 @@ This guide provides instructions for contributing to Spark Android. It covers en
 
 ### Repository Access
 
-> [!NOTE] 
+> [!NOTE]
 > Leboncoin employees only
-> Please ensure you have push rights to this repository, rather than forking the repository for contributions. Follow the "Engineering Contribution" guide in the (To be defined, Android Guild or Foundation) space in Backstage to get access.
+> Please ensure you have push rights to this repository, rather than forking it. Follow the "Engineering Contribution" guide in the Android Guild space in Backstage to get access.
 
-This repository being public, you can directly contribute to it. However, we encourage you to fork the repository for your contributions to avoid conflicts when pulling as only contributors can push to the main repository.
+This repository is public. External contributors should fork it and submit pull requests from their fork. Only team members with push access may contribute directly to branches in the upstream repository.
 
 ### Knowledge Requirements
 
@@ -118,7 +118,7 @@ Once you have a compatible environment as described above, you can set up the pr
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/adevinta/spark-android.git
+   git clone https://github.com/leboncoin/spark-android.git
    cd spark-android
    ```
 
@@ -501,104 +501,54 @@ Use feature flags when:
 
 **Step 1: Define the Feature Flag**
 
-Add a new entry to the `SparkFeatureFlags` class:
+Add a new property to the `SparkFeatureFlag` data class in `spark/src/main/kotlin/com/adevinta/spark/SparkFeatureFlag.kt`:
 
 ```kotlin
-// spark/src/main/kotlin/com/adevinta/spark/SparkFeatureFlags.kt
-object SparkFeatureFlags {
-    /**
-     * Enables the new ripple animation for buttons.
-     * When enabled, buttons use Material 3 ripple effects.
-     * When disabled, buttons use the legacy ripple animation.
-     * 
-     * @default false (legacy behavior maintained)
-     */
-    var enableNewButtonRipple: Boolean = false
-    
-    /**
-     * Enables automatic content description generation for badges.
-     * When enabled, badges automatically generate accessibility descriptions.
-     * When disabled, consumers must provide explicit content descriptions.
-     * 
-     * @default true (new accessibility feature enabled by default)
-     */
-    var enableBadgeAutoContentDescription: Boolean = true
-}
+public data class SparkFeatureFlag(
+    /** Highlight visually where Spark tokens are used. Makes text cursive and colours diagnostic. */
+    val useSparkTokensHighlighter: Boolean = false,
+    /** Show an overlay on Spark components to highlight where they are used. */
+    val useSparkComponentsHighlighter: Boolean = false,
+    val isContainingActivityEdgeToEdge: Boolean = false,
+    /** Use rebranded shapes for buttons, chips, tags, and text fields. */
+    val useRebrandedShapes: Boolean = false,
+    // Add your new flag here with a conservative default
+    val myNewFlag: Boolean = false,
+)
 ```
 
 **Step 2: Use the Feature Flag in Your Component**
 
+Read the flag via `SparkTheme.featureFlag`, which is provided by `LocalSparkFeatureFlag`:
+
 ```kotlin
-// spark/src/main/kotlin/com/adevinta/spark/components/button/Button.kt
 @Composable
-public fun ButtonFilled(
-    onClick: () -> Unit,
-    text: String,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    // ... other parameters
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    
-    Button(
-        onClick = onClick,
-        modifier = modifier,
-        enabled = enabled,
-        interactionSource = interactionSource,
-        // Use feature flag to determine behavior
-        colors = if (SparkFeatureFlags.enableNewButtonRipple) {
-            ButtonDefaults.newRippleColors()
-        } else {
-            ButtonDefaults.legacyColors()
-        }
-    ) {
-        Text(text = text)
+public fun MyComponent() {
+    val featureFlag = SparkTheme.featureFlag
+    if (featureFlag.myNewFlag) {
+        // new behaviour
+    } else {
+        // existing behaviour
     }
 }
 ```
 
-**Step 3: Consumer Override Example**
+**Step 3: Pass the Flag to SparkTheme**
 
-Here's how a consumer (like the catalog app or a feature team) can override the feature flag:
+`SparkFeatureFlag` is an immutable data class passed directly to `SparkTheme`. Consumers construct it once and pass it at the theme root:
 
 ```kotlin
-...
-// Override Spark feature flags before using components
-SparkFeatureFlags.enableNewButtonRipple = true
-CompositionLocalProvider(
-    LocalSparkFeatureFlag provides SparkFeatureFlag(
-        enableNewButtonRipple = true,
+SparkTheme(
+    colors = myColors,
+    sparkFeatureFlag = SparkFeatureFlag(
+        myNewFlag = true,
     ),
 ) {
-    ButtonFilled()
-}
-...
-```
-
-**Or in a specific activity/fragment:**
-
-```kotlin
-// In a specific screen where you want to test the new behavior
-@Composable
-fun MyScreen() {
-    // Temporarily override for this screen
-    DisposableEffect(Unit) {
-        val originalRippleFlag = SparkFeatureFlags.enableNewButtonRipple
-        SparkFeatureFlags.enableNewButtonRipple = true
-        
-        onDispose {
-            // Restore original value when leaving the screen
-            SparkFeatureFlags.enableNewButtonRipple = originalRippleFlag
-        }
-    }
-    
-    // Use components normally - they'll use the overridden flag
-    ButtonFilled(
-        onClick = { /* handle click */ },
-        text = "Try New Ripple Effect"
-    )
+    // content
 }
 ```
+
+To enable a flag only for a subtree, wrap that subtree in its own `SparkTheme` call with the desired flag value.
 
 #### Best Practices
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -186,6 +186,67 @@ public fun ComponentName(
 2. Create the public api ([see](https://github.com/leboncoin/spark-android/blob/f108bfd6ce313005eb2ff9fa563345497829b5f1/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagFilled.kt#L35-L60))
 3. Create defaults either inlined in the component file or in a separate file if its already too big ([see](https://github.com/leboncoin/spark-android/blob/f108bfd6ce313005eb2ff9fa563345497829b5f1/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt#L246-L292)):
 4. Create intent and size enums ([see](https://github.com/leboncoin/spark-android/blob/f108bfd6ce313005eb2ff9fa563345497829b5f1/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagIntent.kt#L14-L19)):
+
+### Component Generator
+
+`scripts/generate-component.main.kts` scaffolds the full file structure for a new component so you don't create files manually.
+
+**Invocation**
+
+```bash
+./scripts/generate-component.main.kts
+```
+
+The script prompts for the component name and package name interactively. Pass them as flags to skip the prompts:
+
+```bash
+./scripts/generate-component.main.kts \
+  --component-name Card \
+  --package-name card \
+  -v Elevated -v Outlined
+```
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `--component-name` | Component name in PascalCase (e.g., `Card`). Prompted if omitted. |
+| `--package-name` | Package directory name in lowercase (e.g., `card`). Prompted if omitted. |
+| `-v` / `--variants` | Variant names, repeatable (e.g., `-v Elevated -v Outlined`). Omit to generate a single `Default` variant. |
+| `--dry-run` | Preview which files would be created without writing anything. |
+
+**What it generates**
+
+For a component named `Card` in package `card` with variants `Elevated` and `Outlined`, the script creates:
+
+```text
+spark/src/main/kotlin/com/adevinta/spark/components/card/
+├── Card.kt
+├── SparkCard.kt
+├── CardDefaults.kt
+└── Card.md
+
+spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/
+└── CardScreenshot.kt
+
+catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/card/
+└── CardConfigurator.kt
+
+catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/card/
+└── CardExamples.kt
+```
+
+**What you still need to do manually**
+
+The generator produces scaffolding only. After running it you must:
+
+- Fill in the component logic in `SparkCard.kt` and `Card.kt`
+- Add design token mappings in `CardDefaults.kt`
+- Create `CardIntent.kt` and `CardSize.kt` if the component needs them
+- Write the screenshot test bodies in `CardScreenshot.kt`
+- Register the component in the catalog's `Components.kt` registry
+- Replace all `TODO` placeholders in `Card.md`
+
 ---
 
 ## 🧪 Testing

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,261 @@
+# Theming and Tokens
+
+Spark exposes its design tokens through `SparkTheme.colors`, `SparkTheme.shapes`, and
+`SparkTheme.typography`. Read any token inside a composable; pass custom values to `SparkTheme` to
+override them.
+
+---
+
+## Colour intents
+
+Each intent is a semantic role, not a raw colour. Components accept an intent enum whose value
+resolves to a `SparkColors` property at runtime, so swapping palettes requires no component changes.
+
+| Intent | Property family | Use |
+|---|---|---|
+| Main | `main` / `onMain` / `mainContainer` / `onMainContainer` / `mainVariant` / `onMainVariant` | Primary brand colour, most-used surfaces |
+| Support | `support` / `onSupport` / `supportContainer` / `onSupportContainer` / `supportVariant` / `onSupportVariant` | Secondary accent, FABs, selection controls, links |
+| Accent | `accent` / `onAccent` / `accentContainer` / `onAccentContainer` / `accentVariant` / `onAccentVariant` | Tertiary highlight |
+| Success | `success` / `onSuccess` / `successContainer` / `onSuccessContainer` | Positive feedback |
+| Alert | `alert` / `onAlert` / `alertContainer` / `onAlertContainer` | Warning feedback |
+| Error | `error` / `onError` / `errorContainer` / `onErrorContainer` | Error states |
+| Info | `info` / `onInfo` / `infoContainer` / `onInfoContainer` | Informational feedback |
+| Neutral | `neutral` / `onNeutral` / `neutralContainer` / `onNeutralContainer` | Neutral / muted emphasis |
+| Surface | `surface` / `onSurface` / `surfaceInverse` / `onSurfaceInverse` / `surfaceDark` / `onSurfaceDark` | Card and sheet backgrounds |
+| Background | `background` / `onBackground` / `backgroundVariant` / `onBackgroundVariant` | Screen backgrounds |
+
+Every foreground colour is prefixed with `on` and pairs with its background counterpart. The
+`contentColorFor` function returns the correct foreground given any background colour:
+
+```kotlin
+val fg = SparkTheme.colors.contentColorFor(SparkTheme.colors.mainContainer)
+```
+
+### Reading tokens
+
+```kotlin
+@Composable
+fun BrandBadge() {
+    Box(
+        modifier = Modifier
+            .background(SparkTheme.colors.main)
+            .padding(8.dp)
+    ) {
+        Text(
+            text = "New",
+            color = SparkTheme.colors.onMain,
+            style = SparkTheme.typography.caption,
+        )
+    }
+}
+```
+
+### Dim levels
+
+`SparkColors` exposes five alpha values for de-emphasis:
+
+| Property | Alpha | Typical use |
+|---|---|---|
+| `dim1` | 0.72 | Medium-emphasis text |
+| `dim2` | 0.56 | Medium-emphasis icons |
+| `dim3` | 0.40 | Disabled components |
+| `dim4` | 0.16 | Low-visibility elements |
+| `dim5` | 0.08 | Pressed / ripple (avoid on Android) |
+
+Use the extension properties on `Color` to apply them:
+
+```kotlin
+// dim3 composited over the surface colour - safe for disabled text
+val disabledColour = SparkTheme.colors.onSurface.disabled
+
+// or apply any dim directly
+val mutedIcon = SparkTheme.colors.onBackground.dim2
+```
+
+---
+
+## Providing a custom palette
+
+Call `lightSparkColors()` or `darkSparkColors()` with only the tokens you want to override. All
+other parameters default to the Spark baseline palette.
+
+```kotlin
+val brandLight = lightSparkColors(
+    main = Color(0xFF1A6B3C),
+    onMain = Color.White,
+    mainContainer = Color(0xFFB7E4C7),
+    onMainContainer = Color(0xFF0A3D22),
+    mainVariant = Color(0xFF155230),
+    onMainVariant = Color.White,
+)
+
+val brandDark = darkSparkColors(
+    main = Color(0xFF74C69D),
+    onMain = Color(0xFF0A3D22),
+    mainContainer = Color(0xFF155230),
+    onMainContainer = Color(0xFFB7E4C7),
+    mainVariant = Color(0xFF95D5B2),
+    onMainVariant = Color(0xFF0A3D22),
+)
+
+@Composable
+fun App() {
+    SparkTheme(
+        colors = if (isSystemInDarkTheme()) brandDark else brandLight,
+    ) {
+        // content
+    }
+}
+```
+
+For high-contrast accessibility variants, use `lightHighContrastSparkColors()` and
+`darkHighContrastSparkColors()` as starting points instead.
+
+### Building from a Material 3 colour scheme
+
+If you already generate a `ColorScheme` with Material's dynamic colour or Compose theme builder,
+convert it directly:
+
+```kotlin
+val sparkColors = colorScheme.asSparkColors(useDark = isSystemInDarkTheme())
+
+SparkTheme(colors = sparkColors) { /* … */ }
+```
+
+---
+
+## Shape tokens
+
+`SparkShapes` provides seven steps from flat to fully circular.
+
+| Token | Corner radius | Default component uses |
+|---|---|---|
+| `none` | 0 dp | App bars, banners, navigation rails |
+| `extraSmall` | 4 dp | Text fields, snackbars, menus |
+| `small` | 8 dp | Chips |
+| `medium` | 12 dp | Cards, small FABs |
+| `large` | 16 dp | Extended FABs, navigation drawers |
+| `extraLarge` | 28 dp | Bottom sheets, dialogs, large FABs |
+| `full` | 50 % (circle) | Buttons, badges, sliders, switches |
+
+```kotlin
+Box(
+    modifier = Modifier
+        .clip(SparkTheme.shapes.medium)
+        .background(SparkTheme.colors.surface)
+)
+```
+
+### Custom shapes
+
+```kotlin
+SparkTheme(
+    shapes = sparkShapes(
+        medium = RoundedCornerShape(8.dp),
+        large = RoundedCornerShape(20.dp),
+    ),
+) { /* … */ }
+```
+
+### `useRebrandedShapes`
+
+`SparkFeatureFlag.useRebrandedShapes` opts in to updated corner radii for buttons, chips, tags, and
+text fields introduced during the Adevinta rebranding. Set it to `true` once your product has
+adopted the new visual identity:
+
+```kotlin
+SparkTheme(
+    colors = myColors,
+    sparkFeatureFlag = SparkFeatureFlag(useRebrandedShapes = true),
+) { /* … */ }
+```
+
+#### Component token objects
+
+Each affected component family exposes a token object that resolves the active shape (and any
+related spacing) for the current flag value. Composables consume these internally; you can read
+them to match component geometry in custom layouts or wrappers.
+
+| Object | API |
+|---|---|
+| `ButtonTokens` | `shape: Shape`, `buttonShape: ButtonShape` |
+| `ChipTokens` | `shape: Shape`, `leadingIconSpacing: Dp` |
+| `TagTokens` | `shape: Shape` |
+| `TextFieldTokens` | `shape: Shape` |
+| `IconButtonTokens` | `resolveShape(fallback: Shape): Shape`, `resolveFullShape(fallback: Shape): Shape` |
+
+All members are `@Composable` and must be read inside a composition:
+
+```kotlin
+// Match a custom overlay to the current button shape
+Box(modifier = Modifier.clip(ButtonTokens.shape)) { /* … */ }
+```
+
+`ButtonTokens`, `ChipTokens`, `TagTokens`, and `TextFieldTokens` expose plain `shape` properties. `IconButtonTokens` uses functions instead because icon button composables accept a caller-supplied shape as the legacy fallback — the token object needs that argument to resolve the correct value.
+
+---
+
+## Typography tokens
+
+`SparkTypography` covers display through legal text.
+
+| Token | Size / weight | Use |
+|---|---|---|
+| `display1` | 40 sp Bold | Short, important large text |
+| `display2` | 32 sp Bold | Short, important medium text |
+| `display3` | 24 sp Bold | Short, important small text |
+| `headline1` | 20 sp Bold | High-emphasis large heading |
+| `headline2` | 18 sp Bold | High-emphasis medium heading |
+| `subhead` | 16 sp Bold | High-emphasis small heading |
+| `body1` | 16 sp Regular | Primary body text |
+| `body2` | 14 sp Regular | Secondary body text (theme default) |
+| `caption` | 12 sp Regular | Support text, error messages |
+| `small` | 10 sp Regular | Legal text, app bar labels |
+| `callout` | 16 sp Bold | Call-to-action labels |
+
+```kotlin
+Text(
+    text = "Price",
+    style = SparkTheme.typography.headline2,
+)
+```
+
+Apply `highlight` to any style to switch its weight to Bold:
+
+```kotlin
+Text(
+    text = "Important",
+    style = SparkTheme.typography.body2.highlight,
+)
+```
+
+### Custom typography
+
+```kotlin
+val myTypography = sparkTypography(
+    display1 = TextStyle(
+        fontFamily = MyBrandFont,
+        fontSize = 40.sp,
+        fontWeight = FontWeight.Bold,
+        lineHeight = 56.sp,
+    ),
+    body2 = TextStyle(
+        fontFamily = MyBrandFont,
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Normal,
+        lineHeight = 20.sp,
+    ),
+)
+
+SparkTheme(typography = myTypography) { /* … */ }
+```
+
+Alternatively, pass a `fontFamily` parameter to `SparkTheme` directly to apply a single font
+family across all type styles without replacing each style individually:
+
+```kotlin
+SparkTheme(
+    colors = myColors,
+    fontFamily = sparkFontFamily(/* custom FontFamily */),
+) { /* … */ }
+```

--- a/scripts/generate-component.main.kts
+++ b/scripts/generate-component.main.kts
@@ -113,22 +113,13 @@ private fun buildVariantsContent(names: ComponentNames, variantList: List<String
 
 private fun buildScreenshotTable(variantList: List<String>): String {
     val placeholder = "![](../../images/...)"
+    // One sparkDocSnapshot image per variant (light + dark side by side in a single file)
     return if (variantList.isNotEmpty()) {
-        val header = variantList.joinToString(" | ") { it }
-        val separator = variantList.joinToString("|") { "---" }
-        val row = variantList.joinToString(" | ") { placeholder }
-        """
-|       | $header |
-|-------|$separator|
-| Light | $row |
-| Dark  | $row |
-""".trimIndent()
+        variantList.joinToString("\n\n") { variant ->
+            "### $variant\n\n$placeholder"
+        }
     } else {
-        """
-| Light | Dark |
-|-------|------|
-| $placeholder | $placeholder |
-""".trimIndent()
+        placeholder
     }
 }
 
@@ -137,15 +128,13 @@ private fun buildVariantsSections(componentName: String, variantList: List<Strin
         """
 #### $componentName.$variant
 
+![](../../images/...)
+
 TODO: Add description for $variant variant.
 
 ```kotlin
 $componentName.$variant()
 ```
-
-| Light | Dark |
-|-------|------|
-| ![](../../images/...) | ![](../../images/...) |
 """.trimIndent()
     }
 

--- a/scripts/templates/component/ComponentScreenshot.kt.template
+++ b/scripts/templates/component/ComponentScreenshot.kt.template
@@ -6,11 +6,16 @@ import com.adevinta.spark.DefaultTestDevices
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.$packageName.$componentName
 import com.adevinta.spark.paparazziRule
+import com.adevinta.spark.sparkDocSnapshot
 import com.adevinta.spark.sparkSnapshotNightMode
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode.SHRINK
 import com.android.ide.common.rendering.api.SessionParams.RenderingMode.V_SCROLL
 import org.junit.Rule
 import org.junit.Test
 
+/**
+ * Regression screenshots — group all states/variants in a single test for compact coverage.
+ */
 internal class $componentNameScreenshot {
 
     @get:Rule
@@ -27,4 +32,24 @@ internal class $componentNameScreenshot {
             }
         }
     }
+}
+
+/**
+ * Documentation screenshots — one test per variant, light/dark side by side.
+ * Generated images are committed and referenced from the component's .md file.
+ */
+internal class ${componentName}DocumentationScreenshots {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DefaultTestDevices.DocPhone,
+    )
+
+    // TODO: Add one @Test per variant using paparazzi.sparkDocSnapshot { ... }
+    // Example:
+    // @Test
+    // fun ${componentNameLower}Default() = paparazzi.sparkDocSnapshot {
+    //     $componentName.$firstVariant()
+    // }
 }

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziRule.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziRule.kt
@@ -106,6 +106,28 @@ object DefaultTestDevices {
         navigation = Navigation.NONAV,
         released = "December 8, 2015",
     )
+
+    /**
+     * Compact phone in landscape for documentation screenshots.
+     * Smaller than Pixel C to avoid excessive whitespace around isolated components.
+     */
+    val DocPhone = DeviceConfig(
+        screenHeight = 1080,
+        screenWidth = 1920,
+        xdpi = 420,
+        ydpi = 420,
+        orientation = ScreenOrientation.LANDSCAPE,
+        density = Density.XXHIGH,
+        ratio = ScreenRatio.LONG,
+        size = ScreenSize.NORMAL,
+        keyboard = Keyboard.NOKEY,
+        touchScreen = TouchScreen.FINGER,
+        keyboardState = KeyboardState.SOFT,
+        softButtons = true,
+        navigation = Navigation.NONAV,
+        released = "October 2023",
+    )
+
     internal val devices = listOf(Phone, Foldable, Tablet)
 }
 

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziUtils.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziUtils.kt
@@ -219,7 +219,7 @@ private fun RowScope.DocSnapshotHalf(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
-                    .heightIn(min= 160.dp)
+                    .heightIn(min = 160.dp)
                     .background(color = color),
                 contentAlignment = Alignment.Center,
             ) {

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziUtils.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziUtils.kt
@@ -25,14 +25,22 @@ import android.view.View
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.dp
 import app.cash.paparazzi.Paparazzi
 import com.adevinta.spark.tokens.SparkColors
+import com.adevinta.spark.tokens.contentColorFor
 import com.adevinta.spark.tokens.darkHighContrastSparkColors
 import com.adevinta.spark.tokens.darkSparkColors
 import com.adevinta.spark.tokens.lightHighContrastSparkColors
@@ -149,33 +157,21 @@ internal fun Paparazzi.sparkSnapshotNightMode(
  * Generate 1 screenshot with the same content side by side but one in light theme and teh other in dark theme.
  */
 internal fun Paparazzi.sparkDocSnapshot(
-    drawBackground: Boolean = true,
+    color: @Composable () -> Color = { SparkTheme.colors.background },
     composable: @Composable () -> Unit,
 ) {
-    sparkSnapshot(
-        drawBackground = drawBackground,
-    ) {
+    snapshot {
         Row {
-            Box(
-                Modifier.weight(1f),
-            ) {
-                SparkThemeContent(
-                    colors = lightSparkColors(),
-                    drawBackground = drawBackground,
-                ) {
-                    composable()
-                }
-            }
-            Box(
-                Modifier.weight(1f),
-            ) {
-                SparkThemeContent(
-                    colors = darkSparkColors(),
-                    drawBackground = drawBackground,
-                ) {
-                    composable()
-                }
-            }
+            DocSnapshotHalf(
+                colors = lightSparkColors(),
+                color = color,
+                composable = composable,
+            )
+            DocSnapshotHalf(
+                colors = darkSparkColors(),
+                color = color,
+                composable = composable,
+            )
         }
     }
 }
@@ -205,6 +201,36 @@ internal fun Paparazzi.sparkSnapshotHighContrast(
         }
     }
     exception?.let { throw it }
+}
+
+@Composable
+private fun RowScope.DocSnapshotHalf(
+    colors: SparkColors,
+    color: @Composable () -> Color = { SparkTheme.colors.background },
+    composable: @Composable () -> Unit,
+) {
+    CompositionLocalProvider(LocalInspectionMode provides true) {
+        SparkTheme(
+            colors = colors,
+            sparkFeatureFlag = SparkFeatureFlag(useRebrandedShapes = true),
+        ) {
+            val color = color()
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .heightIn(min= 160.dp)
+                    .background(color = color),
+                contentAlignment = Alignment.Center,
+            ) {
+                CompositionLocalProvider(LocalContentColor provides contentColorFor(color)) {
+                    Box(Modifier.padding(16.dp)) {
+                        composable()
+                    }
+                }
+            }
+        }
+    }
 }
 
 enum class ThemeVariant { Light, Dark }

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/buttons/ButtonDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/buttons/ButtonDocumentationScreenshots.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.buttons
+
+import com.adevinta.spark.DefaultTestDevices
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.buttons.ButtonContrast
+import com.adevinta.spark.components.buttons.ButtonFilled
+import com.adevinta.spark.components.buttons.ButtonGhost
+import com.adevinta.spark.components.buttons.ButtonOutlined
+import com.adevinta.spark.components.buttons.ButtonTinted
+import com.adevinta.spark.paparazziRule
+import com.adevinta.spark.sparkDocSnapshot
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode.SHRINK
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Documentation screenshots for Button component, following Material Design's approach of showing
+ * each variant with light and dark theme side by side.
+ */
+internal class ButtonDocumentationScreenshots {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DefaultTestDevices.DocPhone,
+    )
+
+    @Test
+    fun buttonFilled() = paparazzi.sparkDocSnapshot {
+        ButtonFilled(
+            text = "Filled button",
+            onClick = {},
+        )
+    }
+
+    @Test
+    fun buttonOutlined() = paparazzi.sparkDocSnapshot(color = { SparkTheme.colors.backgroundVariant }) {
+        ButtonOutlined(
+            text = "Outlined button",
+            onClick = {},
+        )
+    }
+
+    @Test
+    fun buttonTinted() = paparazzi.sparkDocSnapshot {
+        ButtonTinted(
+            text = "Tinted button",
+            onClick = {},
+        )
+    }
+
+    @Test
+    fun buttonGhost() = paparazzi.sparkDocSnapshot(color = { SparkTheme.colors.backgroundVariant }) {
+        ButtonGhost(
+            text = "Ghost button",
+            onClick = {},
+        )
+    }
+
+    @Test
+    fun buttonContrast() = paparazzi.sparkDocSnapshot(color = { SparkTheme.colors.backgroundVariant }) {
+        ButtonContrast(
+            text = "Contrast button",
+            onClick = {},
+        )
+    }
+}

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/badge/BadgeDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/badge/BadgeDocumentationScreenshots.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.badge
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.DefaultTestDevices
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.icons.BellFill
+import com.adevinta.spark.icons.LeboncoinIcons
+import com.adevinta.spark.paparazziRule
+import com.adevinta.spark.sparkDocSnapshot
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode.SHRINK
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Documentation screenshots for Badge component, following Material Design's approach of showing
+ * each variant with light and dark theme side by side.
+ */
+internal class BadgeDocumentationScreenshots {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DefaultTestDevices.DocPhone,
+    )
+
+    @Test
+    fun badgeCount() = paparazzi.sparkDocSnapshot {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Badge(count = 1)
+            Badge(count = 42)
+            Badge(count = 999, overflowCount = 99)
+        }
+    }
+
+    @Test
+    fun badgeDot() = paparazzi.sparkDocSnapshot {
+        Badge(content = null)
+    }
+
+    @Test
+    fun badgeOverIcon() = paparazzi.sparkDocSnapshot {
+        BadgedBox(
+            badge = { Badge(count = 5) },
+        ) {
+            Icon(
+                sparkIcon = LeboncoinIcons.BellFill,
+                contentDescription = null,
+            )
+        }
+    }
+}

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardDocumentationScreenshots.kt
@@ -54,7 +54,6 @@ internal class CardDocumentationScreenshots {
         Card.Flat {
             CardContent()
         }
-
     }
 
     @Test
@@ -106,7 +105,7 @@ private fun CardContent() {
         )
         Text(
             text = "Spark is a design system backed by open source code that helps teams build " +
-                    "high-quality digital experiences. \uD83D\uDCA4",
+                "high-quality digital experiences. \uD83D\uDCA4",
             style = SparkTheme.typography.body1,
         )
     }

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardDocumentationScreenshots.kt
@@ -22,16 +22,13 @@
 package com.adevinta.spark.components.card
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.cash.paparazzi.DeviceConfig
 import com.adevinta.spark.SparkTheme
-import com.adevinta.spark.components.surface.Surface
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.paparazziRule
 import com.adevinta.spark.sparkDocSnapshot
@@ -53,61 +50,42 @@ internal class CardDocumentationScreenshots {
     )
 
     @Test
-    fun flatCard() = paparazzi.sparkDocSnapshot {
-        Surface(color = SparkTheme.colors.backgroundVariant) {
-            Box(Modifier.padding(16.dp)) {
-                Card.Flat {
-                    CardContent()
-                }
-            }
+    fun flatCard() = paparazzi.sparkDocSnapshot(color = { SparkTheme.colors.backgroundVariant }) {
+        Card.Flat {
+            CardContent()
+        }
+
+    }
+
+    @Test
+    fun elevatedCard() = paparazzi.sparkDocSnapshot(color = { SparkTheme.colors.backgroundVariant }) {
+        Card.Elevated {
+            CardContent()
         }
     }
 
     @Test
-    fun elevatedCard() = paparazzi.sparkDocSnapshot {
-        Surface(color = SparkTheme.colors.backgroundVariant) {
-            Box(Modifier.padding(16.dp)) {
-                Card.Elevated {
-                    CardContent()
-                }
-            }
+    fun outlinedCard() = paparazzi.sparkDocSnapshot(color = { SparkTheme.colors.backgroundVariant }) {
+        Card.Outlined {
+            CardContent()
         }
     }
 
     @Test
-    fun outlinedCard() = paparazzi.sparkDocSnapshot {
-        Surface(color = SparkTheme.colors.backgroundVariant) {
-            Box(Modifier.padding(16.dp)) {
-                Card.Outlined {
-                    CardContent()
-                }
-            }
+    fun highlightFlatCard() = paparazzi.sparkDocSnapshot(color = { SparkTheme.colors.backgroundVariant }) {
+        Card.HighlightFlat(
+            heading = { },
+        ) {
+            CardContent()
         }
     }
 
     @Test
-    fun highlightFlatCard() = paparazzi.sparkDocSnapshot {
-        Surface(color = SparkTheme.colors.backgroundVariant) {
-            Box(Modifier.padding(16.dp)) {
-                Card.HighlightFlat(
-                    heading = { },
-                ) {
-                    CardContent()
-                }
-            }
-        }
-    }
-
-    @Test
-    fun highlightElevatedCard() = paparazzi.sparkDocSnapshot {
-        Surface(color = SparkTheme.colors.backgroundVariant) {
-            Box(Modifier.padding(16.dp)) {
-                Card.HighlightElevated(
-                    heading = { },
-                ) {
-                    CardContent()
-                }
-            }
+    fun highlightElevatedCard() = paparazzi.sparkDocSnapshot(color = { SparkTheme.colors.backgroundVariant }) {
+        Card.HighlightElevated(
+            heading = { },
+        ) {
+            CardContent()
         }
     }
 }
@@ -128,7 +106,7 @@ private fun CardContent() {
         )
         Text(
             text = "Spark is a design system backed by open source code that helps teams build " +
-                "high-quality digital experiences. \uD83D\uDCA4",
+                    "high-quality digital experiences. \uD83D\uDCA4",
             style = SparkTheme.typography.body1,
         )
     }

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/chips/ChipDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/chips/ChipDocumentationScreenshots.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.chips
+
+import com.adevinta.spark.DefaultTestDevices
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.icons.LeboncoinIcons
+import com.adevinta.spark.icons.TagOutline
+import com.adevinta.spark.paparazziRule
+import com.adevinta.spark.sparkDocSnapshot
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode.SHRINK
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Documentation screenshots for Chip component, following Material Design's approach of showing
+ * each variant with light and dark theme side by side.
+ */
+internal class ChipDocumentationScreenshots {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DefaultTestDevices.DocPhone,
+    )
+
+    @Test
+    fun chipOutlined() = paparazzi.sparkDocSnapshot {
+        ChipOutlined(
+            text = "Outlined chip",
+            leadingIcon = LeboncoinIcons.TagOutline,
+            onClick = {},
+        )
+    }
+
+    @Test
+    fun chipTinted() = paparazzi.sparkDocSnapshot {
+        ChipTinted(
+            text = "Tinted chip",
+            leadingIcon = LeboncoinIcons.TagOutline,
+            onClick = {},
+        )
+    }
+
+    @Test
+    fun chipDashed() = paparazzi.sparkDocSnapshot {
+        ChipDashed(
+            onClick = {},
+        ) {
+            Text("Dashed chip")
+        }
+    }
+}

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/toggles/CheckboxDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/toggles/CheckboxDocumentationScreenshots.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.toggles
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.DefaultTestDevices
+import com.adevinta.spark.paparazziRule
+import com.adevinta.spark.sparkDocSnapshot
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode.SHRINK
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Documentation screenshots for Checkbox component, following Material Design's approach of showing
+ * each state with light and dark theme side by side.
+ */
+internal class CheckboxDocumentationScreenshots {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DefaultTestDevices.DocPhone,
+    )
+
+    @Test
+    fun checkboxStates() = paparazzi.sparkDocSnapshot {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Checkbox(
+                state = ToggleableState.Off,
+                onClick = null,
+            )
+            Checkbox(
+                state = ToggleableState.Indeterminate,
+                onClick = null,
+            )
+            Checkbox(
+                state = ToggleableState.On,
+                onClick = null,
+            )
+        }
+    }
+}

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/toggles/RadioButtonDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/toggles/RadioButtonDocumentationScreenshots.kt
@@ -59,4 +59,3 @@ internal class RadioButtonDocumentationScreenshots {
         }
     }
 }
-

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/toggles/RadioButtonDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/toggles/RadioButtonDocumentationScreenshots.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.toggles
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.DefaultTestDevices
+import com.adevinta.spark.paparazziRule
+import com.adevinta.spark.sparkDocSnapshot
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode.SHRINK
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Documentation screenshots for RadioButton component, following Material Design's approach of showing
+ * each state with light and dark theme side by side.
+ */
+internal class RadioButtonDocumentationScreenshots {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DefaultTestDevices.DocPhone,
+    )
+
+    @Test
+    fun radioButtonStates() = paparazzi.sparkDocSnapshot {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            RadioButton(
+                selected = true,
+                onClick = null,
+            )
+            RadioButton(
+                selected = false,
+                onClick = null,
+            )
+        }
+    }
+}
+

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/toggles/SwitchDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/toggles/SwitchDocumentationScreenshots.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.toggles
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.DefaultTestDevices
+import com.adevinta.spark.paparazziRule
+import com.adevinta.spark.sparkDocSnapshot
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode.SHRINK
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Documentation screenshots for Switch component, following Material Design's approach of showing
+ * each state with light and dark theme side by side.
+ */
+internal class SwitchDocumentationScreenshots {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DefaultTestDevices.DocPhone,
+    )
+
+    @Test
+    fun switchStates() = paparazzi.sparkDocSnapshot {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Switch(
+                checked = false,
+                onCheckedChange = null,
+            )
+            Switch(
+                checked = true,
+                onCheckedChange = null,
+                icons = SwitchDefaults.icons,
+            )
+        }
+    }
+}

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonContrast.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonContrast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a739c10166c65fe65170049f3cb79f9f324ad7f040c5ec5bdc0c183cf29ef62f
+size 18175

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonFilled.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonFilled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2929b6e744a190c5156e83eaab973c412900a2749a8461c98499d425898bb6d4
+size 18006

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonGhost.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonGhost.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ad944b7701dd00ba798e18e51723fafcd37ba056b44e255145d9a12cb0e524b
+size 12722

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonOutlined.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonOutlined.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f7c87a8f0a3082d7f4956ec6464a69ea61e5809d3dea3b75cad0565e4a227df
+size 23777

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonTinted.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonTinted.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:118402092a980af0ffd75757398468c10091a845ff8e61d3d618237bcbebdf84
+size 17377

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.badge_BadgeDocumentationScreenshots_badgeCount.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.badge_BadgeDocumentationScreenshots_badgeCount.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec79c0f70e0086076db26632b3b30716c384c05ae902c27e1581e29e0ad54999
+size 13083

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.badge_BadgeDocumentationScreenshots_badgeDot.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.badge_BadgeDocumentationScreenshots_badgeDot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:055b725a3a93bb16e09b75f339ff9335ce87d9488c423f384a6b6017eaa1b5dc
+size 7276

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.badge_BadgeDocumentationScreenshots_badgeOverIcon.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.badge_BadgeDocumentationScreenshots_badgeOverIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a0da55f962fc3ed49e72da77a5ec1b365e950c4f3c332c97b39db1fa2e04f73
+size 11467

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.chips_ChipDocumentationScreenshots_chipDashed.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.chips_ChipDocumentationScreenshots_chipDashed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2ba95d49db5ff1115473ac02b36a3a39dfee133b3e09a17a9a3a231cc62986e
+size 18535

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.chips_ChipDocumentationScreenshots_chipOutlined.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.chips_ChipDocumentationScreenshots_chipOutlined.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d3f56fd46037dfb2198aa7209ef9d3457c9e1162e31a32bc04335fd9cf41876
+size 22256

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.chips_ChipDocumentationScreenshots_chipTinted.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.chips_ChipDocumentationScreenshots_chipTinted.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50fe80d484aa4d05091b77b75a5807be2a226ae274014d9f7f8ec840f9d90856
+size 16888

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.toggles_CheckboxDocumentationScreenshots_checkboxStates.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.toggles_CheckboxDocumentationScreenshots_checkboxStates.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:392c117a76bc6c7540ae139af018c29ad7c452887e27e7c14c3802301393b83b
+size 8315

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.toggles_RadioButtonDocumentationScreenshots_radioButtonStates.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.toggles_RadioButtonDocumentationScreenshots_radioButtonStates.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff2fe7aebcb8c8822ee11e48700cb0921a90c4d3c1761c41281832c90031b506
+size 14513

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.toggles_SwitchDocumentationScreenshots_switchStates.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.toggles_SwitchDocumentationScreenshots_switchStates.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2143c322b47524c93f5aaa52c1902103f5389de8402c6437cc0adf60eb152977
+size 17145

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/AppBar.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/AppBar.md
@@ -1,0 +1,205 @@
+# Package com.adevinta.spark.components.appbar
+
+App bars display navigation controls and key actions at the top or bottom of a screen. Use them to give users consistent access to navigation and contextual actions across your app.
+
+## Top App Bars
+
+Four variants are available, differing in title size and collapsing behaviour.
+
+| Variant | Height (expanded) | Title alignment | Collapses on scroll |
+|---|---|---|---|
+| `TopAppBar` | 64 dp | Start | Yes (hides entirely) |
+| `CenterAlignedTopAppBar` | 64 dp | Center | Yes (hides entirely) |
+| `MediumTopAppBar` | 112 dp | Start (second row) | Yes (collapses to 64 dp) |
+| `LargeTopAppBar` | 152 dp | Start (second row) | Yes (collapses to 64 dp) |
+
+All four share the same parameters:
+
+| Parameter | Description |
+|---|---|
+| `title` | Composable shown as the screen title |
+| `navigationIcon` | Leading icon, typically an `IconButton` with `UpNavigationIcon` or a menu icon |
+| `actions` | Trailing `IconButton`s laid out in a `Row` |
+| `scrollBehavior` | Controls collapse animation; provide via `TopAppBarDefaults` |
+| `colors` | Override colours via the matching `TopAppBarSparkDefaults` factory |
+| `windowInsets` | Insets the bar respects; defaults to `TopAppBarDefaults.windowInsets` |
+
+### TopAppBar
+
+Single-row bar with a start-aligned title. The bar hides entirely when the user scrolls down.
+
+```kotlin
+val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+
+Scaffold(
+    modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    topBar = {
+        TopAppBar(
+            title = { Text("Listings") },
+            navigationIcon = {
+                UpNavigationIcon(onClick = onNavigateUp)
+            },
+            actions = {
+                IconButton(onClick = onSearch) {
+                    Icon(SparkIcons.SearchFill, contentDescription = "Search")
+                }
+            },
+            scrollBehavior = scrollBehavior,
+        )
+    },
+) { padding -> /* content */ }
+```
+
+### CenterAlignedTopAppBar
+
+Same as `TopAppBar` but the title is centred horizontally.
+
+```kotlin
+CenterAlignedTopAppBar(
+    title = { Text("My Profile") },
+    navigationIcon = {
+        UpNavigationIcon(onClick = onNavigateUp)
+    },
+)
+```
+
+### MediumTopAppBar
+
+Two-row bar: navigation and actions on the first row, large title on the second. The title row collapses into the first row when scrolled.
+
+```kotlin
+val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+
+Scaffold(
+    modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    topBar = {
+        MediumTopAppBar(
+            title = { Text("Search results") },
+            navigationIcon = {
+                UpNavigationIcon(onClick = onNavigateUp)
+            },
+            scrollBehavior = scrollBehavior,
+        )
+    },
+) { padding -> /* content */ }
+```
+
+### LargeTopAppBar
+
+Same two-row pattern as `MediumTopAppBar` with a taller expanded height (152 dp) suited for prominent section headers.
+
+```kotlin
+val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+
+LargeTopAppBar(
+    title = { Text("Favourites") },
+    navigationIcon = {
+        UpNavigationIcon(onClick = onNavigateUp)
+    },
+    scrollBehavior = scrollBehavior,
+)
+```
+
+### Colours
+
+Each variant has a matching colour factory on `TopAppBarSparkDefaults`. The container colour animates to a tonal-elevated surface when content scrolls underneath the bar.
+
+```kotlin
+TopAppBar(
+    title = { Text("Custom colours") },
+    colors = TopAppBarSparkDefaults.topAppBarColors(
+        containerColor = SparkTheme.colors.primaryContainer,
+        titleContentColor = SparkTheme.colors.onPrimaryContainer,
+    ),
+)
+```
+
+| Factory | Variant |
+|---|---|
+| `TopAppBarSparkDefaults.topAppBarColors()` | `TopAppBar` |
+| `TopAppBarSparkDefaults.centerAlignedTopAppBarColors()` | `CenterAlignedTopAppBar` |
+| `TopAppBarSparkDefaults.mediumTopAppBarColors()` | `MediumTopAppBar` |
+| `TopAppBarSparkDefaults.largeTopAppBarColors()` | `LargeTopAppBar` |
+
+---
+
+## BottomAppBar
+
+A bottom bar for navigation controls and a primary action. It optionally hosts a `FloatingActionButton` at the trailing end.
+
+```kotlin
+BottomAppBar(
+    actions = {
+        IconButton(onClick = onEdit) {
+            Icon(SparkIcons.PenOutline, contentDescription = "Edit")
+        }
+        IconButton(onClick = onShare) {
+            Icon(SparkIcons.Share, contentDescription = "Share")
+        }
+    },
+    floatingActionButton = {
+        FloatingActionButton(
+            onClick = onAdd,
+            containerColor = BottomAppBarDefaults.bottomAppBarFabColor,
+            elevation = FloatingActionButtonDefaults.bottomAppBarFabElevation(),
+            icon = SparkIcons.Plus,
+            contentDescription = "Add",
+        )
+    },
+)
+```
+
+### Scroll behaviour
+
+`BottomAppBar` gains elevation when the user has scrolled down and there is content above to return to. Use `BottomAppBarSparkDefaults.bottomAppBarScrollBehavior()` and connect it via `nestedScroll`.
+
+```kotlin
+val bottomBarBehavior = BottomAppBarSparkDefaults.bottomAppBarScrollBehavior()
+
+Scaffold(
+    modifier = Modifier.nestedScroll(bottomBarBehavior.nestedScrollConnection),
+    bottomBar = {
+        BottomAppBar(
+            scrollBehavior = bottomBarBehavior,
+            actions = {
+                IconButton(onClick = onCancel) {
+                    Icon(SparkIcons.ArrowLeft, contentDescription = "Cancel")
+                }
+            },
+        )
+    },
+) { padding -> /* content */ }
+```
+
+---
+
+## NavigationBar
+
+A persistent bottom destination switcher. Use it with three to five `NavigationBarItem`s.
+
+```kotlin
+var selected by remember { mutableIntStateOf(0) }
+
+NavigationBar {
+    NavigationBarItem(
+        icon = SparkIcons.HomeFill,
+        label = { Text("Home") },
+        selected = selected == 0,
+        onClick = { selected = 0 },
+    )
+    NavigationBarItem(
+        icon = SparkIcons.SearchFill,
+        label = { Text("Search") },
+        selected = selected == 1,
+        onClick = { selected = 1 },
+    )
+    NavigationBarItem(
+        icon = SparkIcons.AccountFill,
+        label = { Text("Profile") },
+        selected = selected == 2,
+        onClick = { selected = 2 },
+    )
+}
+```
+
+`NavigationBarItem` always shows the label for the selected item. Set `alwaysShowLabel = false` to hide labels on unselected items when space is limited.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.md
@@ -3,7 +3,7 @@
 [Badges](https://spark.adevinta.com/1186e1705/p/8711ec-badge/b/98915d) convey dynamic information,
 such as counts or status. A badge can include labels or numbers.
 
-![](../../images/com.adevinta.spark.components.badge_BadgeScreenshot_badge.png)
+![](../../images/com.adevinta.spark.components.badge_BadgeDocumentationScreenshots_badgeCount.png)
 
 The default value of overflowCount is 99. When count is larger than 99, a `+` is displayed.
 A badge can be used as a part of `BadgedBox` (see Layout section) or as a standalone when it is not attached visually to

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Buttons.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Buttons.md
@@ -11,11 +11,6 @@ places like:
 - Cards
 - Toolbars
 
-| Light                                                                              | Dark                                                                              |
-|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| ![](../../images/com.adevinta.spark.buttons_ButtonScreenshot_large_light.png)      | ![](../../images/com.adevinta.spark.buttons_ButtonScreenshot_large_dark.png)      |
-| ![](../../images/com.adevinta.spark.buttons_ButtonScreenshot_medium_light.png)     | ![](../../images/com.adevinta.spark.buttons_ButtonScreenshot_medium_dark.png)     |
-
 The minimal usage of the component is the text and the click action.
 
 ```kotlin
@@ -36,6 +31,8 @@ There are multiple style variants for the button with the same parameters:
 
 #### ButtonFilled
 
+![](../../images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonFilled.png)
+
 Filled buttons are the standard button for most use cases. The filled styling places the most
 emphasis and should be used for important, final actions.
 
@@ -46,11 +43,9 @@ ButtonFilled(
 )
 ```
 
-| Light                                                                          | Dark                                                                          |
-|--------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| ![](../../images/com.adevinta.spark.buttons_ButtonScreenshot_large_light.png)  | ![](../../images/com.adevinta.spark.buttons_ButtonScreenshot_large_dark.png)  |
-
 #### ButtonOutlined
+
+![](../../images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonOutlined.png)
 
 Outlined buttons are used for support actions. The outlined styling places less emphasis on these
 actions that are important but not the main ones.
@@ -68,6 +63,8 @@ ButtonOutlined(
 
 #### ButtonTinted
 
+![](../../images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonTinted.png)
+
 Tinted buttons are medium-emphasis buttons that is an alternative middle ground between
 default Buttons (filled) and Outlined buttons. They can be used in contexts where lower-priority
 button requires slightly more emphasis than an outline would give, such as "Next" in an onboarding
@@ -84,6 +81,8 @@ ButtonTinted(
 
 #### ButtonGhost
 
+![](../../images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonGhost.png)
+
 Ghost buttons are used for the lowest priority actions, especially when presenting multiple options.
 
 Ghost buttons can be placed on a variety of backgrounds. Until the button is interacted with, its
@@ -98,6 +97,8 @@ ButtonGhost(
 ```
 
 #### ButtonContrast
+
+![](../../images/com.adevinta.spark.buttons_ButtonDocumentationScreenshots_buttonContrast.png)
 
 Contrast buttons are used for the high to mid priority actions when the background is dark like on
 an image or a video.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.md
@@ -8,9 +8,24 @@ Most commonly chip contains an optional `leadingIcon` and the text.
 ### Styles
 
 The chip can have one of the `ChipStyles`:
-- `Outlined` - using a solid border stroke and no background
-- `Tinted` - using one of the "containers" colors
-- `Dashed` - using a dashed border and no background
+
+#### Outlined
+
+![](../../images/com.adevinta.spark.components.chips_ChipDocumentationScreenshots_chipOutlined.png)
+
+Outlined chips use a solid border stroke and no background.
+
+#### Tinted
+
+![](../../images/com.adevinta.spark.components.chips_ChipDocumentationScreenshots_chipTinted.png)
+
+Tinted chips use one of the "containers" colors for a filled background.
+
+#### Dashed
+
+![](../../images/com.adevinta.spark.components.chips_ChipDocumentationScreenshots_chipDashed.png)
+
+Dashed chips use a dashed border and no background.
 
 The color is set using one of the `ChipIntent`s:
 - Support (default color)

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/Dialog.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/Dialog.md
@@ -1,0 +1,161 @@
+# Package com.adevinta.spark.components.dialog
+
+The dialog package provides two composables: `AlertDialog` for concise confirmations and
+`ModalScaffold` for full-screen flows with top/bottom app bars and scrollable content.
+
+Both are annotated `@ExperimentalSparkApi`.
+
+---
+
+## AlertDialog
+
+A compact dialog for alerting the user or requesting confirmation of a single action.
+
+```kotlin
+var showDialog by remember { mutableStateOf(false) }
+
+if (showDialog) {
+    AlertDialog(
+        onDismissRequest = { showDialog = false },
+        title = { Text("Delete listing?") },
+        text = { Text("This action cannot be undone.") },
+        confirmButton = {
+            ButtonGhost(
+                text = "Delete",
+                onClick = { viewModel.delete(); showDialog = false },
+            )
+        },
+        dismissButton = {
+            ButtonGhost(
+                text = "Cancel",
+                onClick = { showDialog = false },
+            )
+        },
+    )
+}
+```
+
+### Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `onDismissRequest` | - | Called when the user taps outside the dialog or presses Back |
+| `confirmButton` | - | Primary action slot; no click handler is wired automatically |
+| `dismissButton` | `null` | Secondary action slot; omit to show a single button |
+| `icon` | `null` | Optional icon displayed above the title |
+| `title` | `null` | Dialog headline; omit when body text is self-explanatory |
+| `text` | `null` | Supporting body text |
+| `properties` | `DialogProperties()` | Platform-specific window properties |
+
+To prevent dismissal on back press or outside tap, pass a no-op lambda or configure
+`DialogProperties`:
+
+```kotlin
+AlertDialog(
+    onDismissRequest = { /* intentionally empty */ },
+    properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false),
+    confirmButton = { /* ... */ },
+)
+```
+
+Use `ButtonGhost` for action buttons inside `AlertDialog`. Filled or outlined buttons are too
+visually heavy for this compact context.
+
+---
+
+## ModalScaffold
+
+`ModalScaffold` presents a full-screen flow with a `TopAppBar` containing a close button, an
+optional bottom action bar, and scrollable content. On tablets and foldables it renders as a
+centred modal dialog instead of full-screen.
+
+```kotlin
+var showModal by remember { mutableStateOf(false) }
+
+if (showModal) {
+    ModalScaffold(
+        onClose = { showModal = false },
+        title = { Text("Edit profile") },
+        mainButton = { modifier ->
+            ButtonFilled(
+                modifier = modifier,
+                text = "Save",
+                onClick = { viewModel.save(); showModal = false },
+            )
+        },
+        supportButton = { modifier ->
+            ButtonOutlined(
+                modifier = modifier,
+                text = "Discard",
+                onClick = { showModal = false },
+            )
+        },
+    ) { innerPadding ->
+        ProfileForm(modifier = Modifier.padding(innerPadding))
+    }
+}
+```
+
+### Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `onClose` | - | Invoked when the close button is tapped or the dialog is dismissed |
+| `title` | `{}` | Composable placed in the `TopAppBar` title slot |
+| `actions` | `{}` | `IconButton`s placed at the end of the `TopAppBar` |
+| `mainButton` | `null` | Primary bottom-bar action; receives a `Modifier` for sizing |
+| `supportButton` | `null` | Secondary bottom-bar action; receives a `Modifier` for sizing |
+| `snackbarHost` | `{}` | Slot for a `SnackbarHost` |
+| `contentPadding` | `PaddingValues(horizontal = 24.dp)` | Padding applied around `content` |
+| `inEdgeToEdge` | feature flag | Set `true` when the host activity is edge-to-edge |
+
+### Dismiss behaviour
+
+The close (X) button in the top bar calls `onClose`. On phone portrait and landscape it also
+dismisses when the user presses Back. On tablets it dismisses on outside tap. To prevent
+dismissal, pass a no-op `onClose` lambda.
+
+### Layout adaptation
+
+`ModalScaffold` picks a layout automatically based on `LocalWindowSizeClass`:
+
+| Context | Layout |
+|---|---|
+| Phone portrait | Full-screen `Scaffold` with stacked buttons |
+| Phone landscape | Full-screen `Scaffold` with side-by-side buttons |
+| Tablet / foldable | Centred dialog (280-560dp wide), `large` shape |
+
+### Bottom bar
+
+Omit both `mainButton` and `supportButton` to hide the bottom bar entirely. This is useful for
+informational modals that need only the close button.
+
+```kotlin
+ModalScaffold(
+    onClose = { showModal = false },
+    title = { Text("Terms of service") },
+    // No mainButton or supportButton - bottom bar hidden
+) { innerPadding ->
+    TermsContent(Modifier.padding(innerPadding))
+}
+```
+
+### Snackbar
+
+Pass a `SnackbarHost` to `snackbarHost` to display in-modal feedback:
+
+```kotlin
+val snackbarHostState = remember { SnackbarHostState() }
+
+ModalScaffold(
+    onClose = { showModal = false },
+    snackbarHost = { SnackbarHost(snackbarHostState) },
+    mainButton = { modifier ->
+        ButtonFilled(modifier = modifier, text = "Submit", onClick = {
+            scope.launch { snackbarHostState.showSnackbar("Saved") }
+        })
+    },
+) { innerPadding ->
+    FormContent(Modifier.padding(innerPadding))
+}
+```

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.md
@@ -1,0 +1,182 @@
+# Package com.adevinta.spark.components.image
+
+The image package provides three composables for displaying visual content: `Image` for remote/async
+images with managed loading states, `Illustration` for local static assets, and `UserAvatar` for
+circular profile pictures.
+
+## Image
+
+`Image` loads remote or local content asynchronously via Coil and handles all loading states
+automatically. Unlike the standard Compose `Image`, it requires bounded dimensions and shows
+built-in placeholder states.
+
+```kotlin
+Image(
+    model = "https://example.com/photo.jpg",
+    contentDescription = "Product photo",
+    modifier = Modifier.size(200.dp),
+)
+```
+
+The component **requires** bounded width and height. Wrap in a `size`, `fillMaxWidth`, or other
+size-constraining modifier; an unbounded `Image` triggers an exception via the Spark exception
+handler.
+
+### Loading states
+
+Three states are rendered automatically. Each slot accepts a custom composable:
+
+| State | Default behaviour | Parameter |
+|---|---|---|
+| Empty (null or blank model) | Neutral icon on `neutralContainer` background | `emptyIcon` |
+| Loading | Shimmer placeholder animation | `loadingPlaceholder` |
+| Error (URL failed to load) | Warning icon on `errorContainer` background | `errorIcon` |
+
+```kotlin
+Image(
+    model = imageUrl,
+    contentDescription = "Ad photo",
+    modifier = Modifier
+        .size(120.dp)
+        .clip(SparkTheme.shapes.medium),
+    emptyIcon = {
+        // Custom empty state
+        Icon(sparkIcon = SparkIcons.ImageFill, contentDescription = null)
+    },
+    errorIcon = {
+        // Custom error state
+        Icon(sparkIcon = SparkIcons.WarningFill, contentDescription = null)
+    },
+)
+```
+
+The `emptyIcon` slot is also shown when loading fails with a null, blank, or
+`NullRequestData` model, distinguishing "no content" from a genuine network failure.
+
+### Observing state changes
+
+Use `onState` to react to loading lifecycle events:
+
+```kotlin
+Image(
+    model = url,
+    contentDescription = "Photo",
+    modifier = Modifier.size(100.dp),
+    onState = { state ->
+        when (state) {
+            is State.Success -> analyticsTracker.imageLoaded()
+            is State.Error -> analyticsTracker.imageFailedToLoad()
+            else -> Unit
+        }
+    },
+)
+```
+
+### Content scale and alignment
+
+`contentScale` and `alignment` mirror the standard Compose parameters and default to
+`ContentScale.Fit` / `Alignment.Center`.
+
+```kotlin
+Image(
+    model = url,
+    contentDescription = "Banner",
+    modifier = Modifier
+        .fillMaxWidth()
+        .height(200.dp),
+    contentScale = ContentScale.Crop,
+    alignment = Alignment.TopCenter,
+)
+```
+
+### Applying shape
+
+Apply shape via `Modifier.clip` before passing to the composable:
+
+```kotlin
+Image(
+    model = url,
+    contentDescription = "Thumbnail",
+    modifier = Modifier
+        .size(80.dp)
+        .clip(SparkTheme.shapes.large),
+)
+```
+
+---
+
+## Illustration
+
+`Illustration` renders static local assets - bitmaps, vectors, drawables, or `SparkIcon`s - without
+loading states or network access.
+
+```kotlin
+// From a drawable resource
+Illustration(
+    drawableRes = R.drawable.il_onboarding,
+    contentDescription = "Onboarding graphic",
+    modifier = Modifier.size(240.dp),
+)
+
+// From a SparkIcon
+Illustration(
+    sparkIcon = SparkIcons.Store,
+    contentDescription = "Store",
+    modifier = Modifier.size(100.dp),
+)
+
+// From a Painter
+Illustration(
+    painter = rememberVectorPainter(MyVector),
+    contentDescription = null, // decorative
+)
+```
+
+Use `Illustration` for design-system illustrations and marketing graphics where content is
+bundled with the app. Use `Image` for any content loaded at runtime.
+
+---
+
+## UserAvatar
+
+`UserAvatar` displays a circular profile picture. It uses `Image` internally and falls back to
+a profile or pro icon when no model is provided.
+
+```kotlin
+UserAvatar(
+    model = user.avatarUrl,
+    style = UserAvatarStyle.MEDIUM,
+    isPro = user.isProfessional,
+    isOnline = user.isOnline,
+)
+```
+
+### Sizes
+
+| Style | Image size |
+|---|---|
+| `UserAvatarStyle.SMALL` | 32dp |
+| `UserAvatarStyle.MEDIUM` | 40dp |
+| `UserAvatarStyle.LARGE` | 64dp |
+
+### Online indicator
+
+Set `isOnline = true` to display a green dot badge at the bottom-right of the avatar. The badge
+scales with the chosen `UserAvatarStyle`.
+
+### Pro badge
+
+Set `isPro = true` to swap the fallback icon from a generic profile silhouette to a pro indicator.
+The pro icon is only visible when no image is loaded (empty or error state).
+
+```kotlin
+UserAvatar(
+    model = null, // shows fallback icon
+    style = UserAvatarStyle.LARGE,
+    isPro = true,
+    color = SparkTheme.colors.mainContainer,
+)
+```
+
+The `color` parameter tints the fallback icon's background surface. Leave as `Color.Unspecified`
+to use the default neutral colour.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/Placeholder.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/Placeholder.md
@@ -1,0 +1,125 @@
+# Package com.adevinta.spark.components.placeholder
+
+Placeholders display skeleton UI whilst content is loading. They occupy the same space as the real
+content and cross-fade out once data is ready, reducing perceived wait time.
+
+Use placeholders when:
+
+- Data loads asynchronously and the layout shape is known in advance
+- Multiple items load simultaneously and a consistent loading state is needed
+
+### Modifiers
+
+Placeholders are applied as `Modifier` extensions rather than standalone composables. Each variant
+targets a specific content type.
+
+#### `Modifier.placeholder`
+
+General-purpose skeleton for any layout element. Shape defaults to `SparkTheme.shapes.small`.
+Animation is a **fade** (pulse in/out).
+
+```kotlin
+Box(
+    modifier = Modifier
+        .fillMaxWidth()
+        .height(48.dp)
+        .placeholder(visible = isLoading),
+)
+```
+
+To override the shape, apply `Modifier.clip` before this modifier:
+
+```kotlin
+Box(
+    modifier = Modifier
+        .size(40.dp)
+        .clip(CircleShape)
+        .placeholder(visible = isLoading),
+)
+```
+
+#### `Modifier.textPlaceholder`
+
+Skeleton for text content. Uses `SparkTheme.shapes.full` (pill shape) to mirror the rounded
+profile of text runs. Animation is a **fade**.
+
+```kotlin
+Text(
+    text = username,
+    modifier = Modifier.textPlaceholder(visible = isLoading),
+)
+```
+
+Apply it to every `Text` composable independently so each line produces its own skeleton at the
+correct width.
+
+#### `Modifier.illustrationPlaceholder`
+
+Skeleton for images and illustrations. Animation is a **shimmer** (radial gradient sweeping from
+top-start to bottom-end). Requires an explicit `shape` parameter.
+
+```kotlin
+AsyncImage(
+    model = url,
+    contentDescription = null,
+    modifier = Modifier
+        .size(128.dp)
+        .illustrationPlaceholder(
+            visible = isLoading,
+            shape = SparkTheme.shapes.extraLarge,
+        ),
+)
+```
+
+### Animation modes
+
+| Mode | Modifier | Behaviour |
+|------|----------|-----------|
+| Fade | `placeholder`, `textPlaceholder` | Colour pulses in and out (600 ms, 200 ms delay, reverses) |
+| Shimmer | `illustrationPlaceholder` | Radial gradient sweeps across the surface (1700 ms, 200 ms delay, restarts) |
+
+All three modifiers apply a cross-fade transition between the skeleton and the real content when
+`visible` flips to `false`.
+
+### Full example
+
+```kotlin
+@Composable
+fun ListingCard(listing: Listing?, isLoading: Boolean) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        AsyncImage(
+            model = listing?.imageUrl,
+            contentDescription = null,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+                .illustrationPlaceholder(
+                    visible = isLoading,
+                    shape = SparkTheme.shapes.medium,
+                ),
+        )
+        Text(
+            text = listing?.title.orEmpty(),
+            modifier = Modifier.textPlaceholder(visible = isLoading),
+        )
+        Text(
+            text = listing?.price.orEmpty(),
+            modifier = Modifier.textPlaceholder(visible = isLoading),
+        )
+    }
+}
+```
+
+### Customising colours
+
+`PlaceholderDefaults` exposes `@Composable` functions to produce theme-aware colours for custom
+highlight implementations:
+
+| Function | Used by | Default alpha |
+|----------|---------|---------------|
+| `PlaceholderDefaults.color()` | Base skeleton fill | 0.25f |
+| `PlaceholderDefaults.fadeHighlightColor()` | `PlaceholderHighlight.fade()` | 0.3f |
+| `PlaceholderDefaults.shimmerHighlightColor()` | `PlaceholderHighlight.shimmer()` | 0.3f |
+
+All three derive from `SparkTheme.colors.surface` and accept `backgroundColor`, `contentColor`,
+and `alpha` overrides.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/Rating.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/Rating.md
@@ -1,0 +1,201 @@
+# Package com.adevinta.spark.components.rating
+
+Rating components display or collect a 1-5 star score. Use display variants to show existing scores
+and `RatingInput` to let users submit their own.
+
+## Variants
+
+| Variant | Purpose | Accepts fractional values |
+|---|---|---|
+| `RatingDisplay` | Raw star row, no label | Yes (Float 0–5) |
+| `RatingFull` | Stars with numeric value, label, and review count | Yes (Float 0–5) |
+| `RatingSimple` | Single star + numeric value + optional review count | Yes (Float 1–5) |
+| `RatingSimpleLarge` | Large single-star display, no review count | Yes (Float 1–5) |
+| `RatingInput` | Interactive 5-star picker | No (Int 0–5) |
+| `RatingStar` | Atomic star icon (full, half, empty) | Via `RatingStarState` |
+
+---
+
+### RatingDisplay
+
+A row of five stars reflecting a fractional value. Values below `0.5` render nothing.
+
+```kotlin
+RatingDisplay(value = 3.5f)
+```
+
+Pass `size` to override the default 12dp star size:
+
+```kotlin
+RatingDisplay(
+    value = 4.2f,
+    size = RatingDefault.StarSize, // 16dp
+)
+```
+
+---
+
+### RatingFull
+
+Displays **`3,4 ★★★☆☆ Label (5 avis)`** — numeric value, stars, optional label, and optional
+review count. Requires a value in the range `[1..5]`; values outside this range render nothing.
+
+```kotlin
+RatingFull(
+    value = 3.6f,
+    commentCount = 42,
+)
+```
+
+Pass `label` to append a category name after the stars:
+
+```kotlin
+RatingFull(
+    value = 4.2f,
+    label = "Communication",
+    commentCount = 5,
+)
+```
+
+Pass `locale = null` to hide the numeric prefix:
+
+```kotlin
+RatingFull(
+    value = 3.6f,
+    commentCount = 23,
+    locale = null,
+)
+```
+
+---
+
+### RatingSimple
+
+A compact single-star summary — **`★ 3,4 (5)`**. Annotated `@ExperimentalSparkApi`.
+
+```kotlin
+RatingSimple(
+    value = 4.5f,
+    commentCount = 12,
+)
+```
+
+Control which side the numeric label appears on with `labelSide`:
+
+```kotlin
+RatingSimple(
+    value = 4.5f,
+    labelSide = RatingLabelSide.Start, // "4,5 ★"
+)
+```
+
+---
+
+### RatingSimpleLarge
+
+An oversized version of `RatingSimple` — renders the value in `display3` typography with a `/5`
+suffix, no review count. Annotated `@ExperimentalSparkApi`.
+
+```kotlin
+RatingSimpleLarge(
+    value = 4.5f,
+    locale = Locale.US,
+)
+```
+
+---
+
+### RatingInput
+
+An interactive 5-star picker. Accepts tap and horizontal drag gestures, triggers haptic feedback
+on drag, and exposes semantics as a slider for accessibility services (TalkBack, Switch Access).
+Keyboard navigation uses `Shift + Arrow` keys to increment or decrement.
+
+```kotlin
+var rating by remember { mutableIntStateOf(0) }
+
+RatingInput(
+    value = rating,
+    onRatingChanged = { rating = it },
+)
+```
+
+Disable the picker while a submission is in flight:
+
+```kotlin
+RatingInput(
+    value = rating,
+    onRatingChanged = { rating = it },
+    enabled = false,
+)
+```
+
+Supply a custom accessibility description when the default "N stars" wording does not fit the
+context:
+
+```kotlin
+RatingInput(
+    value = rating,
+    onRatingChanged = { rating = it },
+    stateDescription = { value -> "$value out of 5" },
+)
+```
+
+Set `allowSemantics = false` when embedding `RatingInput` inside a parent that declares its own
+semantics, to prevent duplicate TalkBack announcements:
+
+```kotlin
+RatingInput(
+    value = rating,
+    onRatingChanged = { rating = it },
+    allowSemantics = false,
+)
+```
+
+---
+
+### RatingStar
+
+The atomic star icon. Use it when none of the composite components match your layout needs.
+
+`RatingStarState` accepts a `Boolean`, `Int` (0 or 1), `Float` (0.0–1.0), or `Double`:
+
+```kotlin
+RatingStar(state = RatingStarState.Full)
+RatingStar(state = RatingStarState.Half)
+RatingStar(state = RatingStarState.Empty)
+
+// Derived from a Float — 0.0–0.25 → Empty, 0.25–0.75 → Half, 0.75–1.0 → Full
+RatingStar(state = RatingStarState(0.6f))
+```
+
+Pass `enabled = false` to render the star at reduced opacity:
+
+```kotlin
+RatingStar(
+    state = RatingStarState.Full,
+    enabled = false,
+    size = RatingDefault.StarSize,
+)
+```
+
+---
+
+## Sizing
+
+| Constant | Value | Used by |
+|---|---|---|
+| `RatingDefault.SmallStarSize` | 12dp | `RatingDisplay`, `RatingSimple` |
+| `RatingDefault.StarSize` | 16dp | `RatingFull`, `RatingStar` |
+| `RatingDefaults.StarSize` | 40dp | `RatingInput` touch target interior |
+
+---
+
+## Accessibility
+
+- `RatingFull` and `RatingSimple` merge all descendants into a single node with a
+  locale-aware content description (`"3.6 stars"` or `"3.6 stars, 42 reviews"`).
+- `RatingInput` exposes a `ProgressBarRangeInfo` so TalkBack announces it as a slider. Swipe up/down
+  adjusts the value in increments of one. `Shift + Arrow` provides the same control from a keyboard.
+- Individual `RatingStar` instances carry no content description; they rely on a parent node to
+  supply context.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.md
@@ -1,0 +1,139 @@
+# Package com.adevinta.spark.components.stepper
+
+Steppers let users increment and decrement a numeric value within a defined range using
+decrease/increase buttons on either side of the current value.
+
+## Stepper
+
+The minimal variant for inline use where a label and helper text are not needed.
+
+```kotlin
+var quantity by remember { mutableStateOf(1) }
+
+Stepper(
+    value = quantity,
+    onValueChange = { quantity = it },
+    range = 1..99,
+    step = 1,
+)
+```
+
+### Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `value` | - | Current displayed value |
+| `onValueChange` | - | Called after each increment or decrement |
+| `range` | `0..10` | Accepted value bounds; buttons disable at the limits |
+| `step` | `1` | Amount added or subtracted per button press |
+| `suffix` | `""` | String appended after the value, e.g. `" kg"` |
+| `enabled` | `true` | Disables interaction and applies disabled styling |
+| `status` | `null` | Validation state; tints the outline (`Error`, `Alert`, `Success`) |
+| `flexible` | `false` | When `true`, fills maximum available width |
+
+```kotlin
+Stepper(
+    value = weight,
+    onValueChange = { weight = it },
+    range = 0..500,
+    step = 5,
+    suffix = " kg",
+    status = if (weight == 0) FormFieldStatus.Error else null,
+)
+```
+
+Both `range.first` and `range.last` must be multiples of `step`, otherwise `stepperSemantics`
+throws `IllegalArgumentException`.
+
+---
+
+## StepperForm
+
+`StepperForm` wraps `Stepper` with a label, optional helper text, and status message - matching
+the layout of other form fields.
+
+```kotlin
+var guests by remember { mutableStateOf(1) }
+
+StepperForm(
+    value = guests,
+    onValueChange = { guests = it },
+    label = "Number of guests",
+    helper = "Maximum 8 per booking",
+    range = 1..8,
+    required = true,
+    status = if (guests > 8) FormFieldStatus.Error else null,
+    statusMessage = if (guests > 8) "Exceeds maximum capacity" else null,
+)
+```
+
+### Additional parameters
+
+| Parameter | Description |
+|---|---|
+| `label` | Field label displayed above the stepper |
+| `helper` | Hint text shown below when `status` is null |
+| `required` | Appends `*` to the label and reads it as "mandatory field" |
+| `statusMessage` | Replaces `helper` when `status` is non-null |
+
+`StepperForm` sets `allowSemantics = false` on the inner `Stepper` and applies
+`stepperSemantics` itself at the `Column` level, so TalkBack announces the label, mandatory
+indicator, and value as a single node.
+
+---
+
+## Accessibility: `stepperSemantics`
+
+`Modifier.stepperSemantics` is a public extension that configures a Stepper-containing layout
+to behave like a slider under TalkBack. Apply it when composing a `Stepper` inside a custom
+layout (e.g. a `Row` with a label).
+
+```kotlin
+var value by remember { mutableStateOf(50) }
+val label = "Volume"
+
+Row(
+    modifier = Modifier
+        .fillMaxWidth()
+        .semantics { text = AnnotatedString(label) }
+        .stepperSemantics(
+            value = value,
+            onValueChange = { value = it },
+            range = 0..100,
+            step = 1,
+            suffix = "%",
+            enabled = true,
+        ),
+) {
+    Text(
+        text = label,
+        modifier = Modifier.invisibleSemantic(), // avoids duplicate announcement
+    )
+    Stepper(
+        value = value,
+        onValueChange = { value = it },
+        range = 0..100,
+        allowSemantics = false, // required when parent applies stepperSemantics
+    )
+}
+```
+
+The modifier:
+
+- Exposes `setProgress` so TalkBack volume-key gestures and swipe-up/down gestures change the value
+- Overrides the percentage description with the raw value plus suffix
+- Announces "disabled" when `enabled = false`
+- Handles Shift+Up / Shift+Down keyboard events for hardware keyboard navigation
+
+Pass `allowSemantics = false` to the inner `Stepper` whenever `stepperSemantics` is applied on
+an ancestor, otherwise accessibility nodes are duplicated.
+
+### Validation constraints
+
+`stepperSemantics` enforces:
+
+- `step > 0`
+- `range.first % step == 0`
+- `range.last % step == 0`
+
+These are also checked by `StepperForm` and `Stepper` at composition time.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.md
@@ -3,14 +3,12 @@
 [Checkboxes](https://spark.adevinta.com/1186e1705/p/76f5a8-checkbox/b/98915d) allows users to select
 one or more items from a set. Checkboxes can turn an option on or off.
 
+![](../../images/com.adevinta.spark.components.toggles_CheckboxDocumentationScreenshots_checkboxStates.png)
+
 - Toggle a single item on or off.
 - Require another action to activate or deactivate something.
 - In cases of a global activation in a indeterminate state where on and off states coexist in the
   children.
-
-| Light                                                                                | Dark                                                                                               |
-|--------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| ![](../../images/com.adevinta.spark.toggles_CheckboxScreenshot_all_states_light.png) | ![](../../images/com.adevinta.spark.toggles_CheckboxScreenshot_all_states_dark.png) |
 
 The minimal usage of the component is the checkbox in standalone but you can add a content at the
 end of the box or customize it.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.md
@@ -3,15 +3,13 @@
 The [radio button](https://spark.adevinta.com/1186e1705/p/98058f-radio-button/b/700a17) allow
 users to select one option from a set.
 
+![](../../images/com.adevinta.spark.components.toggles_RadioButtonDocumentationScreenshots_radioButtonStates.png)
+
 - Use radio buttons to select a single option from a list
 - It should be visible at a glance if a radio button has been selected, and selected items should be
   more visually prominent than unselected items.
 - Present a list showing all available options. If available options can be collapsed, consider
   using a dropdown menu because it uses less space.
-
-| Light                                                                                   | Dark                                                                                   |
-|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
-| ![](../../images/com.adevinta.spark.toggles_RadioButtonScreenshot_all_states_light.png) | ![](../../images/com.adevinta.spark.toggles_RadioButtonScreenshot_all_states_dark.png) |
 
 The minimal usage of the component is the radio button in standalone but you can add a content at
 the end of the radio or customize it.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.md
@@ -5,16 +5,14 @@ full page, in modals, or on side panels.
 They can be used in a list but we shouldn’t mix them with other components such
 as `Checkbox` or `RadioButton`.
 
+![](../../images/com.adevinta.spark.components.toggles_SwitchDocumentationScreenshots_switchStates.png)
+
 Switches must respect the established color code and not use other colors to emphasize the
 activation and deactivation of a functionality or service.
 
 Switch component allows the user to activate or deactivate the state of an element or concept.
 It is usually used as an element to add services, activate functionalities or adjust settings.
 It is also used to control binary options (On/Off or True/False).
-
-| Light                                                                              | Dark                                                                              |
-|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| ![](../../images/com.adevinta.spark.toggles_SwitchScreenshot_all_states_light.png) | ![](../../images/com.adevinta.spark.toggles_SwitchScreenshot_all_states_dark.png) |
 
 ### SwitchLabelled
 


### PR DESCRIPTION
## 📋 Changes

- Add `sparkDocSnapshot` utility in `PaparazziUtils.kt` to render light/dark side-by-side screenshots for component documentation
- Add `DefaultTestDevices.DocPhone` device config targeting compact landscape dimensions suited for inline doc images
- Add `*DocumentationScreenshots` Paparazzi test classes for Badge, Button, Chip, Checkbox, RadioButton, and Switch
- Migrate `CardDocumentationScreenshots` to the new `sparkDocSnapshot` pattern
- Update component `.md` files (Buttons, Chip, CheckBox, RadioButton, Switch, Badge) to reference the generated doc screenshots
- Update `ComponentScreenshot.kt.template` and `generate-component.main.kts` to scaffold the `*DocumentationScreenshots` class as part of the standard generator output
- Update `CONTRIBUTING.md` with a Documentation Screenshots section explaining the `sparkDocSnapshot` pattern and how to add doc images to component `.md` files
- Update `COMPONENT_CREATION_GUIDE.md` to align with what the generator actually scaffolds, replacing the previous hand-maintained content
- Add `UPGRADING.md` covering migration notes for adopters

## 🤔 Context

Component `.md` files previously had no visual reference for each variant — contributors had to run the catalog app to understand the available states. The `sparkDocSnapshot` helper produces a single side-by-side light/dark image in one test call, making it straightforward to add coverage for every variant. Wiring this into the component generator means new components get the documentation screenshot class scaffolded automatically from day one.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.

## 📸 Screenshots

Documentation screenshots are generated by the new Paparazzi tests — run `./gradlew verifyPaparazziDebug` to produce them locally.
