### PR TITLE
docs(tags): fix code fence

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.md
@@ -31,7 +31,7 @@ FlowRow(
     TagTinted(text = "Tag small 5", intent = TagIntent.Main)
     TagOutlined(text = "Tag 6", intent = TagIntent.Main)
 }
-````
+```
 
 ### Tag Intent "Surface"
 


### PR DESCRIPTION
## 📋 Changes

Fix the closing code fence in `Tag.md`.

## 🤔 Context

The extra backtick caused the rest of the page to render as code.

Closes #2122

## ✅ Checklist

- [x] I have reviewed the submitted code.

## 🗒️ Other info

Validation: `./gradlew :spark:spotlessCheck`