### PR TITLE
fix(lint): remove unneeded Composable annotation from ComposeRedundantComposable rule

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBar.kt
@@ -342,7 +342,6 @@ public class TopAppBarColors internal constructor(
      * @param colorTransitionFraction a `0.0` to `1.0` value that represents a color transition
      * percentage
      */
-    @Composable
     internal fun containerColor(colorTransitionFraction: Float): Color = lerp(
         containerColor,
         scrolledContainerColor,
@@ -963,7 +962,6 @@ private fun TopAppBarLayout(
  *
  * @param elevationTransitionFraction a `0.0` to `1.0` value that represents a color transition percentage
  */
-@Composable
 private fun containerElevation(elevationTransitionFraction: Float): Dp = lerp(
     ElevationTokens.Level0,
     ElevationTokens.Level2,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
@@ -279,7 +279,6 @@ public object SparkButtonDefaults {
     /**
      * The default border of [ButtonOutlined]
      */
-    @Composable
     internal fun outlinedBorder(color: Color): BorderStroke = BorderStroke(
         width = 1.0.dp,
         color = color,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTokens.kt
@@ -22,6 +22,7 @@
 package com.adevinta.spark.components.buttons
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Shape
 import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.SparkTheme
@@ -49,7 +50,9 @@ public object ButtonTokens {
      * Used by overloads that delegate to [SparkButton].
      */
     public val buttonShape: ButtonShape
-        @Composable get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
+        @Composable
+        @ReadOnlyComposable
+        get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
             ButtonShape.Pill
         } else {
             SparkButtonDefaults.DefaultShape

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/CardDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/CardDefaults.kt
@@ -113,7 +113,6 @@ public object CardDefaults {
      * @param hoveredElevation the elevation used when the [Card] is hovered.
      * @param draggedElevation the elevation used when the [Card] is dragged.
      */
-    @Composable
     public fun cardElevation(
         defaultElevation: Dp = ElevationTokens.Level0,
         pressedElevation: Dp = ElevationTokens.Level0,
@@ -141,7 +140,6 @@ public object CardDefaults {
      * @param hoveredElevation the elevation used when the [ElevatedCard] is hovered.
      * @param draggedElevation the elevation used when the [ElevatedCard] is dragged.
      */
-    @Composable
     public fun elevatedCardElevation(
         defaultElevation: Dp = ElevationTokens.Level2,
         pressedElevation: Dp = ElevationTokens.Level3,
@@ -169,7 +167,6 @@ public object CardDefaults {
      * @param hoveredElevation the elevation used when the [OutlinedCard] is hovered.
      * @param draggedElevation the elevation used when the [OutlinedCard] is dragged.
      */
-    @Composable
     public fun outlinedCardElevation(
         defaultElevation: Dp = ElevationTokens.Level0,
         pressedElevation: Dp = defaultElevation,
@@ -186,7 +183,6 @@ public object CardDefaults {
         disabledElevation = disabledElevation,
     )
 
-    @Composable
     public fun paddingValues(): PaddingValues = PaddingValues(16.dp)
 
     internal object OutlinedCardTokens {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipTokens.kt
@@ -22,6 +22,7 @@
 package com.adevinta.spark.components.chips
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -49,7 +50,9 @@ public object ChipTokens {
      * The resolved spacing between the leading icon and the label.
      */
     public val leadingIconSpacing: Dp
-        @Composable get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
+        @Composable
+        @ReadOnlyComposable
+        get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
             8.dp
         } else {
             4.dp

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
@@ -21,6 +21,7 @@
  */
 package com.adevinta.spark.components.dialog
 
+import android.annotation.SuppressLint
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -49,6 +50,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.movableContentWithReceiverOf
 import androidx.compose.runtime.remember
@@ -124,8 +126,8 @@ public fun ModalScaffold(
     contentPadding: PaddingValues = DialogPadding,
     contentWindowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
     snackbarHost: @Composable () -> Unit = {},
-    mainButton: (@Composable (Modifier) -> Unit)? = null,
-    supportButton: (@Composable (Modifier) -> Unit)? = null,
+    @SuppressLint("SlotReused") mainButton: (@Composable (Modifier) -> Unit)? = null,
+    @SuppressLint("SlotReused") supportButton: (@Composable (Modifier) -> Unit)? = null,
     title: @Composable () -> Unit = {},
     actions: @Composable RowScope.() -> Unit = {},
     inEdgeToEdge: Boolean = LocalSparkFeatureFlag.current.isContainingActivityEdgeToEdge,
@@ -466,6 +468,7 @@ private fun CloseIconButton(onClose: () -> Unit) {
 
 @Suppress("DEPRECATION")
 @Composable
+@ReadOnlyComposable
 private fun SetUpEdgeToEdgeDialog() {
     val window = (LocalView.current.parent as DialogWindowProvider).window
     window.statusBarColor = Color.Transparent.toArgb()

--- a/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
@@ -625,7 +625,6 @@ private fun MenuItemColors.textColor(
  *
  * @param enabled whether the menu item is enabled
  */
-@Composable
 private fun MenuItemColors.leadingIconColor(enabled: Boolean): Color =
     if (enabled) leadingIconColor else disabledLeadingIconColor
 
@@ -634,7 +633,6 @@ private fun MenuItemColors.leadingIconColor(enabled: Boolean): Color =
  *
  * @param enabled whether the menu item is enabled
  */
-@Composable
 private fun MenuItemColors.trailingIconColor(enabled: Boolean): Color =
     if (enabled) trailingIconColor else disabledTrailingIconColor
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressTracker.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressTracker.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -286,6 +287,7 @@ internal enum class LayoutOrientation {
 }
 
 @Composable
+@ReadOnlyComposable
 internal fun progressTrackerMeasurePolicy(
     orientation: LayoutOrientation,
     indicatorSize: TextUnit,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingSmall.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingSmall.kt
@@ -26,6 +26,7 @@ import androidx.annotation.FloatRange
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -204,6 +205,7 @@ internal enum class RatingSize {
 }
 
 @Composable
+@ReadOnlyComposable
 internal fun firstLocale(): Locale = LocalConfiguration.current.locales[0]
 
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/segmentedcontrol/SegmentedControlTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/segmentedcontrol/SegmentedControlTokens.kt
@@ -77,13 +77,9 @@ public object SegmentedControlTokens {
         get() = SparkTheme.shapes.extraLarge
 
     public val ItemHorizontalShape: Shape
-        @Composable
-        @ReadOnlyComposable
         get() = RoundedCornerShape(24.0.dp)
 
     public val ContainerVerticalShape: Shape
-        @Composable
-        @ReadOnlyComposable
         get() = RoundedCornerShape(20.0.dp)
     public val IndicatorBorderWidth: Dp = 2.dp
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/StepperTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/StepperTokens.kt
@@ -46,10 +46,8 @@ public object StepperTokens {
         get() = SparkTheme.colors.outlineHigh
 
     public val borderThickness: Dp
-        @Composable @ReadOnlyComposable
         get() = 1.dp
     public val borderFocusedThickness: Dp
-        @Composable @ReadOnlyComposable
         get() = 2.dp
 
     @Immutable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabDefaults.kt
@@ -23,6 +23,7 @@ package com.adevinta.spark.components.tab
 
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
@@ -33,7 +34,9 @@ import com.adevinta.spark.components.icons.IconSize.Small
 internal object TabDefaults {
     /** Default content color of a tab */
     val ContentColor: Color
-        @Composable get() = LocalContentColor.current
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalContentColor.current
 
     /** Default intent color of a selected tab */
     internal val SelectedContentIntent = TabIntent.Support

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/DefaultSparkTextFieldColors.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/DefaultSparkTextFieldColors.kt
@@ -277,7 +277,7 @@ internal data class DefaultSparkTextFieldColors(
      * Represents the colors used for text selection in this text field.
      */
     internal val selectionColors: TextSelectionColors
-        @Composable get() = textSelectionColors
+        get() = textSelectionColors
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
@@ -1517,9 +1517,8 @@ public val Color.disabled: Color
  * Returns this [Color] with an alpha of zero. Use this when animating from transparent to a colour,
  * because [Color.Transparent] is opaque black under the hood and produces a black flash.
  */
-@get:SuppressLint("ComposeUnstableReceiver") // https://github.com/slackhq/compose-lints/issues/326
 public val Color.transparent: Color
-    @Composable get() = this.copy(alpha = 0f)
+    get() = this.copy(alpha = 0f)
 
 /**
  * Updates the internal values of the given [SparkColors] with values from the [other] [SparkColors]. This

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Layout.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Layout.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -62,7 +63,9 @@ import com.adevinta.spark.tools.preview.DevicePreviews
 public object Layout {
 
     public val windowSize: WindowSizeClass
-        @Composable get() = LocalWindowSizeClass.current
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalWindowSizeClass.current
 
     public val bodyMargin: Dp
         @Composable get() = when {


### PR DESCRIPTION
We're still blocked until the fix https://github.com/slackhq/compose-lints/issues/558 is not released
