### PR TITLE
docs: add localisation change type to changelog guide

### DIFF
--- a/docs/CHANGELOG STYLE GUIDE.md
+++ b/docs/CHANGELOG STYLE GUIDE.md
@@ -40,8 +40,10 @@ Use emojis and clear keywords to categorize changes:
 - 🔧 Maintenance:
 - 🚀 Performance Improvement:
 - 📝 Documentation:
+- 💬 Localisation / Translation:
 - ⬆️ Dependency Update:
 - 🗑️ Deprecation/Removal:
+
 
 ## Detailed Entries
 


### PR DESCRIPTION
## What does this PR do?

Adds the missing 💬 Localisation / Translation category to the CHANGELOG style guide.

## Why?

The example entry used the 💬 emoji, but it was not included in the Change Types list, which made the category unclear for contributors.

## Related issue

Closes #2128