### PR TITLE
chore: remove `androidx.compose.material:material-icons*` dependencies

### DIFF
--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -71,7 +71,6 @@ dependencies {
 
     api(libs.androidx.compose.animation.graphics)
     api(libs.androidx.compose.foundation)
-    implementation(libs.androidx.compose.material.iconsExtended)
     api(libs.androidx.compose.material3)
     api(libs.androidx.compose.material3.adaptive)
     api(libs.androidx.compose.ui)

--- a/spark/dependencies/releaseRuntimeClasspath.txt
+++ b/spark/dependencies/releaseRuntimeClasspath.txt
@@ -26,10 +26,6 @@ androidx.compose.material3.adaptive:adaptive-android:1.2.0
 androidx.compose.material3.adaptive:adaptive:1.2.0
 androidx.compose.material3:material3-android:1.4.0
 androidx.compose.material3:material3:1.4.0
-androidx.compose.material:material-icons-core-android:1.7.8
-androidx.compose.material:material-icons-core:1.7.8
-androidx.compose.material:material-icons-extended-android:1.7.8
-androidx.compose.material:material-icons-extended:1.7.8
 androidx.compose.material:material-ripple-android:1.11.2
 androidx.compose.material:material-ripple:1.11.2
 androidx.compose.runtime:runtime-android:1.11.2
@@ -161,7 +157,6 @@ org.jetbrains.compose.ui:ui-unit:1.11.1
 org.jetbrains.compose.ui:ui-util:1.11.1
 org.jetbrains.compose.ui:ui:1.11.1
 org.jetbrains.kotlin:kotlin-bom:2.3.21
-org.jetbrains.kotlin:kotlin-stdlib-common:2.3.21
 org.jetbrains.kotlin:kotlin-stdlib:2.3.21
 org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.4.0
 org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
@@ -23,11 +23,8 @@ package com.adevinta.spark.components.dialog
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AlertDialogDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -40,7 +37,9 @@ import com.adevinta.spark.ExperimentalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.buttons.ButtonGhost
 import com.adevinta.spark.components.buttons.IconSide
+import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.icons.CopyFill
+import com.adevinta.spark.icons.HeartFill
 import com.adevinta.spark.icons.LeboncoinIcons
 
 @ExperimentalSparkApi
@@ -153,7 +152,7 @@ internal fun AlertDialogPreview() {
                 // button. If you want to disable that functionality, simply use an empty
                 // onDismissRequest.
             },
-            icon = { Icon(Icons.Filled.Favorite, contentDescription = null) },
+            icon = { Icon(LeboncoinIcons.HeartFill, contentDescription = null) },
             title = {
                 Text(
                     modifier = Modifier

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
@@ -28,10 +28,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Email
-import androidx.compose.material.icons.filled.Face
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.DismissibleDrawerSheet
 import androidx.compose.material3.DrawerDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -51,6 +47,11 @@ import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.icons.HappyFaceFill
+import com.adevinta.spark.icons.HeartFill
+import com.adevinta.spark.icons.LeboncoinIcons
+import com.adevinta.spark.icons.LetterFill
+import com.adevinta.spark.res.resources
 import com.adevinta.spark.tokens.contentColorFor
 
 @SuppressLint("MaterialComposableHasSparkReplacement") // We're wrapping the material component
@@ -123,7 +124,7 @@ internal fun DismissibleDrawerSheetPreview() {
         padding = PaddingValues(0.dp),
     ) {
         // icons to mimic drawer destinations
-        val items = listOf(Icons.Default.Favorite, Icons.Default.Face, Icons.Default.Email)
+        val items = listOf(LeboncoinIcons.HeartFill, LeboncoinIcons.HappyFaceFill, LeboncoinIcons.LetterFill)
         val selectedItem = remember { mutableStateOf(items[0]) }
 
         DismissibleDrawerSheet {
@@ -131,7 +132,7 @@ internal fun DismissibleDrawerSheetPreview() {
             items.forEach { item ->
                 NavigationDrawerItem(
                     icon = { Icon(item, contentDescription = null) },
-                    label = { Text(item.name) },
+                    label = { Text(resources().getResourceName(item.drawableId).substringAfterLast("/")) },
                     selected = item == selectedItem.value,
                     onClick = {
                         selectedItem.value = item

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
@@ -50,7 +50,7 @@ import androidx.compose.material3.OutlinedIconButton as MaterialOutlinedIconButt
  *
  * ![Standard icon button image](https://developer.android.com/images/reference/androidx/compose/material3/standard-icon-button.png)
  *
- * [content] should typically be an [Icon] (see [androidx.compose.material.icons.Icons]). If using a
+ * [content] should typically be an [Icon]. If using a
  * custom icon, note that the typical size for the internal icon is 24 x 24 dp.
  * This icon button has an overall minimum touch target size of 48 x 48dp, to meet accessibility
  * guidelines.
@@ -96,7 +96,7 @@ public fun IconButton(
  *
  * ![Filled icon button image](https://developer.android.com/images/reference/androidx/compose/material3/filled-icon-button.png)
  *
- * [content] should typically be an [Icon] (see [androidx.compose.material.icons.Icons]). If using a
+ * [content] should typically be an [Icon]. If using a
  * custom icon, note that the typical size for the internal icon is 24 x 24 dp.
  * This icon button has an overall minimum touch target size of 48 x 48dp, to meet accessibility
  * guidelines.
@@ -151,7 +151,7 @@ public fun FilledIconButton(
  * They can be used in contexts where the lower-priority icon button requires slightly more emphasis
  * than an outline would give.
  *
- * [content] should typically be an [Icon] (see [androidx.compose.material.icons.Icons]). If using a
+ * [content] should typically be an [Icon]. If using a
  * custom icon, note that the typical size for the internal icon is 24 x 24 dp.
  * This icon button has an overall minimum touch target size of 48 x 48dp, to meet accessibility
  * guidelines.
@@ -209,7 +209,7 @@ public fun FilledTonalIconButton(
  * Use this "contained" icon button when the component requires more visual separation from the
  * background.
  *
- * [content] should typically be an [Icon] (see [androidx.compose.material.icons.Icons]). If using a
+ * [content] should typically be an [Icon]. If using a
  * custom icon, note that the typical size for the internal icon is 24 x 24 dp.
  * The outlined icon button has an overall minimum touch target size of 48 x 48dp, to meet
  * accessibility guidelines.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
@@ -50,7 +50,7 @@ import androidx.compose.material3.OutlinedIconToggleButton as MaterialOutlinedIc
  *
  * ![Standard icon toggle button image](https://developer.android.com/images/reference/androidx/compose/material3/standard-icon-toggle-button.png)
  *
- * [content] should typically be an [Icon] (see [androidx.compose.material.icons.Icons]). If using a
+ * [content] should typically be an [Icon]. If using a
  * custom icon, note that the typical size for the internal icon is 24 x 24 dp.
  * This icon button has an overall minimum touch target size of 48 x 48dp, to meet accessibility
  * guidelines.
@@ -98,7 +98,7 @@ public fun IconToggleButton(
  *
  * ![Filled icon toggle button image](https://developer.android.com/images/reference/androidx/compose/material3/filled-icon-toggle-button.png)
  *
- * [content] should typically be an [Icon] (see [androidx.compose.material.icons.Icons]). If using a
+ * [content] should typically be an [Icon]. If using a
  * custom icon, note that the typical size for the internal icon is 24 x 24 dp.
  * This icon button has an overall minimum touch target size of 48 x 48dp, to meet accessibility
  * guidelines.
@@ -156,7 +156,7 @@ public fun FilledIconToggleButton(
  * They can be used in contexts where the lower-priority icon button requires slightly more emphasis
  * than an outline would give.
  *
- * [content] should typically be an [Icon] (see [androidx.compose.material.icons.Icons]). If using a
+ * [content] should typically be an [Icon]. If using a
  * custom icon, note that the typical size for the internal icon is 24 x 24 dp.
  * This icon button has an overall minimum touch target size of 48 x 48dp, to meet accessibility
  * guidelines.
@@ -211,7 +211,7 @@ public fun FilledTonalIconToggleButton(
  *
  * ![Outlined icon toggle button image](https://developer.android.com/images/reference/androidx/compose/material3/outlined-icon-toggle-button.png)
  *
- * [content] should typically be an [Icon] (see [androidx.compose.material.icons.Icons]). If using a
+ * [content] should typically be an [Icon]. If using a
  * custom icon, note that the typical size for the internal icon is 24 x 24 dp.
  * This icon button has an overall minimum touch target size of 48 x 48dp, to meet accessibility
  * guidelines.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextField.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextField.kt
@@ -47,11 +47,8 @@ import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.material3.TextFieldDefaults
@@ -87,8 +84,9 @@ import com.adevinta.spark.R
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.icons.HeartFill
+import com.adevinta.spark.icons.LeboncoinIcons
 import com.adevinta.spark.tokens.EmphasizeDim3
-import com.adevinta.spark.tools.modifiers.SlotArea
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 
 // FIXME: Duplicate of Material OutlinedTextField while the counter is not supported on their end
@@ -640,13 +638,11 @@ internal val TextFieldMinHeight = 44.dp
 internal fun TextFieldSlotsPreview() {
     PreviewTheme {
         val icon: @Composable (AddonScope.() -> Unit) = @Composable {
-            SlotArea(color = LocalContentColor.current) {
-                Icon(
-                    imageVector = Icons.Filled.Favorite,
-                    contentDescription = null,
-                    modifier = Modifier.size(ButtonDefaults.IconSize),
-                )
-            }
+            Icon(
+                sparkIcon = LeboncoinIcons.HeartFill,
+                contentDescription = null,
+                modifier = Modifier.size(ButtonDefaults.IconSize),
+            )
         }
 
         TextField(


### PR DESCRIPTION
from the main production artifact, and replace them with LeboncoinIcons.