### PR TITLE
fix(stepper): the modifier is reused on the middle text

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/SparkStepper.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/SparkStepper.kt
@@ -48,6 +48,7 @@ import com.adevinta.spark.components.stepper.stepperSemantics
 import com.adevinta.spark.icons.LeboncoinIcons
 import com.adevinta.spark.icons.Minus
 import com.adevinta.spark.icons.Plus
+import com.adevinta.spark.tools.modifiers.ifFalse
 import com.adevinta.spark.tools.modifiers.ifTrue
 import com.adevinta.spark.tools.modifiers.invisibleSemantic
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
@@ -107,13 +108,12 @@ internal fun SparkStepper(
 
         MiddleText(
             modifier = Modifier
-                .then(
-                    if (flexible) {
-                        modifier.weight(1.0f)
-                    } else {
-                        modifier.widthIn(min = 48.dp)
-                    },
-                )
+                .ifTrue(flexible) {
+                    weight(1.0f)
+                }
+                .ifFalse(flexible) {
+                    widthIn(min = 48.dp)
+                }
                 .fillMaxHeight()
                 .invisibleSemantic(),
             value = coerced,


### PR DESCRIPTION
Fixes #1984