### PR TITLE
fix(icons): set JVM target 11 for spark-icons KMP Android compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ## [Unreleased]
 
+## [2.2.1]
+
+_2026-04-16_
+
+### Icons
+
+- 🐛 Fix `spark-icons` JVM target not explicitly set for KMP Android compilation, causing the Compose Preview renderer to reject the class files with "Unsupported class file major version 69"
+
 ## [2.2.0]
 
 _2026-04-14_
@@ -1296,7 +1304,11 @@ _2023-03-29_
 
 <!-- Links -->
 
-[Unreleased]: https://github.com/leboncoin/spark-android/compare/2.2.0...HEAD
+[Unreleased]: https://github.com/leboncoin/spark-android/compare/2.2.1...HEAD
+
+[2.2.1]: https://github.com/leboncoin/spark-android/compare/2.2.0...2.2.1
+
+[2.2.0]: https://github.com/leboncoin/spark-android/compare/2.2.0-alpha05...2.2.0
 
 [2.2.0-alpha05]: https://github.com/leboncoin/spark-android/compare/2.2.0-alpha05...2.2.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-version=2.2.0
+version=2.2.1
 group=com.adevinta.spark
 
 org.gradle.caching=true

--- a/spark-icons/build.gradle.kts
+++ b/spark-icons/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 /*
  * Copyright (c) 2023 Adevinta
  *
@@ -36,6 +38,9 @@ kotlin {
         namespace = "com.adevinta.spark.icons"
         // Doesn't seem to be available for kmp?
 //        resourcePrefix = "spark_icons_"
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
     }
     sourceSets {
         commonMain.dependencies {

--- a/spark-icons/build.gradle.kts
+++ b/spark-icons/build.gradle.kts
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2026 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 /*


### PR DESCRIPTION
## 📋 Changes

Set explicit `jvmTarget = JVM_11` on the `spark-icons` KMP Android compilation via `compilerOptions` inside `kotlin { androidLibrary { } }`.

## 🤔 Context

Without an explicit `jvmTarget`, Kotlin targets the running JDK (25), producing class file major version 69. The Compose Preview renderer rejects this with:

```
java.lang.IllegalArgumentException: Unsupported class file major version 69
```

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [x] I have tested on a local preview.

## 📸 Screenshots

N/A

## 🗒️ Other info

Hotfix for `2.2.0` → `2.2.1`.
This is a hot fix just for icons but we should make a solution that will work with every kmp modules