### PR TITLE
feat(button): add temporary restricted tertiary variant for A/B testing

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
@@ -25,6 +25,7 @@ import android.annotation.SuppressLint
 import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -60,6 +61,7 @@ import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.icons.IdentityCardOutline
 import com.adevinta.spark.icons.LeboncoinIcons
 import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tokens.disabled
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 
 @InternalSparkApi
@@ -217,6 +219,68 @@ public object SparkButtonTags {
     public const val TAG_PROGRESS_INDICATOR: String = "progress_indicator"
 }
 
+@InternalSparkApi
+public object Button {
+
+    /**
+     * Button with the least emphasis possible after the Contrast/Ghost Button
+     *
+     * @param onClick Will be called when the user clicks the button
+     * @param text The text to be displayed in the button
+     * @param modifier Modifier to be applied to the button
+     * @param size The size of the button
+     * @param enabled Controls the enabled state of the button. When `false`, this button will not be clickable
+     * @param icon The optional icon to be displayed at the start or the end of the button container.
+     * @param iconSide If an icon is added, you can configure the side where is should be displayed, at the start
+     * or end of the button
+     * @param isLoading show or hide a CircularProgressIndicator at the start that push the content to indicate a
+     * loading state
+     * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+     * for this button. You can create and pass in your own `remember`ed instance to observe
+     * [Interaction]s and customize the appearance / behavior of this button in different states.
+     */
+    @InternalSparkApi
+    @Composable
+    public fun Tertiary(
+        onClick: () -> Unit,
+        text: String,
+        modifier: Modifier = Modifier,
+        size: ButtonSize = ButtonSize.Medium,
+        enabled: Boolean = true,
+        icon: SparkIcon? = null,
+        iconSide: IconSide = IconSide.START,
+        isLoading: Boolean = false,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+        atEnd: Boolean = false,
+    ) {
+        val contentColor = SparkTheme.colors.onSurface
+        val borderColor = SparkTheme.colors.outline
+        val disabledBorderColor = borderColor.disabled
+        val disabledContentColor = contentColor.disabled
+
+        val colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = contentColor,
+            disabledContentColor = disabledContentColor,
+        )
+        SparkButton(
+            onClick = onClick,
+            text = text,
+            modifier = modifier,
+            size = size,
+            shape = ButtonTokens.buttonShape,
+            enabled = enabled,
+            elevation = null,
+            border = SparkButtonDefaults.outlinedBorder(if (enabled) borderColor else disabledBorderColor),
+            colors = colors,
+            icon = icon,
+            iconSide = iconSide,
+            isLoading = isLoading,
+            interactionSource = interactionSource,
+            atEnd = atEnd,
+        )
+    }
+}
+
 public enum class IconSide { START, END }
 
 public object SparkButtonDefaults {
@@ -279,5 +343,20 @@ private fun SparkButtonPreview() {
                 iconSide = IconSide.END,
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun ButtonTertiaryPreview() {
+    PreviewTheme(
+        color = { SparkTheme.colors.backgroundVariant },
+    ) {
+        Button.Tertiary(
+            text = "ButtonButton",
+            onClick = { },
+            icon = LeboncoinIcons.IdentityCardOutline,
+            iconSide = IconSide.END,
+        )
     }
 }


### PR DESCRIPTION
This button is annotated by `InternalSparkApi` as it's meant to be used in a specific A/B test to test its design before making specs for it.

## Context
This was asked for an A/B Test [here](https://leboncoin.slack.com/archives/C04QQEU3Y2H/p1779960980574769?thread_ts=1778574752.330859&cid=C04QQEU3Y2H)

Close [LBCSPARK-682](https://lbc-lbc.atlassian.net/browse/LBCSPARK-682)
