### PR TITLE
docs: fix checkbox state sample

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.md
@@ -18,7 +18,7 @@ var checkedState by remember { mutableStateOf(ToggleableState.On) }
 Checkbox(
     state = checkedState,
     onClick = {
-        isChecked = !isChecked
+        checkedState = if (checkedState == ToggleableState.On) ToggleableState.Off else ToggleableState.On
     }
 )
 ```


### PR DESCRIPTION
## 📋 Changes

- update the standalone checkbox sample to mutate its declared `checkedState` value
- remove the undefined `isChecked` reference

## 🤔 Context

The current snippet cannot compile because `isChecked` is never declared. The corrected callback toggles the sample between `ToggleableState.On` and `ToggleableState.Off`.

Closes #2102

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [x] `git diff --check` passes.
- [x] The snippet no longer references `isChecked` and mutates the declared state.

## 🗒️ Other info

Java is unavailable in the local environment, so Gradle/Dokka validation was not run. This changes only the one-line documentation snippet.