### PR TITLE
ci(release): simplify release workflow by removing dokka trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,16 +24,3 @@ jobs:
           token: ${{ secrets.PAT_SPARK }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  trigger-dokka:
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Trigger Dokka publish'
-        run: |
-          gh workflow run dokka.yml \
-            --repo ${{ github.repository }} \
-            --field ref=${{ needs.release-please.outputs.tag_name }}
-        env:
-          GH_TOKEN: ${{ secrets.PAT_SPARK }}


### PR DESCRIPTION
Removed trigger for Dokka publish from release workflow.

