### PR TITLE
docs: standardise accessibility standard reference to RAAM

### DIFF
--- a/docs/COMPONENT_CREATION_GUIDE.md
+++ b/docs/COMPONENT_CREATION_GUIDE.md
@@ -579,7 +579,7 @@ All component contributions must pass automated quality checks:
 - **Lint checks** enforce architectural compliance
 - **Code formatting** meets established standards
 - **Documentation** includes comprehensive API coverage
-- **Accessibility** meets WCAG 2.1 AA guidelines
+- **Accessibility** meets [RAAM](https://accessibilite.public.lu/fr/raam1.1/index.html) guidelines
 
 ### Design System Governance
 


### PR DESCRIPTION
## Changes

Standardise the accessibility standard reference in `docs/COMPONENT_CREATION_GUIDE.md` from WCAG 2.1 AA to [RAAM](https://accessibilite.public.lu/fr/raam1.1/index.html), matching the rest of the project (e.g. `CONTRIBUTING.md`).

## Context

The project uses RAAM as its accessibility standard, but `COMPONENT_CREATION_GUIDE.md` still referenced WCAG 2.1 AA. This inconsistency confused contributors about which standard to target.

Closes #2119

## Checklist

- [x] I have reviewed the submitted code.
- [x] No runtime change, documentation only.
