### PR TITLE
fix(catalog): correct side effect keys and lifecycle-aware state collection

### DIFF
--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
 
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.appCompat)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.material.motion)

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/datastore/theme/ThemePropertiesHandler.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/datastore/theme/ThemePropertiesHandler.kt
@@ -24,9 +24,9 @@ package com.adevinta.spark.catalog.datastore.theme
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.datastore.core.DataStore
 import androidx.datastore.dataStore
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adevinta.spark.catalog.themes.Theme
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/datastore/theme/ThemePropertiesHandler.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/datastore/theme/ThemePropertiesHandler.kt
@@ -24,7 +24,7 @@ package com.adevinta.spark.catalog.datastore.theme
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.datastore.core.DataStore
 import androidx.datastore.dataStore
 import com.adevinta.spark.catalog.themes.Theme
@@ -64,8 +64,8 @@ internal class ThemePropertiesHandler(context: Context) {
 }
 
 @Composable
-internal fun Flow<Theme>.collectAsStateWithDefault(context: Context): State<Theme> = collectAsState(
-    initial = ThemeProperties.DEFAULT.copy(
+internal fun Flow<Theme>.collectAsStateWithDefault(context: Context): State<Theme> = collectAsStateWithLifecycle(
+    initialValue = ThemeProperties.DEFAULT.copy(
         fontScale = context.resources.configuration.fontScale,
     ).toTheme(),
 )

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/combobox/ComboboxExample.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/combobox/ComboboxExample.kt
@@ -190,7 +190,7 @@ private val FilteringComboBox = Example(
         }
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(state) {
         snapshotFlow { state.text }
             .debounce(300.milliseconds)
             .onEach { queryText ->
@@ -256,7 +256,7 @@ private val SuggestionComboBox = Example(
         }
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(state) {
         snapshotFlow { state.text }
             .collectLatest { queryText ->
                 searchText = queryText.toString()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ androidx-core = "androidx.core:core-ktx:1.18.0"
 
 androidx-graphics-shapes = "androidx.graphics:graphics-shapes:1.1.0"
 
+androidx-lifecycle-runtime-compose = "androidx.lifecycle:lifecycle-runtime-compose:2.10.0"
 androidx-lifecycle-viewmodel = "androidx.lifecycle:lifecycle-viewmodel:2.10.0"
 androidx-metrics =  "androidx.metrics:metrics-performance:1.0.0"
 


### PR DESCRIPTION
We used `LaunchEffect` with Unit as key when a mutable state was used inside it, we need to add the state as a key otherwise the `LaunchEffect` would be using an old state.

We were missing usage of `collectAsStateWithLifecycle` and were using `collectAsState` instead which may cause bug