### PR TITLE
docs: fix ABI update task name

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -65,7 +65,7 @@ at two points:
 
 1. **Update screenshots and ABI** -- If an icon is removed, added, or modified,
    paparazzi will ask you to update the golden screenshots. If an icon is added,
-   removed, or renamed, update the ABI with `./gradlew updateLegacyAbi`.
+   removed, or renamed, update the ABI with `./gradlew updateKotlinAbi`.
 2. **Merge the Release PR** that release-please opens against `hotfix/X.Y.Z+1`.
    Merging it creates the tag and publishes the new version to Maven Central.
 


### PR DESCRIPTION
## 📋 Changes

Replace the nonexistent `updateLegacyAbi` command in the icon hotfix instructions with `updateKotlinAbi`.

## 🤔 Context

Spark uses Kotlin 2.4.10 and configures KGP’s experimental `abiValidation` DSL. That API creates the [`updateKotlinAbi`](https://kotlinlang.org/docs/gradle-binary-compatibility-validation.html#update-reference-abi-dump) task, which is also the command already documented in `docs/CONTRIBUTING.md`.

This resolves the stale command reported in #2101. The issue suggested `updateAbi`, but that task is not defined by the current KGP API.

Closes #2101

## ✅ Checklist

- [x] I have reviewed the submitted documentation change.

## 🗒️ Verification

- Repository-wide search confirms no `updateLegacyAbi` references remain
- The release command now matches `docs/CONTRIBUTING.md`
- Kotlin 2.4.10 source defines `KotlinAbiUpdateTask.NAME` as `updateKotlinAbi`
- `git diff --check`