### PR TITLE
fix(catalog): use correct drawable prefix when navigating to icon detail

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/Navigation.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/Navigation.kt
@@ -97,7 +97,7 @@ private fun getAnimatedIcon(name: String): SparkIcon.AnimatedPainter =
 
 @SuppressLint("DiscouragedApi")
 private fun getDrawableIcon(context: Context, name: String): SparkIcon.DrawableRes {
-    val resourceName = "spark_icons_${name.toSnakeCase()}"
+    val resourceName = "spark_icons_lbc_${name.toSnakeCase()}"
     val resId = context.resources.getIdentifier(resourceName, "drawable", context.packageName)
     check(resId != 0) { "Icon $name no found in resources" }
     return SparkIcon.DrawableRes(resId)


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

  - Fixes a crash when tapping an icon in the catalog's icon grid
  - getDrawableIcon was constructing the resource name with the spark_icons_ prefix, but drawable resources use spark_icons_lbc_. This caused getIdentifier to return 0 and the subsequent check to throw an IllegalStateException


## 🤔 Context

when tapping an icon in the catalog's icon grid a crash was produced in the app.
This PR fixes it.

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [X] I have reviewed the submitted code.
- [X] I have tested on a phone device/emulator.
## 🗒️ Test plan

  - [ ] Open the catalog app and navigate to the Icons screen
  - [ ] Tap any non-animated icon — verify the detail screen opens without crashing
  - [ ] Tap an animated icon — verify it still works (different code path, unaffected)
  - [ ] Deep link into an icon detail via spark://icons/detail?iconName=ActionsFill&isIconAnimated=false

<!-- Feel free to add any other info here if needed -->
