### PR TITLE
fix(image): attempt to add composition stacktrace when no size is defined

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApplication.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApplication.kt
@@ -37,6 +37,8 @@ public class CatalogApplication : Application() {
         setStrictModePolicy()
         if (isDebuggable()) {
             Composer.setDiagnosticStackTraceMode(ComposeStackTraceMode.SourceInformation)
+        } else {
+            Composer.setDiagnosticStackTraceMode(ComposeStackTraceMode.Auto)
         }
     }
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
@@ -109,10 +109,11 @@ public fun SparkImage(
         movableContentOf(emptyIcon)
     }
     val exceptionHandler = LocalSparkExceptionHandler.current
+    val compositionTrace = remember { Throwable("SparkImage was composed here") }
     SubcomposeAsyncImage(
         modifier = modifier
             .layout { measurable, constraints ->
-                constraints.checkThatImageHasDefinedSize(exceptionHandler, model)
+                constraints.checkThatImageHasDefinedSize(exceptionHandler, model, compositionTrace)
 
                 val placeable = measurable.measure(constraints)
                 layout(placeable.width, placeable.height) {
@@ -270,7 +271,11 @@ internal fun ImageIconState(
     }
 }
 
-private fun Constraints.checkThatImageHasDefinedSize(exceptionHandler: SparkExceptionHandler, model: Any?) {
+private fun Constraints.checkThatImageHasDefinedSize(
+    exceptionHandler: SparkExceptionHandler,
+    model: Any?,
+    compositionTrace: Throwable,
+) {
     val isWidthBounded = hasBoundedWidth
     val isHeightBounded = hasBoundedHeight
     val hasMinWidth = minWidth != 0
@@ -279,6 +284,7 @@ private fun Constraints.checkThatImageHasDefinedSize(exceptionHandler: SparkExce
         exceptionHandler.handleException(
             IllegalStateException(
                 "Image must have a bounded width but was hasBoundedWidth: $isWidthBounded for model: $model",
+                compositionTrace,
             ),
         )
     }
@@ -286,17 +292,24 @@ private fun Constraints.checkThatImageHasDefinedSize(exceptionHandler: SparkExce
         exceptionHandler.handleException(
             IllegalStateException(
                 "Image must have a bounded height but was hasBoundedHeight: $isHeightBounded for model: $model",
+                compositionTrace,
             ),
         )
     }
     if (!hasMinWidth) {
         exceptionHandler.handleException(
-            IllegalStateException("Image must have a minimum width but has minWidth: $minWidth for model: $model"),
+            IllegalStateException(
+                "Image must have a minimum width but has minWidth: $minWidth for model: $model",
+                compositionTrace,
+            ),
         )
     }
     if (!hasMinHeight) {
         exceptionHandler.handleException(
-            IllegalStateException("Image must have a minimum height but has minHeight: $minHeight for model: $model"),
+            IllegalStateException(
+                "Image must have a minimum height but has minHeight: $minHeight for model: $model",
+                compositionTrace,
+            ),
         )
     }
 }


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add a additional Exception to the current one but it'll be instantiated in the composition context

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->

Currently we only get that a Image is missing but we're missing the prcise location in the code since the Exception is outside of the composition context.
```
java.lang.IllegalStateException: Image must have a bounded height but was hasBoundedHeight: false for model: ImageRequest(context=android.view.ContextThemeWrapper@bc5d30, data=3, target=null, listener=null, memoryCacheKey=null, memoryCacheKeyExtras={}, diskCacheKey=null, fileSystem=NioSystemFileSystem, fetcherFactory=null, decoderFactory=null, interceptorCoroutineContext=EmptyCoroutineContext, fetcherCoroutineContext=Dispatchers.IO, decoderCoroutineContext=Dispatchers.IO, memoryCachePolicy=ENABLED, diskCachePolicy=ENABLED, networkCachePolicy=ENABLED, placeholderMemoryCacheKey=null, placeholderFactory=coil3.util.UtilsKt$EMPTY_IMAGE_FACTORY$1@c519e7d, errorFactory=coil3.util.UtilsKt$EMPTY_IMAGE_FACTORY$1@c519e7d, fallbackFactory=coil3.util.UtilsKt$EMPTY_IMAGE_FACTORY$1@c519e7d, sizeResolver=RealSizeResolver(size=Size(width=Undefined, height=Undefined)), scale=FIT, precision=EXACT, extras=Extras(data={coil3.Extras$Key@bdcc037=coil3.transition.CrossfadeTransition$Factory@eb8c172}), defined=Defined(fileSystem=null, interceptorCoroutineContext=null, fetcherCoroutineContext=null, decoderCoroutineContext=null, memoryCachePolicy=null, diskCachePolicy=null, networkCachePolicy=null, placeholderFactory=coil3.util.UtilsKt$EMPTY_IMAGE_FACTORY$1@c519e7d, errorFactory=coil3.util.UtilsKt$EMPTY_IMAGE_FACTORY$1@c519e7d, fallbackFactory=coil3.util.UtilsKt$EMPTY_IMAGE_FACTORY$1@c519e7d, sizeResolver=null, scale=null, precision=null), defaults=Defaults(fileSystem=NioSystemFileSystem, interceptorCoroutineContext=EmptyCoroutineContext, fetcherCoroutineContext=Dispatchers.IO, decoderCoroutineContext=Dispatchers.IO, memoryCachePolicy=ENABLED, diskCachePolicy=ENABLED, networkCachePolicy=ENABLED, placeholderFactory=coil3.util.UtilsKt$EMPTY_IMAGE_FACTORY$1@c519e7d, errorFactory=coil3.util.UtilsKt$EMPTY_IMAGE_FACTORY$1@c519e7d, fallbackFactory=coil3.util.UtilsKt$EMPTY_IMAGE_FACTORY$1@c519e7d, sizeResolver=RealSizeResolver(size=Size(width=Undefined, height=Undefined)), scale=FIT, precision=EXACT, extras=Extras(data={})))
   at com.adevinta.spark.components.image.ImageKt.checkThatImageHasDefinedSize-jYbf7pk(Image.kt:293)
   at com.adevinta.spark.components.image.ImageKt.SparkImage_NSYyRI0$lambda$2$0(Image.kt:116)
   at com.adevinta.spark.components.image.ImageKt.$r8$lambda$KUXx5NJefK8N8dfT0JjyzwONz_g(Unknown Source:0)
   at com.adevinta.spark.components.image.ImageKt$$ExternalSyntheticLambda3.invoke(D8$$SyntheticClass:0)
   at androidx.compose.ui.layout.LayoutModifierImpl.measure-3p2s80s(LayoutModifier.kt:278)
```
Now it'll add these information in addition to the first one
```
Caused by: java.lang.Throwable: SparkImage was composed here
   at com.adevinta.spark.components.image.ImageKt.SparkImage-NSYyRI0(Image.kt:112)
   at com.adevinta.spark.catalog.configurator.samples.image.ImageConfiguratorKt.ImageSample$lambda$28(ImageConfigurator.kt:149) (Fix with AI)
   at com.adevinta.spark.catalog.configurator.samples.image.ImageConfiguratorKt$$ExternalSyntheticLambda2.invoke(D8$$SyntheticClass:0)
```

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
