### PR TITLE
docs: polish and correct code comments across the codebase

### DIFF
--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidPlugin.kt
@@ -25,6 +25,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
+/** Configures Kotlin and Android build settings shared across all Android modules. */
 public class SparkAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkMultiplatformPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkMultiplatformPlugin.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 @OptIn(ExperimentalKotlinGradlePluginApi::class)
+/* Configures Kotlin Multiplatform targets, source sets, and compiler options for Spark modules. */
 public class SparkMultiplatformPlugin : Plugin<Project> {
     override fun apply(target: Project): Unit = with(target) {
         with(pluginManager) {
@@ -46,7 +47,8 @@ public class SparkMultiplatformPlugin : Plugin<Project> {
 
             compilerOptions {
                 freeCompilerArgs.addAll(
-                    // Suppress warning: The feature "multi platform projects" is experimental and should be enabled explicitly
+                    // Suppress warning: The feature "multi platform projects" is experimental and should be
+                    // enabled explicitly
                     "-Xmulti-platform",
                 )
                 if (hasSparkInternalAnnotations) {

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublication.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublication.kt
@@ -82,10 +82,10 @@ internal object SparkPublication {
         publications {
             if (isKotlinMultiplatform) {
                 // KMP auto-generates per-target publications (kotlinMultiplatform, android, jvm…).
-                // Don't register a competing "maven" publication — just configure what KMP created.
+                // Don't register a competing "maven" publication. Just configure what KMP created.
                 //
                 // Each publication gets its own javadoc jar task to avoid signing task ordering
-                // conflicts: a shared task produces one .asc file, but each publication's sign
+                // conflicts. A shared task produces one .asc file, but each publication's sign
                 // task references it, creating an implicit dependency that Gradle cannot resolve.
                 afterEvaluate {
                     publications.withType(MavenPublication::class.java) {
@@ -98,7 +98,7 @@ internal object SparkPublication {
                                 },
                             )
                             archiveClassifier.set("javadoc")
-                            // Disambiguate the output file per publication so signing produces
+                            // Disambiguate the output filename per publication so signing produces
                             // separate .asc files with no cross-publication conflicts.
                             archiveAppendix.set(pubName.lowercase())
                         }
@@ -132,7 +132,7 @@ internal object SparkPublication {
                 }
             }
         }
-        // AGP creates software components during the afterEvaluate callback step...
+        // AGP creates software components during the afterEvaluate callback step.
         afterEvaluate {
             publication.from(components.getByName("release"))
             publication.artifact(dokkaJavadocJar)

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkUtils.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkUtils.kt
@@ -23,6 +23,7 @@ package com.adevinta.spark
 
 import java.util.Locale
 
+/** Returns a copy of this string with the first character uppercased. */
 public fun String.capitalized(): String = replaceFirstChar {
     if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -145,24 +145,6 @@ internal fun ComponentActivity.CatalogApp(
             TextDirection.System -> LocalLayoutDirection.current
         }
 
-        // Update the edge to edge configuration to match the theme
-        // This is the same parameters as the default enableEdgeToEdge call, but we manually
-        // resolve whether or not to show dark theme using uiState, since it can be different
-        // than the configuration's dark theme value based on the user preference.
-//        DisposableEffect(useDark) {
-//            enableEdgeToEdge(
-//                statusBarStyle = SystemBarStyle.auto(
-//                    android.graphics.Color.TRANSPARENT,
-//                    android.graphics.Color.TRANSPARENT,
-//                ) { useDark },
-//                navigationBarStyle = SystemBarStyle.auto(
-//                    lightScrim,
-//                    darkScrim,
-//                ) { useDark },
-//            )
-//            onDispose {}
-//        }
-        // Shader for colorblindness demo
         val runtimeShader = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             RuntimeShader(shader)
         } else {

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/MainActivity.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/MainActivity.kt
@@ -55,10 +55,9 @@ public class MainActivity : AppCompatActivity() {
 
     internal var activeNavController: NavController? = null
 
-    // JankStats usage taken from NIA but it'll help detect issues in the catalog app like the backdrop front layer.
+    // Tracks jank on the front layer; logs janky frames for local debugging.
     internal val jankStats: JankStats by lazy(LazyThreadSafetyMode.NONE) {
         JankStats.createAndTrack(window) { frameData ->
-            // Make sure to only log janky frames.
             if (frameData.isJank) {
                 // We're currently logging this but would better report it to a backend.
                 Log.v("Catalog Jank", frameData.toString())
@@ -68,10 +67,6 @@ public class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // Turn off the decor fitting system windows, which allows us to handle insets,
-        // including IME animations, and go edge-to-edge
-        // This also sets up the initial system bar style based on the platform theme
-//        enableEdgeToEdge()
         val uiModeManager = getSystemService<UiModeManager>()
         val propertiesHandler = ThemePropertiesHandler(context = this@MainActivity)
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/animation/PulseConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/animation/PulseConfigurator.kt
@@ -84,8 +84,7 @@ private fun ColumnScope.PulseSample(snackbarHostState: SnackbarHostState) {
 
     val firstLocale = LocalConfiguration.current.locales[0]
 
-    // Quick and dirty way to restart the animation otherwise when we change the scales they'll become
-    // synchronized with the alpha as they'll be restarted
+    // Toggling isEnabled forces a restart; without this, scale and alpha animations drift out of sync.
     val coroutineScope = rememberCoroutineScope()
     val restartPulseOnChange = {
         coroutineScope.launch {
@@ -96,7 +95,6 @@ private fun ColumnScope.PulseSample(snackbarHostState: SnackbarHostState) {
         Unit
     }
 
-    // Preview area
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -118,7 +116,6 @@ private fun ColumnScope.PulseSample(snackbarHostState: SnackbarHostState) {
         )
     }
 
-    // Configuration controls
     SwitchLabelled(
         checked = isEnabled,
         onCheckedChange = { isEnabled = it },
@@ -129,7 +126,6 @@ private fun ColumnScope.PulseSample(snackbarHostState: SnackbarHostState) {
         )
     }
 
-    // Initial Scale Slider
     Text(text = "Initial Scale: ${String.format(locale = firstLocale , format = "%.1f", initialScale)}")
 
     Slider(
@@ -142,7 +138,6 @@ private fun ColumnScope.PulseSample(snackbarHostState: SnackbarHostState) {
         modifier = Modifier.fillMaxWidth(),
     )
 
-    // Target Scale Slider
     Text(text = "Target Scale: ${String.format(locale = firstLocale , format = "%.1f", targetScale)}")
     Slider(
         value = targetScale,
@@ -154,7 +149,6 @@ private fun ColumnScope.PulseSample(snackbarHostState: SnackbarHostState) {
         modifier = Modifier.fillMaxWidth(),
     )
 
-    // Animation Duration Slider
     Text(text = "Animation Duration: ${animationDuration}ms")
     Slider(
         value = animationDuration.toFloat(),

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/bottomsheet/BottomSheetConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/bottomsheet/BottomSheetConfigurator.kt
@@ -182,7 +182,7 @@ private fun ListContent(onHideBottomSheetClicked: () -> Unit) {
     LazyColumn {
         stickyHeader {
             Row(horizontalArrangement = Arrangement.Center) {
-                // Note: If you provide logic outside of onDismissRequest to remove the sheet,
+                // If you provide logic outside of onDismissRequest to remove the sheet,
                 // you must additionally handle intended state cleanup, if any.
                 ButtonFilled(
                     modifier = Modifier.padding(24.dp),

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/colorselector/ColorSelectorTestConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/colorselector/ColorSelectorTestConfigurator.kt
@@ -63,7 +63,6 @@ private fun ColumnScope.ColorSelectorTestSample(snackbarHostState: SnackbarHostS
     var selectedColor by remember { mutableStateOf(defaultColor) }
     var allowSameColorSelection by remember { mutableStateOf(false) }
 
-    // Display the selected color
     Surface(
         modifier = Modifier
             .fillMaxWidth()

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/fileupload/FileUploadConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/fileupload/FileUploadConfigurator.kt
@@ -95,7 +95,6 @@ private fun ColumnScope.FileUploadSample() {
 
     val selectedType by remember { derivedStateOf { pickerType.toFileUploadType(imageSource, fileExtension) } }
 
-    // Helper function to apply global enabled state to a file
     fun UploadedFile.applyGlobalEnabled(globalEnabled: Boolean): UploadedFile = if (!globalEnabled) {
         copy(enabled = false)
     } else {
@@ -110,7 +109,6 @@ private fun ColumnScope.FileUploadSample() {
         enabled = enabled,
     )
 
-    // Display preview for single file
     AnimatedNullableVisibility(
         value = singleFile,
     ) { file ->
@@ -142,7 +140,6 @@ private fun ColumnScope.FileUploadSample() {
         enabled = enabled,
     )
 
-    // Display preview for multiple files with applied states
     val filesWithStates by remember {
         derivedStateOf {
             multipleFiles.map { it.applyGlobalEnabled(enabled) }.toImmutableList()
@@ -191,7 +188,6 @@ private fun ColumnScope.FileUploadSample() {
         onOptionSelect = { pickerType = it },
     )
 
-    // Show file extension selector only when File type is selected
     AnimatedVisibility(pickerType == FileUploadPickerType.File) {
         DropdownEnum(
             title = "File extension filter",
@@ -200,7 +196,6 @@ private fun ColumnScope.FileUploadSample() {
         )
     }
 
-    // Show ImageSource selector only when Image type is selected
     val selectedTypeHasMultipleSource =
         pickerType.toFileUploadType(imageSource) is FileUploadType.HasMultipleSource
     AnimatedVisibility(selectedTypeHasMultipleSource) {
@@ -211,14 +206,12 @@ private fun ColumnScope.FileUploadSample() {
         )
     }
 
-    // Clear icon selector
     IconPickerItem(
         label = "Clear icon",
         selectedIcon = clearIcon,
         onIconSelected = { icon -> if (icon != null) clearIcon = icon },
     )
 
-    // File state controls
     val allFiles = remember(singleFile, multipleFiles) {
         buildList {
             singleFile?.let { add(it) }
@@ -242,7 +235,6 @@ private fun ColumnScope.FileUploadSample() {
                     file = file,
                     fileName = file.name,
                     onFileChange = { updatedFile ->
-                        // Update the file in the appropriate state
                         if (singleFile?.file?.path == file.file.path) {
                             singleFile = updatedFile
                         } else {
@@ -276,7 +268,6 @@ private fun ColumnScope.FileStateControls(
     Column(
         modifier = Modifier.padding(16.dp),
     ) {
-        // File name as heading
         Text(
             text = fileName,
             style = SparkTheme.typography.headline2,

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tags/TagsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tags/TagsConfigurator.kt
@@ -91,7 +91,6 @@ private fun ColumnScope.TagSample(snackbarHostState: SnackbarHostState) {
         title = "Style",
         selectedOption = style,
         onOptionSelect = { newStyle ->
-            // Check if current intent is invalid for new style
             if (intent == TagIntent.Surface && newStyle != TagStyle.Filled) {
                 coroutineScope.launch {
                     snackbarHostState.showSnackbar(
@@ -99,7 +98,6 @@ private fun ColumnScope.TagSample(snackbarHostState: SnackbarHostState) {
                         intent = SnackbarIntent.Error,
                     )
                 }
-                // Reset intent to a valid one
                 intent = TagIntent.Main
             }
             style = newStyle
@@ -124,7 +122,6 @@ private fun ColumnScope.TagSample(snackbarHostState: SnackbarHostState) {
                 DropdownMenuItem(
                     text = { Text(newIntent.name) },
                     onClick = {
-                        // Check if the selected intent is invalid for current style
                         if (newIntent == TagIntent.Surface && style != TagStyle.Filled) {
                             coroutineScope.launch {
                                 snackbarHostState.showSnackbar(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/ComboBoxConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/ComboBoxConfigurator.kt
@@ -382,7 +382,7 @@ private fun ColumnScope.MultiChoiceComboBoxWithSelectedSample() {
     var helperText by remember { mutableStateOf("Helper message") }
     var statusMessageText by remember { mutableStateOf("State Message") }
     var addonText: String? by remember { mutableStateOf(null) }
-    var selectedBooks by remember { mutableStateOf(setOf(1, 2)) } // Pre-select first two books
+    var selectedBooks by remember { mutableStateOf(setOf(1, 2)) }
 
     val leadingContent: (@Composable AddonScope.() -> Unit)? = addonText?.let {
         @Composable {

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/MultiChoiceDropdownWithSelectedConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/MultiChoiceDropdownWithSelectedConfigurator.kt
@@ -71,7 +71,6 @@ private fun ColumnScope.MultiChoiceDropdownWithSelectedSample() {
     var helperText by rememberSaveable { mutableStateOf("Helper message") }
     var stateMessageText by rememberSaveable { mutableStateOf("State Message") }
     var addonText: String? by rememberSaveable { mutableStateOf(null) }
-    // Pre-select first two books
     var selectedBooks by remember {
         mutableStateOf(
             setOf(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/appbar/StickyBottomAppBarExample.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/appbar/StickyBottomAppBarExample.kt
@@ -67,14 +67,12 @@ import com.adevinta.spark.icons.PenOutline
 @Composable
 private fun StickyBottomAppBarExample() {
     PreviewTheme {
-        // Create scroll behaviors for both top and bottom app bars
         val topAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
         val bottomAppBarScrollBehavior = BottomAppBarSparkDefaults.bottomAppBarScrollBehavior()
 
         Scaffold(
             modifier = Modifier
                 .fillMaxSize()
-                // Connect both scroll behaviors to the nested scroll system
                 .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
                 .nestedScroll(bottomAppBarScrollBehavior.nestedScrollConnection),
             topBar = {

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/fileupload/FileUploadExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/fileupload/FileUploadExamples.kt
@@ -122,7 +122,6 @@ public val FileUploadExamples: ImmutableList<Example> = persistentListOf(
 @Composable
 private fun FilePreviewStatesExample() {
     Column(modifier = Modifier.fillMaxWidth()) {
-        // Create mock files for different states
         val defaultFile = remember {
             UploadedFile(
                 file = PlatformFile(file = File("document.pdf")),
@@ -228,7 +227,6 @@ private fun MultipleFilesConcatenatedExample() {
     Column(modifier = Modifier.fillMaxWidth()) {
         FileUpload.Button(
             onResult = { files ->
-                // Concatenate: add new files to existing ones
                 selectedFiles = selectedFiles.plus(files).toImmutableSet()
             },
             label = "Add files",
@@ -260,7 +258,6 @@ private fun MultipleFilesReplacedExample() {
     Column(modifier = Modifier.fillMaxWidth()) {
         FileUpload.Button(
             onResult = { files ->
-                // Replace: new selection replaces existing files
                 selectedFiles = files
             },
             label = "Select files",
@@ -290,7 +287,6 @@ private fun ButtonCustomizationExample() {
     var selectedFile3 by rememberSaveable { mutableStateOf<UploadedFile?>(null) }
 
     Column(modifier = Modifier.fillMaxWidth()) {
-        // Medium button with icon at end
         FileUpload.ButtonSingleSelect(
             onResult = { file -> selectedFile2 = file },
             label = "Medium with icon at end",
@@ -302,7 +298,6 @@ private fun ButtonCustomizationExample() {
 
         VerticalSpacer(16.dp)
 
-        // Large button with icon at start
         FileUpload.ButtonSingleSelect(
             onResult = { file -> selectedFile3 = file },
             label = "Large with icon",
@@ -348,7 +343,6 @@ private fun CustomButtonContentExample() {
     var selectedFile2 by rememberSaveable { mutableStateOf<UploadedFile?>(null) }
 
     Column(modifier = Modifier.fillMaxWidth()) {
-        // Using ButtonTinted as custom button content
         FileUpload.ButtonSingleSelect(
             onResult = { file -> selectedFile1 = file },
             label = "Select file",
@@ -365,7 +359,6 @@ private fun CustomButtonContentExample() {
 
         VerticalSpacer(16.dp)
 
-        // Using ButtonOutlined as custom button content
         FileUpload.ButtonSingleSelect(
             onResult = { file -> selectedFile2 = file },
             label = "Select file",
@@ -407,15 +400,12 @@ private fun UploadProgressErrorExample() {
     var uploadProgress by rememberSaveable { mutableFloatStateOf(0f) }
     var uploadError by rememberSaveable { mutableStateOf<String?>(null) }
 
-    // Simulate upload progress when a new file is selected
     LaunchedEffect(uploadedFile?.file?.path) {
         val file = uploadedFile ?: return@LaunchedEffect
-        // Only start upload simulation if file doesn't already have progress/error state
         if (file.progress == null && !file.isLoading && file.errorMessage == null) {
             uploadProgress = 0f
             uploadError = null
 
-            // Simulate upload progress
             for (i in 0..100 step 10) {
                 delay(150)
                 uploadProgress = i / 100f
@@ -426,7 +416,7 @@ private fun UploadProgressErrorExample() {
                 )
             }
 
-            // Simulate error at 80% progress (for demonstration purposes)
+            // Simulate an upload failure after reaching 100%.
             delay(200)
             uploadedFile = file.copy(
                 progress = null,
@@ -440,7 +430,6 @@ private fun UploadProgressErrorExample() {
         FileUpload.ButtonSingleSelect(
             onResult = { file ->
                 if (file != null) {
-                    // Reset state when new file is selected
                     uploadedFile = file
                     uploadError = null
                     uploadProgress = 0f

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/stepper/StepperExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/stepper/StepperExamples.kt
@@ -152,13 +152,6 @@ public val StepperExamples: ImmutableList<Example> = persistentListOf(
             enabled = false,
         )
     },
-    //  Example(
-    //     name = "Stepper Custom Buttons",
-    //     description = "Custom implementation allow used defined button for de-increment.",
-    //     sourceUrl = "$SampleSourceUrl/RatingFullSample.kt",
-    // ) {
-    //     WipIllustration()
-    // },
 )
 
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconPickerItem.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconPickerItem.kt
@@ -77,17 +77,12 @@ public fun IconPickerItem(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (selectedIcon != null /*&& selectedIconName != null*/) {
+                if (selectedIcon != null) {
                     Icon(
                         sparkIcon = selectedIcon,
                         contentDescription = null,
                         modifier = Modifier.size(24.dp),
                     )
-//                    Text(
-//                        text = selectedIconName.splitCamelWithSpaces(),
-//                        style = SparkTheme.typography.body2,
-//                        color = SparkTheme.colors.onSurface,
-//                    )
                 } else {
                     Text(
                         text = stringResource(R.string.icon_picker_no_icon_selected),

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/ThemePicker.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/ThemePicker.kt
@@ -108,7 +108,6 @@ public fun ThemePicker(
         verticalArrangement = spacedBy(ItemSpacing),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        // Theme Settings Section
         item(
             key = "theme_settings_header",
             contentType = ThemePickerContentType.SectionHeader,
@@ -162,7 +161,6 @@ public fun ThemePicker(
             }
         }
 
-        // Accessibility Section
         item(
             key = "accessibility_divider",
             contentType = ThemePickerContentType.Divider,
@@ -270,7 +268,6 @@ public fun ThemePicker(
             }
         }
 
-        // Developer Options Section
         item(
             key = "developer_divider",
             contentType = ThemePickerContentType.Divider,

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/Backdrop.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/Backdrop.kt
@@ -120,7 +120,7 @@ public class BackdropScaffoldState(
     public val confirmValueChange: (BackdropValue) -> Boolean = { true },
     public val snackbarHostState: SnackbarHostState = SnackbarHostState(),
 ) {
-    /** The current value of the [BottomSheetState]. */
+    /** The current value of the [BackdropScaffoldState]. */
     public val currentValue: BackdropValue
         get() = anchoredDraggableState.currentValue
 
@@ -366,7 +366,6 @@ public fun BackdropScaffold(
 
     val state = scaffoldState.anchoredDraggableState
 
-    // Back layer
     Surface(
         color = backLayerBackgroundColor,
         contentColor = backLayerContentColor,
@@ -387,7 +386,6 @@ public fun BackdropScaffold(
                 Modifier
             }
 
-            // Front layer
             Surface(
                 nestedScroll
                     .draggableAnchors(state, Orientation.Vertical) { layoutSize, _ ->
@@ -452,7 +450,6 @@ public fun BackdropScaffold(
                 }
             }
 
-            // Snackbar host
             Box(
                 Modifier
                     .padding(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/ColorSelector.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/ColorSelector.kt
@@ -168,7 +168,6 @@ public fun ColorSelector(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             val borderColor = if (selectedColor.luminance() >= 0.5) Color.Black else Color.White
-            // Color preview
             Box(
                 modifier = Modifier
                     .size(24.dp)
@@ -248,7 +247,6 @@ private fun ColorPickerDialog(
             modifier = Modifier.fillMaxWidth(),
         ) {
             stickyHeader {
-                // SparkColors tokens grid
                 Text(
                     text = stringResource(R.string.color_picker_tokens_title),
                     style = SparkTheme.typography.body1,
@@ -283,7 +281,6 @@ private fun ColorPickerDialog(
             ) {
                 Column {
                     if (isCustomPickerVisible) {
-                        // Custom color picker
                         Text(
                             text = stringResource(R.string.color_picker_custom_title),
                             style = SparkTheme.typography.body1,
@@ -297,7 +294,6 @@ private fun ColorPickerDialog(
                             controller = controller,
                             initialColor = selectedCustomColor,
                             onColorChanged = { colorEnvelope: ColorEnvelope ->
-                                // do something
                                 selectedCustomColor = colorEnvelope.color
                             },
                         )

--- a/spark-lint/src/main/kotlin/com/adevinta/spark/lint/LintIssueRegistry.kt
+++ b/spark-lint/src/main/kotlin/com/adevinta/spark/lint/LintIssueRegistry.kt
@@ -26,6 +26,7 @@ import com.android.tools.lint.client.api.Vendor
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 
+/** Registers all Spark lint issues so the Android lint tool can discover them. */
 public class LintIssueRegistry : IssueRegistry() {
 
     override val vendor: Vendor = Vendor(

--- a/spark-lint/src/main/kotlin/com/adevinta/spark/lint/MaterialComposableHasSparkReplacementDetector.kt
+++ b/spark-lint/src/main/kotlin/com/adevinta/spark/lint/MaterialComposableHasSparkReplacementDetector.kt
@@ -39,9 +39,7 @@ import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
 import java.util.EnumSet
 
-/**
- * Checks if a Composable has a Spark replacement.
- */
+/** Reports calls to Material or third-party Composables that have a Spark equivalent. */
 public class MaterialComposableHasSparkReplacementDetector :
     Detector(),
     SourceCodeScanner {

--- a/spark-lint/src/main/kotlin/com/adevinta/spark/lint/ScaffoldPaddingDetector.kt
+++ b/spark-lint/src/main/kotlin/com/adevinta/spark/lint/ScaffoldPaddingDetector.kt
@@ -40,6 +40,7 @@ import kotlin.collections.firstOrNull
 import kotlin.collections.orEmpty
 import kotlin.let
 
+/** Reports unused `content` padding parameters in calls to Spark's `Scaffold`. */
 public class ScaffoldPaddingDetector :
     Detector(),
     SourceCodeScanner {

--- a/spark-lint/src/main/kotlin/com/adevinta/spark/lint/StringResourceAnnotationDetector.kt
+++ b/spark-lint/src/main/kotlin/com/adevinta/spark/lint/StringResourceAnnotationDetector.kt
@@ -37,6 +37,7 @@ import com.android.utils.forEach
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 
+/** Validates attribute names and values inside `<annotation>` elements in string resources. */
 public class StringResourceAnnotationDetector : ResourceXmlDetector() {
 
     override fun appliesTo(folderType: ResourceFolderType): Boolean = folderType == VALUES
@@ -103,7 +104,7 @@ public class StringResourceAnnotationDetector : ResourceXmlDetector() {
                 "variable" to ::checkVariable,
             ).withDefault { ::reportUnknown }
 
-        // NOTE: It would be great to have these values come from `:spark` directly (see SparkStringAnnotations), but we would need to add extra dependencies.
+        // Values are duplicated from SparkStringAnnotations in :spark; pulling them in directly would add a dependency on that module.
         private val SUPPORTED_COLOR_VALUES = listOf(
             "main",
             "support",

--- a/spark-lint/src/main/kotlin/com/adevinta/spark/lint/WrongConditionalModifierUsageDetector.kt
+++ b/spark-lint/src/main/kotlin/com/adevinta/spark/lint/WrongConditionalModifierUsageDetector.kt
@@ -39,6 +39,7 @@ import kotlin.collections.lastOrNull
 import kotlin.jvm.java
 import kotlin.text.endsWith
 
+/** Flags static `Modifier` references used inside conditional Modifier extension lambdas. */
 public class WrongConditionalModifierUsageDetector :
     Detector(),
     SourceCodeScanner {

--- a/spark-lint/src/main/kotlin/com/adevinta/spark/lint/utils/LambdaParameterVisitor.kt
+++ b/spark-lint/src/main/kotlin/com/adevinta/spark/lint/utils/LambdaParameterVisitor.kt
@@ -57,7 +57,6 @@ internal class LambdaParameterVisitor(private val lambda: KtLambdaExpression) {
                 .filter { it.destructuringDeclaration == null }
                 // Ignore referenced parameters
                 .filterNot { isParameterReferenced(it.name!!) }
-                // Return an UnreferencedParameters for each un-referenced parameter
                 .map { UnreferencedParameter(it.name!!, it) }
         }
     }

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziRule.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziRule.kt
@@ -47,9 +47,7 @@ fun paparazziRule(
     useDeviceResolution = true,
 )
 
-/**
- * Defaults devices configuration taken from NiA
- */
+/** Default device configurations for Paparazzi screenshot tests. */
 object DefaultTestDevices {
     /**
      * Pixel 6 Pro

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziUtils.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziUtils.kt
@@ -99,8 +99,8 @@ private fun SparkThemeContent(
             colors = colors,
             sparkFeatureFlag = SparkFeatureFlag(useRebrandedShapes = true),
         ) {
-            // The first box acts as a shield from ComposeView which forces the first layout node
-            // to match it's size. This allows the content below to wrap as needed.
+            // The first box shields from ComposeView which forces the first layout node
+            // to match its size. This allows the content below to wrap as needed.
             Box {
                 // The second box adds a border and background so we can easily see layout bounds in screenshots
                 Box(
@@ -154,7 +154,7 @@ internal fun Paparazzi.sparkSnapshotNightMode(
 }
 
 /**
- * Generate 1 screenshot with the same content side by side but one in light theme and teh other in dark theme.
+ * Generate 1 screenshot with the same content side by side, one in light theme and the other in dark theme.
  */
 internal fun Paparazzi.sparkDocSnapshot(
     color: @Composable () -> Color = { SparkTheme.colors.background },

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/buttons/ButtonDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/buttons/ButtonDocumentationScreenshots.kt
@@ -34,10 +34,7 @@ import com.android.ide.common.rendering.api.SessionParams.RenderingMode.SHRINK
 import org.junit.Rule
 import org.junit.Test
 
-/**
- * Documentation screenshots for Button component, following Material Design's approach of showing
- * each variant with light and dark theme side by side.
- */
+/** Documentation screenshots for the Button component, each variant shown in light and dark theme side by side. */
 internal class ButtonDocumentationScreenshots {
 
     @get:Rule

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/fileupload/FileUploadScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/fileupload/FileUploadScreenshot.kt
@@ -93,7 +93,6 @@ internal class FileUploadScreenshot {
     @Composable
     private fun FilePreviewStatesExample() {
         Column {
-            // Create mock files for different states
             val defaultFile = remember {
                 UploadedFile(
                     file = PlatformFile(file = File("document.pdf")),

--- a/spark/src/main/kotlin/com/adevinta/spark/ExperimentalSparkApi.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/ExperimentalSparkApi.kt
@@ -22,7 +22,7 @@
 package com.adevinta.spark
 
 @RequiresOptIn(
-    message = "This API is experimental and is likely to change in the future.",
+    message = "This API is experimental and may change in the future.",
     level = RequiresOptIn.Level.WARNING,
 )
 @Retention(AnnotationRetention.BINARY)

--- a/spark/src/main/kotlin/com/adevinta/spark/SparkFeatureFlag.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/SparkFeatureFlag.kt
@@ -28,7 +28,7 @@ package com.adevinta.spark
  * makes the text in cursive, colors in red/green/blue and shapes in full cut corners.
  * @property useSparkComponentsHighlighter Highlight visually with an overlay where the spark components are used
  * or not. Setting it to true show an overlay on spark components.
- * @property isContainingActivityEdgeToEdge
+ * @property isContainingActivityEdgeToEdge Whether the containing activity has edge-to-edge enabled.
  * @property useRebrandedShapes Use new button, chips, tags and textfield shapes.
  * @property useRebrandedButtons When true, old intent+style combinations resolve to new semantic button variants.
  */

--- a/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
@@ -102,7 +102,7 @@ import com.adevinta.spark.tools.SparkExceptionHandler
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 public fun SparkTheme(
-    // We don't want to automatically support dark theme in the app but still want it in the previews
+    // Dark theme is disabled in production but enabled in previews via isSystemInDarkTheme().
     colors: SparkColors = SparkTheme.colors,
     shapes: SparkShapes = SparkTheme.shapes,
     typography: SparkTypography = SparkTheme.typography,
@@ -119,8 +119,7 @@ public fun SparkTheme(
 ) {
     val internalColors = if (sparkFeatureFlag.useSparkTokensHighlighter) debugColors() else colors
     val rememberedColors = remember {
-        // Explicitly creating a new object here so we don't mutate the initial [colors]
-        // provided, and overwrite the values set in it.
+        // Creates a new object to avoid mutating the caller-provided [colors] instance.
         internalColors.copy()
     }.apply { updateColorsFrom(internalColors) }
 
@@ -208,7 +207,6 @@ internal fun PreviewTheme(
     content: @Composable ColumnScope.() -> Unit,
 ) {
     SparkTenantTheme(
-        // We don't want to automatically support dark theme in the app but still want it in the previews
         useDarkColors = useDarkColors,
     ) {
         PreviewWrapper(
@@ -222,7 +220,6 @@ internal fun PreviewTheme(
 
 @Composable
 internal fun SparkTenantTheme(
-    // We don't want to automatically support dark theme in the app but still want it in the previews
     useDarkColors: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
@@ -281,9 +278,7 @@ public object SparkTheme {
         get() = LocalSparkFeatureFlag.current
 }
 
-/** CompositionLocal used to pass [SparkExceptionHandler] down the tree to enable control on some crashable
- * behaviors at consumers
- */
+/** CompositionLocal used to pass [SparkExceptionHandler] down the tree. Gives consumers control over crashable behaviours. */
 public val LocalSparkExceptionHandler: ProvidableCompositionLocal<SparkExceptionHandler> =
     staticCompositionLocalOf {
         error(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/BottomAppBar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/BottomAppBar.kt
@@ -173,8 +173,6 @@ public class SparkBottomAppBarScrollBehavior(
      */
     public val overlappedFraction: Float
         get() = if (state.contentOffset > 0f) {
-            // Normalize the contentOffset to a fraction
-            // We use a reasonable maximum scroll distance for normalization
             (state.contentOffset / 1000f).coerceAtMost(1f)
         } else {
             0f
@@ -189,9 +187,6 @@ public class SparkBottomAppBarScrollBehavior(
         ): Offset {
             if (!canScroll()) return Offset.Zero
 
-            // Update the content offset to track scroll position
-            // Negative contentOffset means we've scrolled down (content above)
-            // Positive contentOffset means we've scrolled up (at or near top)
             if (consumed.y == 0f && available.y <= 0f) {
                 // Reset the total content offset to zero when scrolling all the way down.
                 // This will eliminate some float precision inaccuracies.
@@ -316,20 +311,16 @@ public fun BottomAppBar(
     scrollBehavior: BottomAppBarScrollBehavior? = null,
     content: @Composable RowScope.() -> Unit,
 ) {
-    // Obtain the elevation transition fraction using the overlappedFraction. This
-    // ensures that the elevation will adjust whether the app bar behavior is pinned or scrolled.
-    // This may potentially animate or interpolate a transition between the normal elevation and the
-    // elevated state according to the app bar's scroll state.
+    // derivedStateOf prevents recomposition on every scroll pixel; only recomposes when the
+    // threshold crossing changes the binary elevated/not-elevated decision.
     val elevationTransitionFraction by
         remember(scrollBehavior) {
-            // derivedStateOf to prevent redundant recompositions when the content scrolls.
             derivedStateOf {
                 val overlappingFraction = (scrollBehavior as? SparkBottomAppBarScrollBehavior)?.overlappedFraction ?: 0f
                 if (overlappingFraction > 0.001f) 1f else 0f
             }
         }
 
-    // Animate container color for scroll-based elevation effect
     val animatedContainerColor by animateColorAsState(
         targetValue = if (elevationTransitionFraction > 0f) {
             SparkTheme.colors.applyTonalElevation(
@@ -343,7 +334,6 @@ public fun BottomAppBar(
         label = "BottomAppBarContainerColor",
     )
 
-    // Animate elevation
     val animatedElevation by animateDpAsState(
         targetValue = if (elevationTransitionFraction > 0f) {
             elevation + ElevationTokens.Level3

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBar.kt
@@ -527,10 +527,8 @@ private fun SingleRowTopAppBar(
         }
     }
 
-    // Obtain the container color from the TopAppBarColors using the `overlapFraction`. This
-    // ensures that the colors will adjust whether the app bar behavior is pinned or scrolled.
-    // This may potentially animate or interpolate a transition between the container-color and the
-    // container's scrolled-color according to the app bar's scroll state.
+    // Snap to the scrolled color once overlappedFraction crosses 0.1 to avoid expensive
+    // per-pixel animations while still reacting to the scroll state.
     val colorTransitionFraction = scrollBehavior?.state?.overlappedFraction ?: 0f
     val fraction = if (colorTransitionFraction > 0.1f) 1f else 0f
     val appBarContainerColor by animateColorAsState(
@@ -542,7 +540,6 @@ private fun SingleRowTopAppBar(
         animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
     )
 
-    // Wrap the given actions in a Row.
     val actionsRow = @Composable {
         Row(
             horizontalArrangement = Arrangement.End,
@@ -571,10 +568,7 @@ private fun SingleRowTopAppBar(
         Modifier
     }
 
-    // Compose a Surface with a TopAppBarLayout content.
-    // The surface's background color is animated as specified above.
-    // The height of the app bar is determined by subtracting the bar's height offset from the
-    // app bar's defined constant height value (i.e. the ContainerHeight token).
+    // Height = ContainerHeight + heightOffset, allowing the bar to collapse when scrollBehavior shrinks heightOffset.
     Surface(
         modifier = modifier.then(appBarDragModifier),
         color = appBarContainerColor,
@@ -709,16 +703,11 @@ private fun TwoRowsTopAppBar(
         }
     }
 
-    // Obtain the container Color from the TopAppBarColors using the `collapsedFraction`, as the
-    // bottom part of this TwoRowsTopAppBar changes color at the same rate the app bar expands or
-    // collapse.
-    // This will potentially animate or interpolate a transition between the container color and the
-    // container's scrolled color according to the app bar's scroll state.
+    // The bottom row color tracks collapsedFraction so it transitions in sync with the expand/collapse animation.
     val colorTransitionFraction = scrollBehavior?.state?.collapsedFraction ?: 0f
     val appBarContainerColor by rememberUpdatedState(colors.containerColor(colorTransitionFraction))
     val appBarContainerElevation by rememberUpdatedState(containerElevation(colorTransitionFraction))
 
-    // Wrap the given actions in a Row.
     val actionsRow = @Composable {
         Row(
             horizontalArrangement = Arrangement.End,
@@ -917,7 +906,6 @@ private fun TopAppBarLayout(
         val layoutHeight = heightPx.roundToInt()
 
         layout(constraints.maxWidth, layoutHeight) {
-            // Navigation icon
             navigationIconPlaceable.placeRelative(
                 x = 0,
                 y = (layoutHeight - navigationIconPlaceable.height) / 2,
@@ -958,7 +946,6 @@ private fun TopAppBarLayout(
                 },
             )
 
-            // Action icons
             actionIconsPlaceable.placeRelative(
                 x = constraints.maxWidth - actionIconsPlaceable.width,
                 y = (layoutHeight - actionIconsPlaceable.height) / 2,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgedBox.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgedBox.kt
@@ -100,7 +100,7 @@ internal fun SparkBadgedBox(
             totalWidth,
             totalHeight,
             // Provide custom baselines based only on the anchor content to avoid default baseline
-            // calculations from including by any badge content.
+            // calculations from including any badge content.
             mapOf(
                 FirstBaseline to firstBaseline,
                 LastBaseline to lastBaseline,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/BottomSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/BottomSheet.kt
@@ -80,12 +80,6 @@ import kotlinx.coroutines.launch
  *
  * @param onDismissRequest
  * @param modifier Optional [Modifier] for the bottom sheet.
- *
- * If you want to have immersive BottomSheet, you can set contentTopPadding = 0.dp,
- * Beware you need to set your content top padding yourself
- * to avoid content to be hidden by the handle at least SheetDefaults.ContentTopPadding
- *
- *
  * @param sheetState the state of the bottom sheet.
  * @param content The content to be displayed inside the bottom sheet.
  */

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonContrast.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonContrast.kt
@@ -213,11 +213,7 @@ public fun ButtonContrast(
 }
 
 /**
- * Ghost buttons are used for the lowest priority actions, especially when presenting multiple options.
- *
- * Ghost buttons can be placed on a variety of backgrounds. Until the button is interacted with, its container
- * isn’t visible.
- * This button style is often used inside other components like snackbars, dialogs, and cards.
+ * Contrast buttons are used on coloured or image backgrounds where standard buttons lack visibility.
  *
  * @param onClick Will be called when the user clicks the button
  * @param text The text to be displayed in the button

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonGhost.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonGhost.kt
@@ -416,7 +416,7 @@ internal fun SparkButtonGhost(
  * Until the button is interacted with, its container is not visible.
  *
  * ![Button Ghost](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.buttons_NewButtonDocumentationScreenshots_buttonGhost.png)
- **
+ *
  * @param onClick Will be called when the user clicks the button
  * @param modifier Modifier to be applied to the button
  * @param size The size of the button

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/CardDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/CardDefaults.kt
@@ -134,7 +134,7 @@ public object CardDefaults {
      * Creates a [CardElevation] that will animate between the provided values according to the
      * Material specification for an [ElevatedCard].
      *
-     * @param defaultElevation the elevation used when the [ElevatedCard] is has no other
+     * @param defaultElevation the elevation used when the [ElevatedCard] has no other
      * [Interaction]s.
      * @param pressedElevation the elevation used when the [ElevatedCard] is pressed.
      * @param focusedElevation the elevation used when the [ElevatedCard] is focused.
@@ -162,7 +162,7 @@ public object CardDefaults {
      * Creates a [CardElevation] that will animate between the provided values according to the
      * Material specification for an [OutlinedCard].
      *
-     * @param defaultElevation the elevation used when the [OutlinedCard] is has no other
+     * @param defaultElevation the elevation used when the [OutlinedCard] has no other
      * [Interaction]s.
      * @param pressedElevation the elevation used when the [OutlinedCard] is pressed.
      * @param focusedElevation the elevation used when the [OutlinedCard] is focused.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/CardElevation.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/CardElevation.kt
@@ -63,7 +63,7 @@ public class CardElevation internal constructor(
      * Represents the tonal elevation used in a card, depending on its [enabled] state and
      * [interactionSource]. This should typically be the same value as the [shadowElevation].
      *
-     * Tonal elevation is used to apply a color shift to the surface to give the it higher emphasis.
+     * Tonal elevation is used to apply a color shift to the surface to give it higher emphasis.
      * When surface's color is [ColorScheme.surface], a higher elevation will result in a darker
      * color in light theme and lighter color in dark theme.
      *

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.kt
@@ -186,7 +186,7 @@ private fun SparkChipSelectable(
  * Chips help users quickly recognize an important information that has been entered by them,
  * trigger actions, make selections, or filter content.
  *
- * @param style one of [ChipStyles] that defines chips background and border colors.
+ * @param style one of [ChipStyles] that defines chips background and border.
  * @param onClose when provided will add the closing indicator and make it clickable. note that adding it will require
  * [onCloseLabel] to be provided as well.
  * @param onCloseLabel semantic / accessibility label for the onClose action. It should describe to the user what
@@ -255,14 +255,14 @@ public fun Chip(
 /**
  * Chips help users quickly recognize an important information that has been entered by them,
  * trigger actions, make selections, or filter content.
- * @param selected - whether this chip is selected or not * @param style one of [ChipStyles] that defines chips background and border colors.
+ * @param selected whether this chip is selected or not
+ * @param style one of [ChipStyles] that defines chips background and border.
  * @param onClose when provided will add the closing indicator and make it clickable. note that adding it will require
  * [onCloseLabel] to be provided as well.
  * @param onCloseLabel semantic / accessibility label for the onClose action. It should describe to the user what
  * will happen if [onClose] is tapped.
  * @param intent The [ChipIntent] colors that will be used for the content and background of this chip in
  * different states.
- * @param style one of [ChipStyles] that defines chips background and border.
  * @param onClick called when this chip is clicked
  * @param modifier the [Modifier] to be applied to this chip
  * @param enabled controls the enabled state of this chip. When `false`, this component will not
@@ -425,14 +425,13 @@ public fun Chip(
  * Chips help users quickly recognize an important information that has been entered by them,
  * trigger actions, make selections, or filter content.
  *
- * @param style one of [ChipStyles] that defines chips background and border colors.
+ * @param style one of [ChipStyles] that defines chips background and border.
  * @param onClose when provided will add the closing indicator and make it clickable. note that adding it will require
  * [onCloseLabel] to be provided as well.
  * @param onCloseLabel semantic / accessibility label for the onClose action. It should describe to the user what
  * will happen if [onClose] is tapped.
  * @param intent The [ChipIntent] colors that will be used for the content and background of this chip in
  * different states.
- * @param style one of [ChipStyles] that defines chips background and border.
  * @param onClick called when this chip is clicked
  * @param modifier the [Modifier] to be applied to this chip
  * @param enabled controls the enabled state of this chip. When `false`, this component will not

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipDefaults.kt
@@ -36,7 +36,7 @@ public object ChipDefaults {
     internal val LeadingIconSize = 16.dp
 
     /**
-     * Returns the [PaddingValues] for the assist chip.
+     * Horizontal padding for chip content.
      */
     internal val ChipPadding = PaddingValues(horizontal = HorizontalElementsPadding)
 
@@ -51,7 +51,7 @@ public object ChipDefaults {
     internal val BorderStrokeWidth = 1.dp
 
     /**
-     * The outlined chip's border size
+     * The dashed chip's border corner radius.
      */
     internal val DashedBorderRadius = 8.dp
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
@@ -148,9 +148,7 @@ internal fun AlertDialogPreview() {
         AlertDialog(
             modifier = Modifier.fillMaxWidth(),
             onDismissRequest = {
-                // Dismiss the dialog when the user clicks outside the dialog or on the back
-                // button. If you want to disable that functionality, simply use an empty
-                // onDismissRequest.
+                // To disable dismissal on outside tap or back press, use an empty onDismissRequest.
             },
             icon = { Icon(LeboncoinIcons.HeartFill, contentDescription = null) },
             title = {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
@@ -101,7 +101,7 @@ import com.adevinta.spark.tokens.LocalWindowSizeClass
  * The scaffold provides different layouts for phone portrait, phone landscape, and other
  * devices (e.g., tablets or foldables) where it'll show a modal instead.
  *
- * IF you don't want the Bottom App Bar to appear then provide null to both [mainButton] & [supportButton]
+ * To hide the Bottom App Bar, pass null to both [mainButton] and [supportButton].
  *
  * @param onClose callback that will be invoked when the modal is dismissed
  * @param snackbarHost Component to host Snackbars that are pushed to be shown
@@ -112,8 +112,8 @@ import com.adevinta.spark.tokens.LocalWindowSizeClass
  * @param title the title of the modal
  * @param actions the actions displayed at the end of the top app bar. This should typically be
  *  * [IconButton]s. The default layout here is a [Row], so icons inside will be placed horizontally.
- * @param inEdgeToEdge tel the component that the activity where it's being displayed on is a edege to edge screen.
- * This has to be explicitly specified as no api wan reliably tel us
+ * @param inEdgeToEdge tell the component that the host activity uses edge-to-edge.
+ * This must be set explicitly because no API can reliably detect it.
  * @param content the center custom Composable for modal content
  */
 @ExperimentalSparkApi
@@ -225,7 +225,7 @@ private fun DialogScaffold(
             Column {
                 TopAppBar(
                     navigationIcon = {
-                        // As a fallback when to action button is displayed to easily close the dialog
+                        // When no action buttons are present, show the close button so the dialog can be dismissed.
                         if (supportButton == null && mainButton == null) {
                             CloseIconButton(onClose = onClose)
                         }
@@ -285,7 +285,7 @@ private fun PhonePortraitModalScaffold(
         onDismissRequest = onClose,
         properties = properties,
     ) {
-        // Work around for b/246909281 as for now Dialog doesn't pass the drawing insets to its content
+        // Work around b/246909281: Dialog does not pass drawing insets to its content.
         if (inEdgeToEdge) SetUpEdgeToEdgeDialog()
 
         val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
@@ -378,7 +378,7 @@ private fun PhoneLandscapeModalScaffold(
         onDismissRequest = onClose,
         properties = properties,
     ) {
-        // Work around for b/246909281 as for now Dialog doesn't pass the drawing insets to its content
+        // Work around b/246909281: Dialog does not pass drawing insets to its content.
         if (inEdgeToEdge) SetUpEdgeToEdgeDialog()
         val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
         val bottomAppBarScrollBehavior = BottomAppBarSparkDefaults.bottomAppBarScrollBehavior()
@@ -471,15 +471,12 @@ private fun SetUpEdgeToEdgeDialog() {
     window.statusBarColor = Color.Transparent.toArgb()
     window.navigationBarColor = Color.Transparent.toArgb()
     window.navigationBarColor = Color.Transparent.toArgb()
-    // Displaying a popup with this flag will make it un scrollable if it's bigger that the screen
+    // FLAG_LAYOUT_NO_LIMITS would make large popups unscrollable, so it is intentionally omitted.
     // window.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
     window.setDimAmount(0f)
 }
 
-/**
- * Merge 2 padding values with each others.
- * This was not provided by Google so we're making our own
- */
+/** Adds two [PaddingValues] together. Not provided by Google so defined here. */
 private operator fun PaddingValues.plus(other: PaddingValues): PaddingValues = PaddingValues(
     start = this.calculateStartPadding(LayoutDirection.Ltr) +
         other.calculateStartPadding(LayoutDirection.Ltr),

--- a/spark/src/main/kotlin/com/adevinta/spark/components/divider/Divider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/divider/Divider.kt
@@ -127,7 +127,7 @@ public fun HorizontalDivider(
                 modifier = Modifier.constrainAs(lineRight) {
                     start.linkTo(labelBox.end)
                     end.linkTo(parent.end)
-                    centerVerticallyTo(parent) // Align vertically to the center of the parent
+                    centerVerticallyTo(parent)
                     width = calculateLineWidth(LabelHorizontalAlignment.End, labelHorizontalAlignment)
                 },
 
@@ -175,7 +175,7 @@ public fun VerticalDivider(
                 modifier = Modifier.constrainAs(lineTop) {
                     top.linkTo(parent.top)
                     bottom.linkTo(labelBox.top)
-                    centerHorizontallyTo(parent) // Align horizontally to the center of the parent
+                    centerHorizontallyTo(parent)
                     height = calculateLineHeight(LabelVerticalAlignment.Top, labelVerticalAlignment)
                 },
             )
@@ -191,7 +191,6 @@ public fun VerticalDivider(
                     },
             ) { label() }
 
-            // Bottom Divider
             MaterialVerticalDivider(
                 color = intent.color(),
                 modifier = Modifier.constrainAs(lineBottom) {
@@ -291,7 +290,7 @@ private fun TextComposable(textOverflow: TextOverflow = TextOverflow.Ellipsis) {
         textAlign = TextAlign.Center,
         overflow = textOverflow,
         style = SparkTheme.typography.body1,
-        //  text = "jdkdkskjdkkklnljxcljcxlcjvxxcljljxcsdksj\n\ndljjjcdljcjdljcljdsljfdld\nlkjkjisd\nsdsksjddsk\njdksdjslds",
+        // text = "jdkdkskjdkkklnljxcljcxlcjvxxcljljxcsdksj\n\ndljjjcdljcjdljcljdsljfdld\nlkjkjisd\nsdsksjddsk\njdksdjslds",
         text = "label",
     )
 }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
@@ -80,7 +80,7 @@ internal fun SparkDismissibleDrawerSheet(
 /**
  * Spark DismissibleDrawerSheet.
  *
- * An DismissibleDrawerSheet is a simple dismissible drawer sheet with content inside.
+ * A DismissibleDrawerSheet is a simple dismissible drawer sheet with content inside.
  *
  * @param modifier the [Modifier] to be applied to this drawer's content
  * @param drawerShape defines the shape of this drawer's container
@@ -123,7 +123,6 @@ internal fun DismissibleDrawerSheetPreview() {
     PreviewTheme(
         padding = PaddingValues(0.dp),
     ) {
-        // icons to mimic drawer destinations
         val items = listOf(LeboncoinIcons.HeartFill, LeboncoinIcons.HappyFaceFill, LeboncoinIcons.LetterFill)
         val selectedItem = remember { mutableStateOf(items[0]) }
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
@@ -74,7 +74,7 @@ internal fun SparkDismissibleNavigationDrawer(
 /**
  * Spark DismissibleNavigationDrawer.
  *
- * A DismissibleNavigationDrawer provide ergonomic access to destinations in an app. They’re often next to app content and affect the screen’s layout grid.
+ * A DismissibleNavigationDrawer provides ergonomic access to destinations in an app. It sits next to app content and affects the screen’s layout grid.
  *
  * ![DismissibleNavigationDrawer image](https://developer.android.com/images/reference/androidx/compose/material3/navigation-drawer.png)
  *
@@ -126,7 +126,6 @@ internal fun AlertDialogPreview() {
     ) {
         val drawerState = rememberDrawerState(DrawerValue.Closed)
         val scope = rememberCoroutineScope()
-        // icons to mimic drawer destinations
         val items = listOf(LeboncoinIcons.HeartOutline, LeboncoinIcons.Family, LeboncoinIcons.MailBoxOpenOutline)
         val selectedItem = remember { mutableStateOf(items[0]) }
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
@@ -74,7 +74,7 @@ internal fun SparkModalDrawerSheet(
 /**
  * Spark ModalDrawerSheet.
  *
- * A ModalDrawerSheet is a Content inside of a modal navigation drawer.
+ * A ModalDrawerSheet is the content inside a modal navigation drawer.
  *
  * @param modifier the [Modifier] to be applied to this drawer's content
  * @param drawerShape defines the shape of this drawer's container
@@ -115,7 +115,6 @@ internal fun ModalDrawerSheetPreview() {
     PreviewTheme(
         padding = PaddingValues(0.dp),
     ) {
-        // icons to mimic drawer destinations
         val items = listOf(LeboncoinIcons.HeartOutline, LeboncoinIcons.Family, LeboncoinIcons.MailBoxOpenOutline)
         val selectedItem = remember { mutableStateOf(items[0]) }
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
@@ -76,8 +76,8 @@ internal fun SparkModalNavigationDrawer(
 /**
  * Spark ModalNavigationDrawer.
  *
- * An ModalNavigationDrawer provide ergonomic access to destinations in an app.
- * Modal navigation drawers block interaction with the rest of an app’s content with a scrim. They are elevated above most of the app’s UI and don’t affect the screen’s layout grid.
+ * A ModalNavigationDrawer provides ergonomic access to destinations in an app.
+ * Modal navigation drawers block interaction with the rest of the UI using a scrim. They float above most content and do not affect the screen’s layout grid.
  *
  * ![ModalNavigationDrawer image](https://developer.android.com/images/reference/androidx/compose/material3/navigation-drawer.png)
  *
@@ -121,7 +121,6 @@ internal fun ModalNavigationDrawerPreview() {
     ) {
         val drawerState = rememberDrawerState(DrawerValue.Closed)
         val scope = rememberCoroutineScope()
-        // icons to mimic drawer destinations
         val items = listOf(LeboncoinIcons.HeartOutline, LeboncoinIcons.Family, LeboncoinIcons.MailBoxOpenOutline)
         val selectedItem = remember { mutableStateOf(items[0]) }
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/fileupload/FileSizeHumanReadable.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/fileupload/FileSizeHumanReadable.kt
@@ -35,14 +35,12 @@ internal fun Double.formatNumber(
     val rounded = formatWithDecimals(decimals)
     val parts = rounded.split('.')
 
-    // Format the integer part
     val formattedIntegerPart = parts[0]
         .reversed()
         .chunked(3)
         .joinToString(groupSeparator)
         .reversed()
 
-    // Format the decimal part
     val decimalPart = if (parts.size > 1) parts[1] else ""
     val formattedDecimalPart = if (decimals > 0) {
         val truncatedDecimals = decimalPart.padEnd(decimals, '0').substring(0, decimals)
@@ -101,7 +99,5 @@ private fun Double.formatWithDecimals(decimals: Int): String {
     }
 }
 
-/**
- * Workaround for Libres returning an empty string if it contains only a space.
- */
+/** Libres returns an empty string for a string that contains only a space, so substitute it. */
 private fun String.formatWithSpaceIfNeeded(): String = ifEmpty { " " }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/fileupload/FileUploadList.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/fileupload/FileUploadList.kt
@@ -69,7 +69,6 @@ public fun FileUploadList(
             verticalArrangement = spacedBy(8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // Display all files
             files.forEach { file ->
                 key(file.file.path) {
                     PreviewFile(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/fileupload/FileUploadPattern.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/fileupload/FileUploadPattern.kt
@@ -121,7 +121,7 @@ public fun rememberFileUploadPattern(
     val isSingleMode = mode is FileUploadMode.Single
     val maxFiles = if (mode is FileUploadMode.Multiple) mode.maxFiles else null
 
-    // No ActivityResultRegistryOwner in Paparazzi/Preview — return a no-op state.
+    // Paparazzi/Preview has no ActivityResultRegistryOwner, so return a no-op state.
     if (LocalInspectionMode.current) {
         return remember(isSingleMode, maxFiles) {
             FileUploadPatternState(
@@ -135,10 +135,8 @@ public fun rememberFileUploadPattern(
         }
     }
 
-    // File picker launcher (for gallery/file selection)
     val fileKitType = type.toFileKitType()
     val filePicker = if (isSingleMode) {
-        // Single mode: callback receives PlatformFile? directly
         rememberFilePickerLauncher(
             type = fileKitType,
             directory = directory,
@@ -162,7 +160,6 @@ public fun rememberFileUploadPattern(
         }
     }
 
-    // Camera picker launcher
     val cameraPicker = rememberCameraPickerLauncher { newPhoto ->
         if (newPhoto == null) return@rememberCameraPickerLauncher
 
@@ -200,7 +197,7 @@ private fun FileUploadPatternPreview() {
         val pattern = rememberFileUploadPattern(
             onFilesSelect = {},
         )
-        // Use Chip as this is not a prebuild FileUpload component
+        // Chip is used here because this preview exercises the wrapper pattern, not a pre-built upload button.
         FileUploadPattern(
             pattern = pattern,
         ) { onClick ->

--- a/spark/src/main/kotlin/com/adevinta/spark/components/fileupload/PreviewFile.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/fileupload/PreviewFile.kt
@@ -119,7 +119,6 @@ public fun PreviewFile(
     val isLoading = file.isLoading
     val errorMessage = file.errorMessage
 
-    // Disable clear button if progress or loading is active
     val isClearEnabled = file.enabled && progress == null && !isLoading
 
     Surface(
@@ -160,7 +159,6 @@ public fun PreviewFile(
                         modifier = Modifier.fillMaxWidth(1f),
                     )
 
-                    // Show progress bar during upload
                     AnimatedVisibility(
                         visible = progress != null || isLoading,
                     ) {
@@ -173,8 +171,8 @@ public fun PreviewFile(
                         } else {
                             val animatedProgress by
                                 animateFloatAsState(
-                                    // backup to 100 otherwise we would crash since the progress
-                                    // is still in use for the time we hide it
+                                    // Fall back to 100f while hiding, to avoid a crash while the
+                                    // progress lambda is still referenced during the exit animation.
                                     targetValue = progress?.invoke() ?: 100f,
                                     animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec,
                                 )
@@ -187,7 +185,6 @@ public fun PreviewFile(
                         }
                     }
 
-                    // Show error message if present
                     AnimatedVisibility(visible = hasError) {
                         Text(
                             text = errorMessage ?: "",

--- a/spark/src/main/kotlin/com/adevinta/spark/components/gauge/GaugeSize.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/gauge/GaugeSize.kt
@@ -24,8 +24,6 @@ package com.adevinta.spark.components.gauge
 /**
  * Defines the available sizes for the SegmentedGauge component.
  *
- * Note that each parameters
- *
  * @property width The width of each segment in density-independent pixels.
  * @property height The height of each segment in density-independent pixels.
  * @property indicatorSize The size of the indicator in density-independent pixels.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/gauge/SegmentedGauge.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/gauge/SegmentedGauge.kt
@@ -91,7 +91,6 @@ private fun SparkSegmentedGauge(
         )
     }
 
-    // Coordinated animation state
     val transition = updateTransition(
         targetState = GaugeAnimationState(
             type = type,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconIntent.kt
@@ -89,7 +89,7 @@ public enum class IconIntent {
     },
 
     /**
-     * Used to alert.
+     * Used for risky or destructive actions.
      */
     Danger {
         @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
@@ -98,7 +98,7 @@ public fun Icon(
  * and does not represent a meaningful action that a user can take. This text should be
  * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
  * @param modifier optional [Modifier] for this Icon
- * @param tint to be applied to [imageVector]. If no intent is provided, then a default is used.
+ * @param tint to be applied to [imageVector]. If no tint is provided, then a default is used.
  * @param size one of [IconSize] to be applied as size of the icon.
  * If no size is provided the default [IconSize.Medium] is used.
  */
@@ -132,7 +132,7 @@ public fun Icon(
  * and does not represent a meaningful action that a user can take. This text should be
  * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
  * @param modifier optional [Modifier] for this Icon
- * @param tint to be applied to [bitmap]. If no intent is provided, then a default is used
+ * @param tint to be applied to [bitmap]. If no tint is provided, then a default is used.
  * @param size one of [IconSize] to be applied as size of the icon.
  * If no size is provided the default [IconSize.Medium] is used.
  */
@@ -166,7 +166,7 @@ public fun Icon(
  * and does not represent a meaningful action that a user can take. This text should be
  * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
  * @param modifier optional [Modifier] for this Icon
- * @param tint to be applied to [painter]. If no intent is provided, then a default is used
+ * @param tint to be applied to [painter]. If no tint is provided, then a default is used.
  * @param size one of [IconSize] to be applied as size of the icon.
  * If no size is provided the default [IconSize.Medium] is used.
  */
@@ -192,7 +192,7 @@ public fun Icon(
 
 /**
  * A [Painter] that can be used to draw a [SparkIcon]. This will use the correct painter for whatever type the SparkIcon
- * use.
+ * uses.
  * @param sparkIcon the icon to draw.
  * @param atEnd Whether the animated vector should be rendered at the end of all its animations.
  */

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
@@ -262,7 +262,7 @@ internal fun ImageIconState(
         EmphasizeDim2 {
             Icon(
                 sparkIcon = sparkIcon,
-                contentDescription = null, // The SparkImage handle the content description
+                contentDescription = null, // SparkImage handles the content description.
                 modifier = Modifier.ifNotNull(size) {
                     imageIconDynamicSize(it)
                 },
@@ -315,10 +315,8 @@ private fun Constraints.checkThatImageHasDefinedSize(
 }
 
 /**
- * This modifier allow us to define the icon size without relying on subcomposition which would block
- * some of our consumer usages
- *
- * @param dynamicSize
+ * This modifier allows us to define the icon size without relying on subcomposition which would block
+ * some of our consumer usages.
  */
 private fun Modifier.imageIconDynamicSize(
     dynamicSize: (maxWidth: Dp, maxHeight: Dp) -> Dp,
@@ -372,7 +370,7 @@ public sealed class State {
     /** The current painter being drawn by [Image]. */
     public abstract val painter: Painter?
 
-    /** The request has not been started or the request has no data*/
+    /** The request has not been started or the request has no data. */
     public object Empty : State() {
         override val painter: Painter? get() = null
     }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/UserAvatar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/UserAvatar.kt
@@ -100,7 +100,7 @@ internal fun SparkUserAvatar(
                         val dotSize = style.badgeSize.toPx() / 2
                         val xOffset = style.badgeXOffset.toPx()
                         val yOffset = style.badgeYOffset.toPx()
-                        // Clip a white border for the content
+                        // BlendMode.Clear cuts a transparent ring to create the border gap.
                         drawCircle(
                             Color.Black,
                             radius = dotSize,
@@ -110,7 +110,7 @@ internal fun SparkUserAvatar(
                             ),
                             blendMode = BlendMode.Clear,
                         )
-                        // draw the colored circle indication
+                        // Draw the online indicator dot.
                         drawCircle(
                             indicatorColor,
                             radius = dotSize - style.borderSize.toPx(),
@@ -157,8 +157,7 @@ public fun UserAvatar(
  * @param badgeSize size of online badge in [Dp]
  * @param badgeXOffset size of the x offset of the badge in [Dp]
  * @param badgeYOffset size of the y offset of the badge in [Dp]
- * @param borderSize The indicator border size in [Dp], it needs to be defined since the border mechanisms is
- * different than figma
+ * @param borderSize The indicator border size in [Dp]. Must be set explicitly because the border mechanism differs from the Figma spec.
  */
 public enum class UserAvatarStyle(
     public val imageSize: Dp,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationRail.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationRail.kt
@@ -62,15 +62,15 @@ internal fun SparkNavigationRail(
 }
 
 /**
- * Spark bottom navigation rail.
+ * Spark navigation rail.
  * Navigation rails provide access to main destinations in apps when using tablet and desktop screens.
  *
  * The navigation rail should be used to display three to seven app destinations and, optionally,
  * a FloatingActionButton or a logo header.
  * NavigationRail should contain multiple NavigationRailItems, each representing a singular destination.
- * @param modifier commentCountthe Modifier to be applied to this navigation rail
- * @param header commentCountoptional header that may hold a FloatingActionButton or a logo
- * @param content commentCountthe content of this navigation rail, typically 3-7 NavigationRailItems
+ * @param modifier the Modifier to be applied to this navigation rail
+ * @param header optional header that may hold a FloatingActionButton or a logo
+ * @param content the content of this navigation rail, typically 3-7 NavigationRailItems
  */
 @ExperimentalSparkApi
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentDrawerSheet.kt
@@ -76,11 +76,11 @@ internal fun SparkPermanentDrawerSheet(
 
 /**
  * Content inside of a permanent navigation drawer.
- * @param modifier commentCountthe Modifier to be applied to this drawer's content
- * @param drawerContainerColor commentCountthe color used for the background of this drawer. Use Color.Transparent to have no color.
- * @param drawerContentColor commentCountthe preferred color for content inside this drawer. Defaults to either the matching content color
+ * @param modifier the Modifier to be applied to this drawer's content
+ * @param drawerContainerColor the color used for the background of this drawer. Use Color.Transparent to have no color.
+ * @param drawerContentColor the preferred color for content inside this drawer. Defaults to either the matching content color
  * for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
- * @param content commentCountcontent inside a permanent navigation drawer
+ * @param content content inside a permanent navigation drawer
  */
 @ExperimentalSparkApi
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentNavigationDrawer.kt
@@ -65,9 +65,9 @@ internal fun SparkPermanentNavigationDrawer(
  * The permanent navigation drawer is always visible and usually used for frequently switching destinations.
  * On mobile screens, use ModalNavigationDrawer instead.
  *
- * @param drawerContent commentCountcontent inside this drawer
- * @param modifier commentCountthe Modifier to be applied to this drawer
- * @param content commentCountcontent of the rest of the UI
+ * @param drawerContent content inside this drawer
+ * @param modifier the Modifier to be applied to this drawer
+ * @param content content of the rest of the UI
  */
 @ExperimentalSparkApi
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/PlaceholderFoundation.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/PlaceholderFoundation.kt
@@ -140,10 +140,8 @@ internal fun Modifier.placeholder(
     val lastLayoutDirection = remember { Ref<LayoutDirection>() }
     val lastOutline = remember { Ref<Outline>() }
 
-    // The current highlight animation progress
     var highlightProgress: Float by remember { mutableFloatStateOf(0f) }
 
-    // This is our crossfade transition
     val transitionState = remember { MutableTransitionState(visible) }.apply {
         targetState = visible
     }
@@ -175,7 +173,6 @@ internal fun Modifier.placeholder(
     val paint = remember { Paint() }
     remember(color, shape, highlight) {
         drawWithContent {
-            // Draw the composable content first
             if (contentAlpha in 0.01f..0.99f) {
                 // If the content alpha is between 1% and 99%, draw it in a layer with
                 // the alpha applied
@@ -218,7 +215,6 @@ internal fun Modifier.placeholder(
                 )
             }
 
-            // Keep track of the last size & layout direction
             lastSize.value = size
             lastLayoutDirection.value = layoutDirection
         }
@@ -226,7 +222,7 @@ internal fun Modifier.placeholder(
 }
 
 /**
- * Placeholder that holds the defaults values used by the public api
+ * Placeholder that holds the default values used by the public api
  */
 internal fun Modifier.basePlaceholder(
     visible: Boolean,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/popover/PopoverIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/popover/PopoverIntent.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.graphics.Color
 import com.adevinta.spark.SparkTheme
 
 /**
- * TagIntent is used to define the intent of the tag.
+ * PopoverIntent is used to define the intent of the popover.
  */
 public enum class PopoverIntent {
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/LinearProgressIndicator.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/LinearProgressIndicator.kt
@@ -42,7 +42,7 @@ internal fun SparkLinearProgressIndicator(
     isIndeterminate: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val color = ProgressIndicatorDefaults.linearColor // Main
+    val color = ProgressIndicatorDefaults.linearColor
     val trackColor = SparkTheme.colors.neutralContainer
     if (isIndeterminate) {
         MaterialLinearProgressIndicator(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/SpinnerIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/SpinnerIntent.kt
@@ -28,7 +28,7 @@ import com.adevinta.spark.components.IntentColor
 import com.adevinta.spark.components.IntentColors
 
 /**
- * SpinnerIntent is used to define the intent of the chip.
+ * SpinnerIntent is used to define the intent of the spinner.
  */
 public enum class SpinnerIntent {
     /**

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressStep.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressStep.kt
@@ -33,7 +33,7 @@ import com.adevinta.spark.icons.SparkIcon
  * @property label The label of the step to be displayed in the progress tracker. [AnnotatedString]s will be styled but
  * other class inheriting from [CharSequence] will be displayed as plain text.
  * @property enabled Indicate whether the step is enabled or disabled. Disabled steps won't be interactive.
- * @property icon The icon displayed when an icon is no yet considered as done by the user.
+ * @property icon The icon displayed when an icon is not yet considered as done by the user.
  * @property doneIcon The icon displayed when an icon is considered as done by the user
  */
 public data class ProgressStep(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressTracker.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressTracker.kt
@@ -218,7 +218,7 @@ private fun ProgressTracker(
 
     val progressTracks = @Composable {
         items.fastForEachIndexed { index, progressStep ->
-            // Since the track is layouted after the step, we need to check the next step to know if the track
+            // Since the track is laid out after the step, we need to check the next step to know if the track
             // should be enabled
             val nextIndex = (index + 1).coerceAtMost(items.size - 1)
             val nextStep = items[nextIndex]
@@ -247,7 +247,7 @@ private fun ProgressTracker(
     }
     val stepIndicators = @Composable {
         items.forEachIndexed { index, progressStep ->
-            // If the step is nul then consider that every step should not be shown as selected
+            // If selectedStep is null, no step is shown as selected
             val isDone = index < (selectedStep ?: -1)
             StepIndicator(
                 colors = colors,
@@ -464,7 +464,7 @@ private fun StepIndicator(
                         modifier = Modifier
                             .size(indicatorSize)
                             .wrapContentSize(Alignment.Center),
-                        contentDescription = null, // content description is handle on the Layout
+                        contentDescription = null, // content description is handled on the Layout
                         atEnd = true,
                     )
                 } else if (icon != null) {
@@ -473,7 +473,7 @@ private fun StepIndicator(
                         modifier = Modifier
                             .size(indicatorSize)
                             .wrapContentSize(Alignment.Center),
-                        contentDescription = null, // content description is handle on the Layout
+                        contentDescription = null, // content description is handled on the Layout
                         atEnd = true,
                     )
                 } else {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressTrackerMeasurePolicy.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressTrackerMeasurePolicy.kt
@@ -53,7 +53,7 @@ internal data class ProgressTrackerMeasurePolicy(
         val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
 
         val stepsCount = indicatorMeasurables.size
-        // Each indicator  have a fixed size coming from the size object
+        // Each indicator has a fixed size coming from the size object
         val indicatorSize = indicatorSize.roundToPx()
         // Calculate the width of each step, taking into account the padding between steps
         val stepsWidth = (constraints.maxWidth / stepsCount)

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progressbar/ProgressbarIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progressbar/ProgressbarIntent.kt
@@ -92,7 +92,7 @@ public enum class ProgressbarIntent {
     },
 
     /**
-     * Used informational valuable actions.
+     * Used for informational actions.
      */
     Info {
         @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingSmall.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingSmall.kt
@@ -54,7 +54,7 @@ import java.util.Locale
  *  - ★ 3,4 (5)
  * @param value rating value as a float, should be between 1.0 and 5.0
  * @param modifier to apply
- * @param commentCount the count of comments are associated with this rating
+ * @param commentCount the number of comments associated with this rating
  */
 @InternalSparkApi
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingStar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingStar.kt
@@ -49,7 +49,6 @@ import com.adevinta.spark.tokens.dim5
  * RatingStar is the atomic element of rating components
  * @param modifier to be applied
  * @param enabled whether the star should be enabled or disabled
- * @param modifier to be applied
  * @param size of the star, can be any size but preferably, use [RatingDefault.StarSize] or [RatingDefault.SmallStarSize].
  * @param state of the star,
  * can be [RatingStarState.Full], [RatingStarState.Empty] or [RatingStarState.Half]

--- a/spark/src/main/kotlin/com/adevinta/spark/components/scaffold/Scaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/scaffold/Scaffold.kt
@@ -113,7 +113,7 @@ public fun Scaffold(
         contentColor = contentColor,
         contentWindowInsets = contentWindowInsets,
     ) { innerPadding ->
-        // Wrapping it in a surface since the scaffold use the M3 Surface that apply a tint overlay
+        // Wrapping in a surface since the scaffold uses the M3 Surface that applies a tint overlay
         Surface(
             color = containerColor,
             contentColor = contentColor,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/segmentedcontrol/SegmentedControl.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/segmentedcontrol/SegmentedControl.kt
@@ -233,8 +233,8 @@ private fun row0Count(segmentCount: Int): Int = (segmentCount + 1) / 2
 
 private enum class SegmentSlot { Segments, Indicator, Dividers, RowDivider }
 
-// We suppress the content emmiter with returning values as we use it to enforce which composable we accept inside the
-// segemented control slot
+// We suppress the content emitter with returning values as we use it to enforce which composable we accept inside the
+// segmented control slot
 @SuppressLint("ComposeContentEmitterReturningValues")
 private object SegmentedControlScopeImpl : SegmentedControlScope {
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/slider/SliderIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/slider/SliderIntent.kt
@@ -92,7 +92,7 @@ public enum class SliderIntent {
     },
 
     /**
-     * Used informational valuable actions.
+     * Used for informational actions.
      */
     Info {
         @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarHost.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarHost.kt
@@ -176,14 +176,13 @@ public class SnackbarHostState {
     ) : SnackbarData {
 
         /**
-         *Function to be called when Snackbar action has been performed to notify the listeners
+         * Function to be called when Snackbar action has been performed to notify the listeners
          */
         override fun performAction() {
             if (continuation.isActive) continuation.resume(SnackbarResult.ActionPerformed)
         }
 
         /**
-         * Dismisses the Snackbar.
          * Function to be called when Snackbar is dismissed either by timeout or by the user
          */
         override fun dismiss() {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/IconButton.kt
@@ -83,7 +83,7 @@ internal fun IconButton(
         },
         modifier = modifier
             .sizeIn(minWidth = 44.dp, minHeight = 44.dp)
-            .focusProperties { canFocus = false }, // Focus is show by the parent
+            .focusProperties { canFocus = false }, // Focus is shown by the parent
         enabled = enabled,
         shape = shape,
         color = containerColor,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/Dropdown.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/Dropdown.kt
@@ -254,7 +254,7 @@ public fun SelectTextField(
  * @param keyboardActions when the input service emits an IME action, the corresponding callback
  * is called. Note that this IME action may be different from what you specified in
  * [KeyboardOptions.imeAction]
- * @param properties commentCountPopupProperties for further customization of this popup's behavior.
+ * @param properties PopupProperties for further customization of this popup's behavior.
  * @param interactionSource the [MutableInteractionSource] representing the stream of
  * [Interaction]s for this TextField. You can create and pass in your own remembered
  * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
@@ -362,7 +362,7 @@ public fun SelectTextField(
  * @param visualTransformation transforms the visual representation of the input [value]
  * For example, you can use [PasswordVisualTransformation][androidx.compose.ui.text.input.PasswordVisualTransformation]
  * to create a password text field. By default no visual transformation is applied
- * @param properties commentCountPopupProperties for further customization of this popup's behavior.
+ * @param properties PopupProperties for further customization of this popup's behavior.
  * @param interactionSource the [MutableInteractionSource] representing the stream of
  * [Interaction]s for this TextField. You can create and pass in your own remembered
  * [MutableInteractionSource] if you want to observe [Interaction]s and customize the

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/TextField.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/TextField.kt
@@ -174,7 +174,7 @@ public fun TextField(
  * information about expected text
  * @param counter The optional counter to be displayed the the end bottom outside the text input container
  * @param leadingContent the optional leading icon to be displayed at the beginning of the text field
- * container, note that
+ * container
  * @param trailingContent the optional trailing icon to be displayed at the end of the text field
  * container
  * @param state indicates the validation state of the text field. The label, outline, leading & trailing content are

--- a/spark/src/main/kotlin/com/adevinta/spark/res/AnnotatedStringResource.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/res/AnnotatedStringResource.kt
@@ -107,7 +107,7 @@ public fun annotatedStringResource(@StringRes id: Int, formatArgs: PersistentMap
 /**
  * Load a annotated string resource with formatting.
  *
- * Be aware that using this method you'll loose the annotations support.
+ * Be aware that using this method you will lose annotation support.
  *
  * @param id the resource identifier
  * @param formatArgs the format arguments
@@ -249,8 +249,8 @@ internal fun resources(): Resources = LocalResources.current
 /**
  * The framework `getText()` method doesn't support formatting arguments, so we need to do it ourselves.
  *
- * Unfortunately `toHtml()` doesn't support the `<annotation>` tag so we loose this span as we need to convert it to a
- * [String] to be able to use `String.format()`.
+ * Unfortunately `toHtml()` doesn't support the `<annotation>` tag, so we lose this span when converting to a
+ * [String] to use `String.format()`.
  */
 private fun Resources.getText(@StringRes id: Int, vararg args: Any): CharSequence {
     val escapedArgs = args.map {
@@ -273,8 +273,8 @@ internal fun Resources.getQuantityText(@PluralsRes id: Int, quantity: Int, varar
 }
 
 /**
- * Convert a [Spanned] to a [String] without the `<p dir="ltr">` and `</p>` tags that are added by `toHtml()` which
- * added a padding at the end of the text.
+ * Converts a [Spanned] to a [String] without the `<p dir="ltr">` and `</p>` tags added by `toHtml()`,
+ * which add unwanted padding at the end of the text.
  */
 private fun Spanned.toHtmlWithoutParagraphs(): String = toHtml()
     .substringAfter("<p dir=\"ltr\">")

--- a/spark/src/main/kotlin/com/adevinta/spark/res/SparkStringAnnotations.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/res/SparkStringAnnotations.kt
@@ -33,7 +33,7 @@ import com.adevinta.spark.tokens.SparkTypography
 public object SparkStringAnnotations {
 
     /**
-     * Given a string representing an annotation key and a string representing an annotation value, returns the corresponding [SpanStyle].
+     * Returns the [SpanStyle] for the given [annotation], or null if the key/value is unsupported.
      */
     public fun toSpanStyle(
         annotation: Annotation,
@@ -49,9 +49,7 @@ public object SparkStringAnnotations {
         }
     }
 
-    /**
-     * Given a string representing annotation value of a spark color, returns the corresponding [SpanStyle] with the color token.
-     */
+    /** Returns a [SpanStyle] for the named Spark colour token, or null if the name is unknown. */
     private fun String.toColorSpanStyle(token: SparkColors): SpanStyle? = when (this) {
         "main" -> token.main
 
@@ -74,9 +72,7 @@ public object SparkStringAnnotations {
         }
     }?.let(::SpanStyle)
 
-    /**
-     * Given a string representing annotation value of a spark typography, returns the corresponding [SpanStyle] with the typography token.
-     */
+    /** Returns a [SpanStyle] for the named Spark typography token, or null if the name is unknown. */
     private fun String.toTypographySpanStyle(token: SparkTypography): SpanStyle? = when (this) {
         "display1" -> token.display1
 

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
@@ -686,8 +686,8 @@ public fun darkHighContrastSparkColors(
  * @property onAiContainer Color used for text and icons displayed on top of the [aiContainer] color.
  * @property background The background color that appears behind scrollable content.
  * @property onBackground Color used for text and icons displayed on top of the background color.
- * @property backgroundVariant The background color that appears behind scrollable content.
- * @property onBackgroundVariant Color used for text and icons displayed on top of the background color.
+ * @property backgroundVariant An alternate background color for surfaces that need visual separation from [background].
+ * @property onBackgroundVariant Color used for text and icons displayed on top of [backgroundVariant].
  * @property surface The surface color that affect surfaces of components, such as cards, sheets,
  * and menus.
  * @property onSurface Color used for text and icons displayed on top of the surface color.
@@ -1305,9 +1305,8 @@ public fun SparkColors.asMaterial3Colors(): ColorScheme = ColorScheme(
  * This function adapts the color values from a Material Design ColorScheme
  * to the structure and naming conventions used by SparkColors.
  * The following tokens [SparkColors.mainVariant], [SparkColors.accentVariant],
- * [SparkColors.supportVariant] and their on counterparts have no equivalent in Material so
- * their are juste derivative of their principal token with a different tone that needs to
- * be different for each (90/10 or 10/99).
+ * [SparkColors.supportVariant] and their on-counterparts have no equivalent in Material, so
+ * they are derived from their principal token with a different tone (90/10 or 10/99).
  * It handles both light and dark themes by adjusting the color tones accordingly.
  *
  * @param useDark Whether to generate colors for a dark theme as the tone used for
@@ -1515,9 +1514,8 @@ public val Color.disabled: Color
     @Composable get() = this.dim3.compositeOver(SparkTheme.colors.surface)
 
 /**
- * Extension property to get a [Color] that apply an alpha of zero to the color.
- * This is useful when you want to animate fro ma transparent color to a colored one
- * since using  [Color.Transparent] will start with a black background.
+ * Returns this [Color] with an alpha of zero. Use this when animating from transparent to a colour,
+ * because [Color.Transparent] is opaque black under the hood and produces a black flash.
  */
 @get:SuppressLint("ComposeUnstableReceiver") // https://github.com/slackhq/compose-lints/issues/326
 public val Color.transparent: Color

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/ContentColor.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/ContentColor.kt
@@ -40,12 +40,8 @@ import com.adevinta.spark.icons.IdentityCardOutline
 import com.adevinta.spark.icons.LeboncoinIcons
 
 /**
- * This function is used to set the current value of [LocalContentColor] to onSurface. Any [Text], Icons, other
- * components included.
- *
- * This is the default emphasis applied in the whole theme.
- * This component's [content] will be styled with this a content color alpha that apply a medium emphasis which
- * is close to Black.
+ * Sets [LocalContentColor] to [SparkColors.onSurface], the full-emphasis colour. This is the
+ * default emphasis for the whole theme.
  */
 @Composable
 public fun EmphasizeHigh(content: @Composable () -> Unit) {
@@ -53,9 +49,7 @@ public fun EmphasizeHigh(content: @Composable () -> Unit) {
 }
 
 /**
- * This function is used to set the current value of [LocalContentColor] to onSurfaceVariant. Any [Text], Icons, other
- * components included in this component's [content] will be styled with this a content color alpha that apply a
- * medium emphasis which is close to Dark Gray.
+ * Sets [LocalContentColor] to [SparkColors.onSurface] at [dim1] alpha (medium emphasis, close to dark grey).
  */
 @Composable
 public fun EmphasizeMedium(content: @Composable () -> Unit) {
@@ -66,9 +60,7 @@ public fun EmphasizeMedium(content: @Composable () -> Unit) {
 }
 
 /**
- * This function is used to set the current value of [LocalContentColor] to onSurface with a disabled alpha.
- * Any [Text], Icons, other  components included in this component's [content] will be styled with this a content
- * color alpha that apply a disabled emphasis which is close to Gray or Light Gray.
+ * Sets [LocalContentColor] to [SparkColors.onSurface] at [dim3] alpha (disabled emphasis, close to grey).
  */
 @Composable
 public fun EmphasizeDisable(content: @Composable () -> Unit) {
@@ -125,9 +117,7 @@ public fun EmphasizeDim4(content: @Composable () -> Unit) {
 }
 
 /**
- * Used for press and ripples
- *
- * This is should not be used on Android as the Material Ripple handles this already.
+ * Sets [LocalContentColor] at [dim5] alpha. Do not use on Android; the Material Ripple handles press states already.
  */
 @InternalSparkApi
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Elevation.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Elevation.kt
@@ -89,8 +89,7 @@ internal suspend fun Animatable<Dp, *>.animateElevation(
         // Moving to default, from a previous state
         from != null -> ElevationDefaults.outgoingAnimationSpecForInteraction(from)
 
-        // Loading the initial state, or moving back to the baseline state from a disabled /
-        // unknown state, so just snap to the final value.
+        // No known interaction: snap to the target value without animating.
         else -> null
     }
     if (spec != null) animateTo(target, spec) else snapTo(target)

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Font.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Font.kt
@@ -45,9 +45,7 @@ public fun sparkFontFamily(
     fontFamily = fontFamily,
 )
 
-/**
- * Utility class to handle the change of font family for the SparkTheme.
- */
+/** Holds the active font family for the SparkTheme, with optional token-highlighter override. */
 @Immutable
 public class SparkFontFamily(private val useSparkTokensHighlighter: Boolean, private val fontFamily: FontFamily) {
     /**

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Layout.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Layout.kt
@@ -132,7 +132,6 @@ internal fun LayoutPreview() {
                     horizontal = bodyMargin,
                     vertical = gutter,
                 ),
-                // We minus 8.dp off the grid padding, as we use content padding on the items below
                 horizontalArrangement = Arrangement.spacedBy(gutter),
                 verticalArrangement = Arrangement.spacedBy(gutter),
                 modifier = Modifier

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Shape.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Shape.kt
@@ -139,9 +139,7 @@ public fun SparkShapes.asMaterial3Shapes(): Material3Shapes = Material3Shapes(
 public val CornerBasedShape.highlight: CornerBasedShape
     get() = copy(bottomStart = CornerSize(percent = 0))
 
-/**
- * CompositionLocal used to specify the default shapes for the surfaces.
- */
+/** CompositionLocal that provides the current [SparkShapes] down the composition tree. */
 internal val LocalSparkShapes = staticCompositionLocalOf { SparkShapes() }
 
 @Preview(

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/SparkExceptionHandler.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/SparkExceptionHandler.kt
@@ -24,9 +24,8 @@ package com.adevinta.spark.tools
 import androidx.compose.runtime.Stable
 
 /**
- * Implementations of this interface provide a centralized mechanism for
- * dealing with errors and exceptions that may arise when using a Spark component in an unexpected way.
- * This allows for custom error handling logic, such as log reporting for production or crash in development.
+ * Centralised handler for errors that arise when a Spark component is used unexpectedly.
+ * Implementations can log in production or crash in development.
  */
 @Stable
 public fun interface SparkExceptionHandler {

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Drawings.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Drawings.kt
@@ -151,8 +151,7 @@ private fun Modifier.dashedBorder(width: Dp, brush: Brush, shape: Shape): Modifi
 
     onDrawWithContent {
         drawContent()
-        // Only draw the border if a have a valid stroke parameter. If we have
-        // an invalid border size we will just draw the content
+        // Only draw the border when stroke is non-null. A zero or negative border size skips it.
         if (stroke != null) {
             if (insetOutline != null && pathClip != null) {
                 val isSimpleRoundRect = insetOutline is Outline.Rounded &&
@@ -160,8 +159,7 @@ private fun Modifier.dashedBorder(width: Dp, brush: Brush, shape: Shape): Modifi
                 withTransform(
                     {
                         clipPath(pathClip)
-                        // we are drawing the round rect not as a path so we must
-                        // translate ourselves othe
+                        // Drawing a round rect directly (not via path), so translate manually.
                         if (isSimpleRoundRect) {
                             translate(inset, inset)
                         }

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Semantics.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Semantics.kt
@@ -28,16 +28,12 @@ import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 
 /**
- * If present, this node is considered hidden from accessibility services.
+ * Marks this node as hidden from accessibility services, causing screen readers to skip it during
+ * linear navigation. Use this when the node is obscured (for example, under a scrim) and should
+ * not be announced.
  *
- * For example, if the node is currently occluded by a dark semitransparent pane above it, then for
- * all practical purposes the node should not be announced to the user. Since the system cannot
- * automatically determine that, this property can be set to make the screen reader linear
- * navigation skip over this type of node.
- *
- * If looking for a way to clear semantics of small items from the UI tree completely because they
- * are redundant with semantics of their parent, consider [SemanticsModifier.clearAndSetSemantics]
- * instead.
+ * To remove redundant semantics that are already covered by a parent node, use
+ * [SemanticsModifier.clearAndSetSemantics] instead.
  */
 public fun Modifier.invisibleSemantic(): Modifier =
     semantics { hideFromAccessibility() }

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/UsageOverlay.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/UsageOverlay.kt
@@ -71,7 +71,7 @@ private class SparkUsageOverlayElement(val overlayColor: Color) : ModifierNodeEl
 }
 
 /**
- * A Composable that hides its content and draw a dashed border to identify slot areas.
+ * A composable that hides its content and draws a dashed border to identify slot areas.
  */
 @Composable
 internal fun SlotArea(


### PR DESCRIPTION
Comments had drifted from the code they described. Wrong component names in KDoc (e.g. "chip" in SpinnerIntent, "TagIntent" in PopoverIntent), typos ("teh", "juste", "fro ma"), stale references to removed parameters, and self-evident narration that restated the next line all added noise for readers and agents navigating the source.

This pass fixes inaccurate comments, removes dead narration and commented-out code, replaces em dashes with full stops or commas, shortens verbose multi-line blocks to one-liners, and adds doc comments to public symbols that lacked them. 92 files changed, all edits are comment-only, no logic touched.