### PR TITLE
fix(ci): match the spark-icons artefact name that changed since migrating to kmp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: aar-release
-          path: '**/build/outputs/aar/*-release.aar'
+          path: |
+            **/build/outputs/aar/*-release.aar
+            **/build/outputs/aar/spark-icons.aar
       - name: 📦 Archive JVM JARs
         uses: actions/upload-artifact@v7
         with:
@@ -293,7 +295,7 @@ jobs:
           diffuse=~/.spark/diffuse/diffuse-0.3.0/bin/diffuse
           "$diffuse" info --apk $(find apk-output -name "*-release.apk" | head -1) > apk.txt
           "$diffuse" info --aar $(find aar-output -name "spark-release.aar" | head -1) > spark.txt
-          "$diffuse" info --aar $(find aar-output -name "spark-icons-release.aar" | head -1) > spark-icons.txt
+          "$diffuse" info --aar $(find aar-output -name "spark-icons*.aar" | head -1) > spark-icons.txt
           "$diffuse" info --jar $(find jar-output -name "*-jvm-*.jar" | head -1) > spark-icons-jvm.txt
 
       - name: Submit artifact metrics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,7 @@ jobs:
         with:
           name: aar-release
           path: |
-            **/build/outputs/aar/*-release.aar
-            **/build/outputs/aar/spark-icons.aar
+            **/build/outputs/aar/*.aar
       - name: 📦 Archive JVM JARs
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION


<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
  - Add spark-icons.aar to upload-artifact glob alongside *-release.aar                                                                                                                                                                                                                                                                             
  - Update diffuse find pattern from spark-icons-release.aar to spark-icons*.aar 

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
KMP artefacts don't have the release suffix causing the diffuse step to fail since we didn't download the artefact and matched nothing
