### PR TITLE
ci(release): push the app distrib apk to the github release associated tag page

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -111,6 +111,15 @@ jobs:
         env:
           GROUPS: ${{ inputs.group || 'all' }}
 
+      - name: '📎 Upload APK to GitHub Release'
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            catalog/build/outputs/apk/release/catalog-release.apk \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.PAT_SPARK }}
+
       - name: '♻️ Cleanup'
         if: ${{ success() || failure() }}
         continue-on-error: true

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -114,11 +114,12 @@ jobs:
       - name: '📎 Upload APK to GitHub Release'
         if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         run: |
-          gh release upload "${{ github.ref_name }}" \
+          gh release upload "$TAG" \
             catalog/build/outputs/apk/release/catalog-release.apk \
             --clobber
         env:
           GH_TOKEN: ${{ secrets.PAT_SPARK }}
+          TAG: ${{ github.ref_name }}
 
       - name: '♻️ Cleanup'
         if: ${{ success() || failure() }}


### PR DESCRIPTION
This can make installation easier for power users (like developers) by not forcing subscription to firebase app distribution to be able to test components.

We may be able to use Github realeases to know from the catalog if a new version is available and install it with in-app updates 🤔