### PR TITLE
fix(icons): SparkIcons.MailOutline was referencing MailBoxOpenOutline as a replacement instead of LetterOutline

### DIFF
--- a/spark-icons/src/androidMain/kotlin/com/adevinta/spark/icons/SparkIcons.kt
+++ b/spark-icons/src/androidMain/kotlin/com/adevinta/spark/icons/SparkIcons.kt
@@ -1506,10 +1506,10 @@ public val SparkIcons.MailOpenFill: DrawableRes get() = DrawableRes(R.drawable.s
 public val SparkIcons.MailOpenOutline: DrawableRes get() = DrawableRes(R.drawable.spark_icons_mail_open_outline)
 
 @Deprecated(
-    "MailOutline has been renamed MailBoxOpenOutline",
-    ReplaceWith("LeboncoinIcons.MailBoxOpenOutline", "com.adevinta.spark.icons.LeboncoinIcons"),
+    "MailOutline has been renamed LetterOutline",
+    ReplaceWith("LeboncoinIcons.LetterOutline", "com.adevinta.spark.icons.LeboncoinIcons"),
 )
-public val SparkIcons.MailOutline: DrawableRes get() = DrawableRes(R.drawable.spark_icons_mail_outline)
+public val SparkIcons.MailOutline: DrawableRes get() = LeboncoinIcons.LetterOutline
 
 @Deprecated(
     "MapCursorFill has been renamed CursorFill",


### PR DESCRIPTION
That was most likely a copy paste mistake when applying the Deprecated annotations on `SparkIcons`
