### PR TITLE
docs: add 3.0 migration guide to UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,18 @@
 
 Migration guides for breaking changes, newest first. For a full list of changes see [CHANGELOG.md](CHANGELOG.md).
 
+## Upgrading to 3.0
+
+### `contentSide` parameter removed from toggles
+
+The `contentSide` parameter has been removed from `CheckboxLabelled`, `RadioButtonLabelled`, and `SwitchLabelled` to enforce a consistent label placement across the design system.
+
+### Deprecated `ToggleIntent` APIs removed
+
+The deprecated `ToggleIntent` enum and the `intent` parameter have been removed. Use the `error` parameter to represent validation states.
+
+---
+
 ## Upgrading to 2.0
 
 ### Snackbar API redesigned


### PR DESCRIPTION
## 📋 Changes

- Added an **Upgrading to 3.0** section to `UPGRADING.md`.
- i have documented the removal of the `contentSide` parameter from labelled toggle components.
- and documented the removal of the deprecated `ToggleIntent` enum and `intent` parameter.
- and added migration guidance based on the documented 3.0 breaking changes.

## 🤔 Context

This PR adds the missing migration guide for the 3.0 release to help users upgrade from previous versions.

Closes #2099

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator. *(Not applicable – documentation-only change.)*