### PR TITLE
chore: add paseo config and promote slider API to stable

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/slider/RangeSlider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/slider/RangeSlider.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.adevinta.spark.ExperimentalSparkApi
 import com.adevinta.spark.InternalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
@@ -117,7 +116,6 @@ internal fun SparkRangeSlider(
  * but rather to know when the user has completed selecting a new value by ending a drag or a click.
  */
 @OptIn(ExperimentalMaterial3Api::class)
-@ExperimentalSparkApi
 @Composable
 public fun RangeSlider(
     value: ClosedFloatingPointRange<Float>,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/slider/Slider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/slider/Slider.kt
@@ -60,7 +60,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import com.adevinta.spark.ExperimentalSparkApi
 import com.adevinta.spark.InternalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
@@ -406,7 +405,6 @@ internal fun Track(
  * and customize the appearance / behavior of this slider in different states.
  */
 @OptIn(ExperimentalMaterial3Api::class)
-@ExperimentalSparkApi
 @Composable
 public fun Slider(
     value: Float,


### PR DESCRIPTION
## Changes

- Remove `@ExperimentalSparkApi` from `Slider` and `RangeSlider`, promoting both to stable public API