### PR TITLE
feat(card): card highlight outlined

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/card/CardHighlightedConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/card/CardHighlightedConfigurator.kt
@@ -195,7 +195,7 @@ private fun ConfiguredHighlightedCard(
                         modifier = Modifier.fillMaxWidth(),
                         onClick = onClick,
                         shape = shape,
-                        colors = headingColor,
+                        headingColor = headingColor,
                         contentPadding = contentPadding,
                         heading = {
                             if (hasHeading) {
@@ -213,7 +213,7 @@ private fun ConfiguredHighlightedCard(
                     Card.HighlightFlat(
                         modifier = Modifier.fillMaxWidth(),
                         shape = shape,
-                        colors = headingColor,
+                        headingColor = headingColor,
                         contentPadding = contentPadding,
                         heading = {
                             if (hasHeading) {
@@ -237,7 +237,7 @@ private fun ConfiguredHighlightedCard(
                     modifier = modifier,
                     onClick = onClick,
                     shape = shape,
-                    colors = headingColor,
+                    headingColor = headingColor,
                     contentPadding = contentPadding,
                     heading = {
                         if (hasHeading) {
@@ -255,7 +255,7 @@ private fun ConfiguredHighlightedCard(
                 Card.HighlightElevated(
                     modifier = modifier,
                     shape = shape,
-                    colors = headingColor,
+                    headingColor = headingColor,
                     contentPadding = contentPadding,
                     heading = {
                         if (hasHeading) {

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardDocumentationScreenshots.kt
@@ -87,6 +87,15 @@ internal class CardDocumentationScreenshots {
             CardContent()
         }
     }
+
+    @Test
+    fun highlightOutlinedCard() = paparazzi.sparkDocSnapshot(color = { SparkTheme.colors.backgroundVariant }) {
+        Card.HighlightOutlined(
+            heading = { },
+        ) {
+            CardContent()
+        }
+    }
 }
 
 @Composable
@@ -105,7 +114,7 @@ private fun CardContent() {
         )
         Text(
             text = "Spark is a design system backed by open source code that helps teams build " +
-                "high-quality digital experiences. \uD83D\uDCA4",
+                    "high-quality digital experiences. \uD83D\uDCA4",
             style = SparkTheme.typography.body1,
         )
     }

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardDocumentationScreenshots.kt
@@ -114,7 +114,7 @@ private fun CardContent() {
         )
         Text(
             text = "Spark is a design system backed by open source code that helps teams build " +
-                    "high-quality digital experiences. \uD83D\uDCA4",
+                "high-quality digital experiences. \uD83D\uDCA4",
             style = SparkTheme.typography.body1,
         )
     }

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardScreenshot.kt
@@ -76,6 +76,9 @@ internal class CardScreenshot {
                     Card.HighlightElevated {
                         Text("This is an elevated card with a highlight banner.")
                     }
+                    Card.HighlightOutlined {
+                        Text("This is an outlined card with a highlight banner.")
+                    }
                 }
             }
         }

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/card/CardScreenshot.kt
@@ -155,7 +155,7 @@ internal class CardScreenshot {
                 }
 
                 Card.HighlightElevated(
-                    colors = SparkTheme.colors.accentContainer,
+                    headingColor = SparkTheme.colors.accentContainer,
                 ) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightElevatedCard.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightElevatedCard.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:21207cfaa71f360937ba0c89547661518f51ed13782671ea215babc4e096fd63
-size 68251
+oid sha256:cc555def84c4f26998e75099635f59cf416b049904e9d87524bfdbd70ea8c0f5
+size 43712

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightFlatCard.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightFlatCard.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c869bd2d5a7d5229ab9a93b52f0dade1b1fccd3861134de639130b67a22bd9c0
-size 69152
+oid sha256:1e1bc890a7d0bac4ca54a731d529b7b26a64af1bcbc8142198186797e576ab35
+size 43682

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightOutlinedCard.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightOutlinedCard.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b29db9ac3f23cf2fef13f899c81a31db95c2b1f5d115f353bc001d0328dbecf
+size 44567

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardScreenshot_cardColors_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardScreenshot_cardColors_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e22611d2feab21bc59d320719bcc768305906b1ddf5d861c353a0db0088db0e
-size 30970
+oid sha256:f910553bc2c63a10636f7d40eb740e6e5a085e4a812c1b8e0878785e055ae83d
+size 19740

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardScreenshot_cardColors_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardScreenshot_cardColors_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2fafc2c44151b954e4ef95913ddb39f38058b22377f373f8a38ad1b649f57e26
-size 26719
+oid sha256:76379afeebdd46e60f366ecac7e89704815e101f4e6e922d8374b05579f79119
+size 19754

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardScreenshot_cardShapes.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardScreenshot_cardShapes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f24f618c7a2c68c51892ecf7db4e5f144b8e0e1e221db6df4ca089a351dabab8
-size 80091
+oid sha256:733fed7aec0ec3c00a9c9215cca8851d53d28418f6698b7ed82302b4e35b3764
+size 35955

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardScreenshot_cardVariants_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardScreenshot_cardVariants_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa7a9edf5dc5ce0fc1aeecfa8c6973a952e0b98144b4628b29fcf8130846e937
-size 58851
+oid sha256:df98bd6f98797d9f27b95f8717386ada36f691b4f3855bd90aaf9f84a3d1ed58
+size 41403

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardScreenshot_cardVariants_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.card_CardScreenshot_cardVariants_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76fa817878518bb52aba07d1c4fbe8ca5cec4baf2421335180a01de19f362263
-size 61852
+oid sha256:3d75dfada346e3dee744af16ef0fe64dd05030668d5c6b0063d1bd7850dcf31e
+size 42056

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
@@ -228,7 +228,7 @@ internal fun SparkCard(
  */
 @Deprecated(
     message = "Use Card.Flat for a simple card with default styling, or use Card with" +
-            " CardColors for more customization",
+        " CardColors for more customization",
     replaceWith = ReplaceWith(
         "Card.Flat(modifier = modifier, shape = shape, content = content)",
         "com.adevinta.spark.components.card.Card",
@@ -706,7 +706,7 @@ public object Card {
  */
 @Deprecated(
     message = "Use Card.Flat with onClick for a clickable card with default styling, or use Card with " +
-            "onClick and CardColors for more customization",
+        "onClick and CardColors for more customization",
     replaceWith = ReplaceWith(
         "Card.Flat(onClick = onClick, modifier = modifier, shape = shape, content = content)",
         "com.adevinta.spark.components.card.Card",
@@ -992,7 +992,6 @@ internal fun PreviewInteractiveCard() {
 @Composable
 internal fun PreviewHighlightCard() {
     PreviewTheme(color = { SparkTheme.colors.backgroundVariant }) {
-
         HighlightOutlined(
             headingAndBorderColor = SparkTheme.colors.accent,
             heading = {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
@@ -609,7 +609,7 @@ public object Card {
     /**
      * Highlight outlined card with a colored banner at the top for additional emphasis.
      *
-     * ![Highlight outlined card](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightFlatCard.png)
+     * ![Highlight outlined card](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightOutlined.png)
      *
      * @param modifier the Modifier to be applied to this card
      * @param shape the shape of this card
@@ -644,7 +644,7 @@ public object Card {
     /**
      * Clickable outlined flat card with a colored banner at the top for additional emphasis.
      *
-     * ![Highlight outlined card](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightFlatCard.png)
+     * ![Highlight outlined card](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightOutlined.png)
      *
      * @param onClick called when this card is clicked
      * @param modifier the Modifier to be applied to this card

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
@@ -96,7 +96,7 @@ internal fun SparkCard(
     headingColor: Color = SparkTheme.colors.main,
     elevation: CardElevation = CardDefaults.cardElevation(),
     heading: @Composable (BoxScope.() -> Unit)? = null,
-    contentPadding: PaddingValues = CardDefaults.paddingValues(heading != null),
+    contentPadding: PaddingValues = CardDefaults.paddingValues(),
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val border = if (borderColor != Color.Unspecified) {
@@ -131,7 +131,7 @@ internal fun SparkCard(
     headingColor: Color = SparkTheme.colors.main,
     elevation: CardElevation = CardDefaults.cardElevation(),
     heading: @Composable (BoxScope.() -> Unit)? = null,
-    contentPadding: PaddingValues = CardDefaults.paddingValues(heading != null),
+    contentPadding: PaddingValues = CardDefaults.paddingValues(),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable ColumnScope.() -> Unit,
 ) {
@@ -481,7 +481,7 @@ public object Card {
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
         headingColor: Color = SparkTheme.colors.main,
-        contentPadding: PaddingValues = CardDefaults.paddingValues(true),
+        contentPadding: PaddingValues = CardDefaults.paddingValues(),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
     ) {
@@ -517,7 +517,7 @@ public object Card {
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
         headingColor: Color = SparkTheme.colors.main,
-        contentPadding: PaddingValues = CardDefaults.paddingValues(true),
+        contentPadding: PaddingValues = CardDefaults.paddingValues(),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
     ) {
@@ -552,7 +552,7 @@ public object Card {
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
         headingColor: Color = SparkTheme.colors.main,
-        contentPadding: PaddingValues = CardDefaults.paddingValues(true),
+        contentPadding: PaddingValues = CardDefaults.paddingValues(),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
     ) {
@@ -588,7 +588,7 @@ public object Card {
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
         headingColor: Color = SparkTheme.colors.main,
-        contentPadding: PaddingValues = CardDefaults.paddingValues(true),
+        contentPadding: PaddingValues = CardDefaults.paddingValues(),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
     ) {
@@ -624,7 +624,7 @@ public object Card {
         shape: Shape = SparkTheme.shapes.medium,
         headingAndBorderColor: Color = SparkTheme.colors.main,
         borderWidth: Dp = 2.dp,
-        contentPadding: PaddingValues = CardDefaults.paddingValues(true),
+        contentPadding: PaddingValues = CardDefaults.paddingValues(),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
     ) {
@@ -661,7 +661,7 @@ public object Card {
         shape: Shape = SparkTheme.shapes.medium,
         headingAndBorderColor: Color = SparkTheme.colors.main,
         borderWidth: Dp = 2.dp,
-        contentPadding: PaddingValues = CardDefaults.paddingValues(true),
+        contentPadding: PaddingValues = CardDefaults.paddingValues(),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
     ) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
@@ -27,23 +27,32 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.ExperimentalSparkApi
@@ -53,11 +62,14 @@ import com.adevinta.spark.components.card.Card.Elevated
 import com.adevinta.spark.components.card.Card.Flat
 import com.adevinta.spark.components.card.Card.HighlightElevated
 import com.adevinta.spark.components.card.Card.HighlightFlat
+import com.adevinta.spark.components.card.Card.HighlightOutlined
 import com.adevinta.spark.components.card.Card.Outlined
 import com.adevinta.spark.components.surface.Surface
 import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.tokens.contentColorFor
 import com.adevinta.spark.tokens.dim2
 import com.adevinta.spark.tokens.dim4
+import com.adevinta.spark.tokens.highlight
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 
 @Composable
@@ -89,7 +101,7 @@ internal fun SparkCard(
     borderColor: Color = SparkTheme.colors.outline,
     headingColor: Color = SparkTheme.colors.main,
     elevation: CardElevation = CardDefaults.cardElevation(),
-    heading: @Composable (() -> Unit)? = null,
+    heading: @Composable (BoxScope.() -> Unit)? = null,
     contentPadding: PaddingValues = CardDefaults.paddingValues(heading != null),
     content: @Composable ColumnScope.() -> Unit,
 ) {
@@ -107,7 +119,7 @@ internal fun SparkCard(
     ) {
         Column {
             if (heading != null) {
-                CardHeading(heading, headingColor, shape)
+                CardHeading(heading, headingColor)
             }
             Column(modifier = Modifier.padding(contentPadding), content = content)
         }
@@ -123,7 +135,7 @@ internal fun SparkCard(
     borderColor: Color = SparkTheme.colors.outline,
     headingColor: Color = SparkTheme.colors.main,
     elevation: CardElevation = CardDefaults.cardElevation(),
-    heading: @Composable (() -> Unit)? = null,
+    heading: @Composable (BoxScope.() -> Unit)? = null,
     contentPadding: PaddingValues = CardDefaults.paddingValues(heading != null),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable ColumnScope.() -> Unit,
@@ -146,7 +158,7 @@ internal fun SparkCard(
     ) {
         Column {
             if (heading != null) {
-                CardHeading(heading = heading, headingColor = headingColor, shape = shape)
+                CardHeading(heading = heading, headingColor = headingColor)
             }
             Column(modifier = Modifier.padding(contentPadding), content = content)
         }
@@ -155,26 +167,22 @@ internal fun SparkCard(
 
 @Composable
 private fun CardHeading(
-    heading: @Composable (() -> Unit),
+    heading: @Composable (BoxScope.() -> Unit),
     headingColor: Color,
-    shape: Shape,
 ) {
-    val cornerSize = if (shape is CornerBasedShape) shape.topStart else CornerSize(16.dp)
     Box(
         modifier = Modifier
-            .height(16.dp)
-            .fillMaxWidth()
-            .clip(CardHighlightShape(cornerSize))
-            .background(
-                brush = Brush.horizontalGradient(
-                    colors = listOf(
-                        headingColor.dim4,
-                        headingColor.dim2,
-                    ),
-                ),
-            ),
+            .background(headingColor)
+            .heightIn(min = 32.dp)
+            .wrapContentHeight()
+            .fillMaxWidth(),
+        contentAlignment = Alignment.Center,
     ) {
-        heading()
+        ProvideTextStyle(SparkTheme.typography.body2.highlight) {
+            CompositionLocalProvider(LocalContentColor provides contentColorFor(headingColor)) {
+                heading()
+            }
+        }
     }
 }
 
@@ -225,7 +233,7 @@ internal fun SparkCard(
  */
 @Deprecated(
     message = "Use Card.Flat for a simple card with default styling, or use Card with" +
-        " CardColors for more customization",
+            " CardColors for more customization",
     replaceWith = ReplaceWith(
         "Card.Flat(modifier = modifier, shape = shape, content = content)",
         "com.adevinta.spark.components.card.Card",
@@ -471,7 +479,7 @@ public object Card {
         shape: Shape = SparkTheme.shapes.medium,
         colors: Color = SparkTheme.colors.main,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
-        heading: @Composable (() -> Unit) = { },
+        heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
     ) {
         SparkCard(
@@ -506,7 +514,7 @@ public object Card {
         shape: Shape = SparkTheme.shapes.medium,
         colors: Color = SparkTheme.colors.main,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
-        heading: @Composable (() -> Unit) = { },
+        heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
     ) {
         SparkCard(
@@ -540,7 +548,7 @@ public object Card {
         shape: Shape = SparkTheme.shapes.medium,
         colors: Color = SparkTheme.colors.main,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
-        heading: @Composable (() -> Unit) = { },
+        heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
     ) {
         SparkCard(
@@ -575,7 +583,7 @@ public object Card {
         shape: Shape = SparkTheme.shapes.medium,
         colors: Color = SparkTheme.colors.main,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
-        heading: @Composable (() -> Unit) = { },
+        heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
     ) {
         SparkCard(
@@ -584,6 +592,75 @@ public object Card {
             shape = shape,
             headingColor = colors,
             borderColor = Color.Unspecified,
+            elevation = CardDefaults.cardElevation(),
+            contentPadding = contentPadding,
+            heading = heading,
+            content = content,
+        )
+    }
+
+    /**
+     * Highlight outlined card with a colored banner at the top for additional emphasis.
+     *
+     * ![Highlight outlined card](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightFlatCard.png)
+     *
+     * @param modifier the Modifier to be applied to this card
+     * @param shape the shape of this card
+     * @param colors color used for the heading banner and the card border
+     * @param contentPadding padding around the content
+     * @param heading optional composable drawn in the top banner area
+     * @param content content of the card
+     */
+    @Composable
+    public fun HighlightOutlined(
+        modifier: Modifier = Modifier,
+        shape: Shape = SparkTheme.shapes.medium,
+        colors: Color = SparkTheme.colors.main,
+        contentPadding: PaddingValues = CardDefaults.paddingValues(true),
+        heading: @Composable (BoxScope.() -> Unit) = { },
+        content: @Composable ColumnScope.() -> Unit,
+    ) {
+        SparkCard(
+            modifier = modifier,
+            shape = shape,
+            headingColor = colors,
+            borderColor = colors,
+            elevation = CardDefaults.cardElevation(),
+            contentPadding = contentPadding,
+            heading = heading,
+            content = content,
+        )
+    }
+
+    /**
+     * Clickable outlined flat card with a colored banner at the top for additional emphasis.
+     *
+     * ![Highlight outlined card](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.card_CardDocumentationScreenshots_highlightFlatCard.png)
+     *
+     * @param onClick called when this card is clicked
+     * @param modifier the Modifier to be applied to this card
+     * @param shape the shape of this card
+     * @param colors color used for the heading banner and the card border
+     * @param contentPadding padding around the content
+     * @param heading optional composable drawn in the top banner area
+     * @param content content of the card
+     */
+    @Composable
+    public fun HighlightOutlined(
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        shape: Shape = SparkTheme.shapes.medium,
+        colors: Color = SparkTheme.colors.main,
+        contentPadding: PaddingValues = CardDefaults.paddingValues(true),
+        heading: @Composable (BoxScope.() -> Unit) = { },
+        content: @Composable ColumnScope.() -> Unit,
+    ) {
+        SparkCard(
+            onClick = onClick,
+            modifier = modifier,
+            shape = shape,
+            headingColor = colors,
+            borderColor = colors,
             elevation = CardDefaults.cardElevation(),
             contentPadding = contentPadding,
             heading = heading,
@@ -618,7 +695,7 @@ public object Card {
  */
 @Deprecated(
     message = "Use Card.Flat with onClick for a clickable card with default styling, or use Card with " +
-        "onClick and CardColors for more customization",
+            "onClick and CardColors for more customization",
     replaceWith = ReplaceWith(
         "Card.Flat(onClick = onClick, modifier = modifier, shape = shape, content = content)",
         "com.adevinta.spark.components.card.Card",
@@ -904,17 +981,36 @@ internal fun PreviewInteractiveCard() {
 @Composable
 internal fun PreviewHighlightCard() {
     PreviewTheme(color = { SparkTheme.colors.backgroundVariant }) {
-        HighlightFlat {
+
+        HighlightOutlined(
+            colors = SparkTheme.colors.accent,
+            heading = {
+                Text(
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "Heading",
+                )
+            },
+        ) {
             Text(
-                text = "Card preview",
+                text = "Highlight Outlined Card preview",
+            )
+        }
+
+        HighlightFlat(
+            heading = { Text(text = "Heading") },
+        ) {
+            Text(
+                text = "Highlight Flat Card preview",
             )
         }
 
         HighlightElevated(
+            heading = { Text(text = "Heading") },
             onClick = {},
         ) {
             Text(
-                text = "Card preview",
+                text = "Highlight Elevated Card preview",
             )
         }
     }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
@@ -32,15 +32,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.CornerBasedShape
-import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -48,8 +44,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.style.TextAlign
@@ -68,8 +62,6 @@ import com.adevinta.spark.components.card.Card.Outlined
 import com.adevinta.spark.components.surface.Surface
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.tokens.contentColorFor
-import com.adevinta.spark.tokens.dim2
-import com.adevinta.spark.tokens.dim4
 import com.adevinta.spark.tokens.highlight
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 
@@ -479,7 +471,7 @@ public object Card {
      *
      * @param modifier the Modifier to be applied to this card
      * @param shape the shape of this card
-     * @param colors color used for the heading banner
+     * @param headingColor color used for the heading banner
      * @param contentPadding padding around the content
      * @param heading optional composable drawn in the top banner area
      * @param content content of the card
@@ -488,7 +480,7 @@ public object Card {
     public fun HighlightElevated(
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
-        colors: Color = SparkTheme.colors.main,
+        headingColor: Color = SparkTheme.colors.main,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
@@ -496,7 +488,7 @@ public object Card {
         SparkCard(
             modifier = modifier,
             shape = shape,
-            headingColor = colors,
+            headingColor = headingColor,
             borderColor = Color.Unspecified,
             borderWidth = Dp.Unspecified,
             elevation = CardDefaults.elevatedCardElevation(),
@@ -514,7 +506,7 @@ public object Card {
      * @param onClick called when this card is clicked
      * @param modifier the Modifier to be applied to this card
      * @param shape the shape of this card
-     * @param colors color used for the heading banner
+     * @param headingColor color used for the heading banner
      * @param contentPadding padding around the content
      * @param heading optional composable drawn in the top banner area
      * @param content content of the card
@@ -524,7 +516,7 @@ public object Card {
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
-        colors: Color = SparkTheme.colors.main,
+        headingColor: Color = SparkTheme.colors.main,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
@@ -533,7 +525,7 @@ public object Card {
             onClick = onClick,
             modifier = modifier,
             shape = shape,
-            headingColor = colors,
+            headingColor = headingColor,
             borderColor = Color.Unspecified,
             borderWidth = Dp.Unspecified,
             elevation = CardDefaults.elevatedCardElevation(),
@@ -550,7 +542,7 @@ public object Card {
      *
      * @param modifier the Modifier to be applied to this card
      * @param shape the shape of this card
-     * @param colors color used for the heading banner
+     * @param headingColor color used for the heading banner
      * @param contentPadding padding around the content
      * @param heading optional composable drawn in the top banner area
      * @param content content of the card
@@ -559,7 +551,7 @@ public object Card {
     public fun HighlightFlat(
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
-        colors: Color = SparkTheme.colors.main,
+        headingColor: Color = SparkTheme.colors.main,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
@@ -567,7 +559,7 @@ public object Card {
         SparkCard(
             modifier = modifier,
             shape = shape,
-            headingColor = colors,
+            headingColor = headingColor,
             borderColor = Color.Unspecified,
             borderWidth = Dp.Unspecified,
             elevation = CardDefaults.cardElevation(),
@@ -585,7 +577,7 @@ public object Card {
      * @param onClick called when this card is clicked
      * @param modifier the Modifier to be applied to this card
      * @param shape the shape of this card
-     * @param colors color used for the heading banner
+     * @param headingColor color used for the heading banner
      * @param contentPadding padding around the content
      * @param heading optional composable drawn in the top banner area
      * @param content content of the card
@@ -595,7 +587,7 @@ public object Card {
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
-        colors: Color = SparkTheme.colors.main,
+        headingColor: Color = SparkTheme.colors.main,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
@@ -604,7 +596,7 @@ public object Card {
             onClick = onClick,
             modifier = modifier,
             shape = shape,
-            headingColor = colors,
+            headingColor = headingColor,
             borderColor = Color.Unspecified,
             borderWidth = Dp.Unspecified,
             elevation = CardDefaults.cardElevation(),
@@ -621,7 +613,7 @@ public object Card {
      *
      * @param modifier the Modifier to be applied to this card
      * @param shape the shape of this card
-     * @param colors color used for the heading banner and the card border
+     * @param headingAndBorderColor color used for the heading banner and the card border
      * @param contentPadding padding around the content
      * @param heading optional composable drawn in the top banner area
      * @param content content of the card
@@ -630,7 +622,7 @@ public object Card {
     public fun HighlightOutlined(
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
-        colors: Color = SparkTheme.colors.main,
+        headingAndBorderColor: Color = SparkTheme.colors.main,
         borderWidth: Dp = 2.dp,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
         heading: @Composable (BoxScope.() -> Unit) = { },
@@ -639,8 +631,8 @@ public object Card {
         SparkCard(
             modifier = modifier,
             shape = shape,
-            headingColor = colors,
-            borderColor = colors,
+            headingColor = headingAndBorderColor,
+            borderColor = headingAndBorderColor,
             borderWidth = borderWidth,
             elevation = CardDefaults.cardElevation(),
             contentPadding = contentPadding,
@@ -657,7 +649,7 @@ public object Card {
      * @param onClick called when this card is clicked
      * @param modifier the Modifier to be applied to this card
      * @param shape the shape of this card
-     * @param colors color used for the heading banner and the card border
+     * @param headingAndBorderColor color used for the heading banner and the card border
      * @param contentPadding padding around the content
      * @param heading optional composable drawn in the top banner area
      * @param content content of the card
@@ -667,7 +659,7 @@ public object Card {
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
-        colors: Color = SparkTheme.colors.main,
+        headingAndBorderColor: Color = SparkTheme.colors.main,
         borderWidth: Dp = 2.dp,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
         heading: @Composable (BoxScope.() -> Unit) = { },
@@ -677,8 +669,8 @@ public object Card {
             onClick = onClick,
             modifier = modifier,
             shape = shape,
-            headingColor = colors,
-            borderColor = colors,
+            headingColor = headingAndBorderColor,
+            borderColor = headingAndBorderColor,
             borderWidth = borderWidth,
             elevation = CardDefaults.cardElevation(),
             contentPadding = contentPadding,
@@ -1002,7 +994,7 @@ internal fun PreviewHighlightCard() {
     PreviewTheme(color = { SparkTheme.colors.backgroundVariant }) {
 
         HighlightOutlined(
-            colors = SparkTheme.colors.accent,
+            headingAndBorderColor = SparkTheme.colors.accent,
             heading = {
                 Text(
                     textAlign = TextAlign.Center,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.ExperimentalSparkApi
 import com.adevinta.spark.PreviewTheme
@@ -99,6 +100,7 @@ internal fun SparkCard(
     shape: Shape = SparkTheme.shapes.large,
     colors: Color = SparkTheme.colors.surface,
     borderColor: Color = SparkTheme.colors.outline,
+    borderWidth: Dp = 1.dp,
     headingColor: Color = SparkTheme.colors.main,
     elevation: CardElevation = CardDefaults.cardElevation(),
     heading: @Composable (BoxScope.() -> Unit)? = null,
@@ -106,7 +108,7 @@ internal fun SparkCard(
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val border = if (borderColor != Color.Unspecified) {
-        BorderStroke(1.dp, borderColor)
+        BorderStroke(borderWidth, borderColor)
     } else {
         null
     }
@@ -133,6 +135,7 @@ internal fun SparkCard(
     shape: Shape = SparkTheme.shapes.large,
     color: Color = SparkTheme.colors.surface,
     borderColor: Color = SparkTheme.colors.outline,
+    borderWidth: Dp = 1.dp,
     headingColor: Color = SparkTheme.colors.main,
     elevation: CardElevation = CardDefaults.cardElevation(),
     heading: @Composable (BoxScope.() -> Unit)? = null,
@@ -143,7 +146,7 @@ internal fun SparkCard(
     val animatedBorderColor by animateColorAsState(borderColor)
     val animatedBackgroundColor by animateColorAsState(color)
     val border = if (borderColor != Color.Unspecified) {
-        BorderStroke(1.dp, animatedBorderColor)
+        BorderStroke(borderWidth, animatedBorderColor)
     } else {
         null
     }
@@ -292,6 +295,7 @@ public object Card {
             shape = shape,
             colors = colors,
             borderColor = Color.Unspecified,
+            borderWidth = Dp.Unspecified,
             elevation = CardDefaults.elevatedCardElevation(),
             contentPadding = contentPadding,
             content = content,
@@ -325,6 +329,7 @@ public object Card {
             shape = shape,
             color = colors,
             borderColor = Color.Unspecified,
+            borderWidth = Dp.Unspecified,
             elevation = CardDefaults.elevatedCardElevation(),
             contentPadding = contentPadding,
             content = content,
@@ -349,6 +354,7 @@ public object Card {
         shape: Shape = SparkTheme.shapes.medium,
         colors: Color = SparkTheme.colors.surface,
         borderColor: Color = SparkTheme.colors.outline,
+        borderWidth: Dp = 1.dp,
         contentPadding: PaddingValues = PaddingValues(16.dp),
         content: @Composable ColumnScope.() -> Unit,
     ) {
@@ -357,6 +363,7 @@ public object Card {
             shape = shape,
             colors = colors,
             borderColor = borderColor,
+            borderWidth = borderWidth,
             elevation = CardDefaults.outlinedCardElevation(),
             contentPadding = contentPadding,
             content = content,
@@ -383,6 +390,7 @@ public object Card {
         shape: Shape = SparkTheme.shapes.medium,
         colors: Color = SparkTheme.colors.surface,
         borderColor: Color = SparkTheme.colors.outline,
+        borderWidth: Dp = 1.dp,
         contentPadding: PaddingValues = PaddingValues(16.dp),
         content: @Composable ColumnScope.() -> Unit,
     ) {
@@ -392,6 +400,7 @@ public object Card {
             shape = shape,
             color = colors,
             borderColor = borderColor,
+            borderWidth = borderWidth,
             elevation = CardDefaults.outlinedCardElevation(),
             contentPadding = contentPadding,
             content = content,
@@ -422,6 +431,7 @@ public object Card {
             shape = shape,
             colors = colors,
             borderColor = Color.Unspecified,
+            borderWidth = Dp.Unspecified,
             elevation = CardDefaults.cardElevation(),
             contentPadding = contentPadding,
             content = content,
@@ -455,6 +465,7 @@ public object Card {
             shape = shape,
             color = colors,
             borderColor = Color.Unspecified,
+            borderWidth = Dp.Unspecified,
             elevation = CardDefaults.cardElevation(),
             contentPadding = contentPadding,
             content = content,
@@ -487,6 +498,7 @@ public object Card {
             shape = shape,
             headingColor = colors,
             borderColor = Color.Unspecified,
+            borderWidth = Dp.Unspecified,
             elevation = CardDefaults.elevatedCardElevation(),
             contentPadding = contentPadding,
             heading = heading,
@@ -523,6 +535,7 @@ public object Card {
             shape = shape,
             headingColor = colors,
             borderColor = Color.Unspecified,
+            borderWidth = Dp.Unspecified,
             elevation = CardDefaults.elevatedCardElevation(),
             contentPadding = contentPadding,
             heading = heading,
@@ -556,6 +569,7 @@ public object Card {
             shape = shape,
             headingColor = colors,
             borderColor = Color.Unspecified,
+            borderWidth = Dp.Unspecified,
             elevation = CardDefaults.cardElevation(),
             contentPadding = contentPadding,
             heading = heading,
@@ -592,6 +606,7 @@ public object Card {
             shape = shape,
             headingColor = colors,
             borderColor = Color.Unspecified,
+            borderWidth = Dp.Unspecified,
             elevation = CardDefaults.cardElevation(),
             contentPadding = contentPadding,
             heading = heading,
@@ -616,6 +631,7 @@ public object Card {
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
         colors: Color = SparkTheme.colors.main,
+        borderWidth: Dp = 2.dp,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
@@ -625,6 +641,7 @@ public object Card {
             shape = shape,
             headingColor = colors,
             borderColor = colors,
+            borderWidth = borderWidth,
             elevation = CardDefaults.cardElevation(),
             contentPadding = contentPadding,
             heading = heading,
@@ -651,6 +668,7 @@ public object Card {
         modifier: Modifier = Modifier,
         shape: Shape = SparkTheme.shapes.medium,
         colors: Color = SparkTheme.colors.main,
+        borderWidth: Dp = 2.dp,
         contentPadding: PaddingValues = CardDefaults.paddingValues(true),
         heading: @Composable (BoxScope.() -> Unit) = { },
         content: @Composable ColumnScope.() -> Unit,
@@ -661,6 +679,7 @@ public object Card {
             shape = shape,
             headingColor = colors,
             borderColor = colors,
+            borderWidth = borderWidth,
             elevation = CardDefaults.cardElevation(),
             contentPadding = contentPadding,
             heading = heading,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/CardDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/CardDefaults.kt
@@ -187,8 +187,7 @@ public object CardDefaults {
     )
 
     @Composable
-    public fun paddingValues(hasHeading: Boolean): PaddingValues =
-        PaddingValues(16.dp)
+    public fun paddingValues(): PaddingValues = PaddingValues(16.dp)
 
     internal object OutlinedCardTokens {
         const val DisabledOutlineOpacity = 0.12f

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/CardDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/CardDefaults.kt
@@ -187,16 +187,8 @@ public object CardDefaults {
     )
 
     @Composable
-    public fun paddingValues(hasHeading: Boolean): PaddingValues = if (hasHeading) {
-        PaddingValues(
-            top = 8.dp,
-            start = 16.dp,
-            end = 16.dp,
-            bottom = 16.dp,
-        )
-    } else {
+    public fun paddingValues(hasHeading: Boolean): PaddingValues =
         PaddingValues(16.dp)
-    }
 
     internal object OutlinedCardTokens {
         const val DisabledOutlineOpacity = 0.12f


### PR DESCRIPTION
## 📋 Changes

Introduce a new type of card : HighlightOutlined. 
This card displays a heading and borders.
Heading and broder share the same color.

## 🤔 Context

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

## 🗒️ Other info
