### PR TITLE
fix(ci): suppress digest-mismatch false positives in artifact download steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,18 +270,21 @@ jobs:
         with:
           name: aar-release
           path: aar-output/
+          digest-mismatch: warn
 
       - name: Download APK
         uses: actions/download-artifact@v8
         with:
           name: apk-release
           path: apk-output/
+          digest-mismatch: warn
 
       - name: Download JVM JARs
         uses: actions/download-artifact@v8
         with:
           name: jar-release
           path: jar-output/
+          digest-mismatch: warn
 
       - uses: ./.github/actions/diffuse-aar
 


### PR DESCRIPTION
## Summary

`actions/download-artifact@v8` changed the default for `digest-mismatch` to `error`. A [known upstream bug (actions/download-artifact#458)](https://github.com/actions/download-artifact/issues/458) causes it to fail even when SHA256 hashes match, producing a false positive. This has broken the `📊 Datadog CI Metrics` job on every push to main since the dependabot bump from v4 to v8 (commit `7d7871b59`).

Setting `digest-mismatch: warn` on the three affected steps unblocks CI while the upstream fix is pending.

## Changes

- Add `digest-mismatch: warn` to the `Download AARs` step
- Add `digest-mismatch: warn` to the `Download APK` step
- Add `digest-mismatch: warn` to the `Download JVM JARs` step

All three steps are in the `📊 Datadog CI Metrics` job in `.github/workflows/ci.yml`.

## Related Issues
- Revert `digest-mismatch: warn` and restore `error` (or remove the key) once upstream issue #458 is resolved
- Upstream bug: https://github.com/actions/download-artifact/issues/458