### PR TITLE
chore(ci): add setup-kotlin action to install Kotlin 2.3.21

### DIFF
--- a/.github/actions/setup-kotlin/action.yml
+++ b/.github/actions/setup-kotlin/action.yml
@@ -1,0 +1,33 @@
+name: '🤖 Setup Kotlin'
+description: 'Kotlin setup'
+
+inputs:
+  kotlin-version:
+    description: 'Kotlin version'
+    # Don't use 2.4.0 as it breaks our kotlin scripts, it should be fixed in 2.4.10. see KT-86352
+    default: '2.3.21'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v5
+      id: cache
+      with:
+        path: ~/.kotlin
+        key: kotlin-${{ inputs.kotlin-version }}-${{ runner.os }}
+
+    - name: 'Installing Kotlin v${{ inputs.kotlin-version }}'
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir --parents ~/.kotlin
+        wget --no-verbose -O "$KOTLIN_ZIP" "$KOTLIN_URL"
+        unzip "$KOTLIN_ZIP" -d ~/.kotlin
+      env:
+        KOTLIN_URL: https://github.com/JetBrains/kotlin/releases/download/v${{ inputs.kotlin-version }}/kotlin-compiler-${{ inputs.kotlin-version }}.zip
+        KOTLIN_ZIP: ${{ runner.temp }}/kotlin-${{ inputs.kotlin-version }}.zip
+
+    - name: 'Add Kotlin to PATH'
+      shell: bash
+      run: echo "$HOME/.kotlin/kotlinc/bin" >> $GITHUB_PATH

--- a/.github/actions/setup-kotlin/action.yml
+++ b/.github/actions/setup-kotlin/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         mkdir --parents ~/.kotlin
-        wget --no-verbose -O "$KOTLIN_ZIP" "$KOTLIN_URL"
+        wget --https-only --no-verbose -O "$KOTLIN_ZIP" "$KOTLIN_URL"
         unzip "$KOTLIN_ZIP" -d ~/.kotlin
       env:
         KOTLIN_URL: https://github.com/JetBrains/kotlin/releases/download/v${{ inputs.kotlin-version }}/kotlin-compiler-${{ inputs.kotlin-version }}.zip
@@ -30,4 +30,5 @@ runs:
 
     - name: 'Add Kotlin to PATH'
       shell: bash
+      # zizmor: ignore[github-env] -- path is hardcoded, no external input reaches it
       run: echo "$HOME/.kotlin/kotlinc/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,8 @@ jobs:
           count=$(grep -r --include="*.kt" -c "@Test" spark-screenshot-testing/src/test | awk -F: '{s+=$2} END {print s}')
           echo "count=$count" >> $GITHUB_OUTPUT
 
+      - uses: ./.github/actions/setup-kotlin
+
       - name: Submit library metrics
         run: kotlin scripts/datadog/library-metrics.main.kts -- --project-dir .
         env:

--- a/.github/workflows/pr-icon-updates.yml
+++ b/.github/workflows/pr-icon-updates.yml
@@ -40,6 +40,7 @@ jobs:
           cp -r spark-icons/icons/. spark-icons/src/androidMain/res/drawable/
           cp -r spark-icons/icons/. spark-icons/src/nonAndroidMain/composeResources/drawable/
           rm -rf spark-icons/icons
+      - uses: ./.github/actions/setup-kotlin
       - run: |
           ./scripts/spark-icons-kt/spark-icons-kt.main.kts \
             --in=spark-icons/src/androidMain/res/drawable \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-kotlin
 
       - name: Submit release cadence metric
         run: |


### PR DESCRIPTION
## 📋 Changes
- Create `setup-kotlin` action to install and pin Kotlin 2.3.21, working around Kotlin 2.4.0
FIR bug with `@file:Import` ([KT-86352](https://youtrack.jetbrains.com/issue/KT-86352/K2-scripting-FirResolvedTypeRef-exception-when-resolving-extension-functions-from-imported-scripts))
- Wire setup-kotlin into any workflow that call a kotlin script

## 🤔 Context

Kotlin 2.4.0 breaks the icon generation script due to a compiler bug in FIR type
resolution across `@file:Import` boundaries. Install Kotlin 2.3.21 before running the
script.

## ✅ Checklist

- [x] I have reviewed the submitted code.
