### PR TITLE
feat(stepper): introduce Nudger and Input variants with new Stepper object API

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/fileupload/FileUploadConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/fileupload/FileUploadConfigurator.kt
@@ -19,6 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+@file:Suppress("DEPRECATION")
+
 package com.adevinta.spark.catalog.configurator.samples.fileupload
 
 import androidx.compose.animation.AnimatedVisibility

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/stepper/StepperConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/stepper/StepperConfigurator.kt
@@ -47,7 +47,6 @@ import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.snackbars.SnackbarHostState
 import com.adevinta.spark.components.snackbars.SnackbarIntent
 import com.adevinta.spark.components.stepper.Stepper
-import com.adevinta.spark.components.stepper.StepperForm
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.textfields.FormFieldStatus
 import com.adevinta.spark.components.textfields.TextField
@@ -60,212 +59,114 @@ import kotlinx.coroutines.launch
 
 public val StepperConfigurators: ImmutableList<Configurator> = persistentListOf(
     Configurator(
-        id = "stepper",
-        name = "Stepper",
-        description = "Stepper configuration",
+        id = "nudger",
+        name = "Nudger",
+        description = "Nudger stepper configuration",
         sourceUrl = "$SampleSourceUrl/StepperSamples.kt",
     ) { snackbarHostState, _ ->
-        StepperSample(snackbarHostState)
+        NudgerSample(snackbarHostState)
     },
     Configurator(
-        id = "stepper-form",
-        name = "Stepper Form",
-        description = "Stepper Form configuration with helper and label",
+        id = "nudger-form",
+        name = "Nudger Form",
+        description = "Nudger Form configuration with helper and label",
         sourceUrl = "$SampleSourceUrl/StepperSamples.kt",
     ) { snackbarHostState, _ ->
-        StepperFormSample(snackbarHostState)
+        NudgerFormSample(snackbarHostState)
+    },
+    Configurator(
+        id = "input",
+        name = "Input",
+        description = "Input stepper configuration",
+        sourceUrl = "$SampleSourceUrl/StepperSamples.kt",
+    ) { snackbarHostState, _ ->
+        InputSample(snackbarHostState)
+    },
+    Configurator(
+        id = "input-form",
+        name = "Input Form",
+        description = "Input Form configuration with helper and label",
+        sourceUrl = "$SampleSourceUrl/StepperSamples.kt",
+    ) { snackbarHostState, _ ->
+        InputFormSample(snackbarHostState)
     },
 )
 
+// region Nudger
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun ColumnScope.StepperSample(snackbarState: SnackbarHostState) {
+private fun ColumnScope.NudgerSample(snackbarState: SnackbarHostState) {
     var isEnabled by rememberSaveable { mutableStateOf(true) }
     var min by rememberSaveable { mutableIntStateOf(-2) }
     var max by rememberSaveable { mutableIntStateOf(100) }
-    var value by rememberSaveable { mutableIntStateOf(99) }
+    var value by rememberSaveable { mutableStateOf<Int?>(99) }
     var step by rememberSaveable { mutableIntStateOf(1) }
-    var stepFormStatus: TextFieldState? by rememberSaveable { mutableStateOf(null) }
-    var stepStatusMessage: String? by rememberSaveable { mutableStateOf(null) }
     var isFlexible by rememberSaveable { mutableStateOf(false) }
     var suffix by rememberSaveable { mutableStateOf("") }
-    var status: TextFieldState? by rememberSaveable { mutableStateOf(null) }
     val coroutineScope = rememberCoroutineScope()
-    Stepper(
+
+    Stepper.Nudger(
         modifier = Modifier.align(Alignment.CenterHorizontally),
         value = value,
-        onValueChange = {
-            value = it
-        },
+        onValueChange = { value = it },
         step = step,
         range = min..max,
         suffix = suffix,
         enabled = isEnabled,
         flexible = isFlexible,
-        status = status,
     )
-    SwitchLabelled(
-        checked = isEnabled,
-        onCheckedChange = { isEnabled = it },
-    ) {
-        Text(
-            text = "Enabled",
-            modifier = Modifier.fillMaxWidth(),
-        )
+
+    SwitchLabelled(checked = isEnabled, onCheckedChange = { isEnabled = it }) {
+        Text(text = "Enabled", modifier = Modifier.fillMaxWidth())
     }
-    SwitchLabelled(
-        checked = isFlexible,
-        onCheckedChange = { isFlexible = it },
-    ) {
-        Text(
-            text = "Flexible",
-            modifier = Modifier.fillMaxWidth(),
-        )
+    SwitchLabelled(checked = isFlexible, onCheckedChange = { isFlexible = it }) {
+        Text(text = "Flexible", modifier = Modifier.fillMaxWidth())
     }
-    val textFieldStates: MutableSet<TextFieldState?> =
-        TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
-    val buttonStylesLabel = textFieldStates.map { it?.run { name } ?: "Default" }.toImmutableList()
-    ButtonGroup(
-        title = "Status",
-        selectedOption = status?.name ?: "Default",
-        onOptionSelect = { status = if (it == "Default") null else TextFieldState.valueOf(it) },
-        options = buttonStylesLabel,
-    )
     FlowRow(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = spacedBy(8.dp),
         verticalArrangement = spacedBy(8.dp),
     ) {
-        TextField(
-            modifier = Modifier.weight(1f),
-            value = min.toString(),
-            onValueChange = {
-                val newMin = it.toIntOrNull()
-                when {
-                    newMin == null -> {
-                        coroutineScope.launch {
-                            snackbarState.showSnackbar(
-                                message = "The value for min: $it can't be used.",
-                                intent = SnackbarIntent.Error,
-                            )
-                        }
-                    }
-
-                    newMin > max -> {
-                        coroutineScope.launch {
-                            snackbarState.showSnackbar(
-                                message = "The value for min: $newMin can't be greater than $max.",
-                                intent = SnackbarIntent.Error,
-                            )
-                        }
-                        min = max - 1
-                    }
-
-                    else -> min = newMin
-                }
-            },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            label = "Min",
-            placeholder = "0",
-            helper = "Minimal range of the stepper",
-        )
-        TextField(
-            modifier = Modifier.weight(1f),
-            value = max.toString(),
-            onValueChange = {
-                val newMax = it.toIntOrNull()
-                when {
-                    newMax == null -> {
-                        coroutineScope.launch {
-                            snackbarState.showSnackbar(
-                                message = "The value for max: $it can't be used.",
-                                intent = SnackbarIntent.Error,
-                            )
-                        }
-                    }
-
-                    newMax < min -> {
-                        coroutineScope.launch {
-                            snackbarState.showSnackbar(
-                                message = "The value for max: $newMax can't be lesser than $min.",
-                                intent = SnackbarIntent.Error,
-                            )
-                        }
-                        max = min + 1
-                    }
-
-                    else -> max = newMax
-                }
-            },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            label = "Max",
-            placeholder = "15",
-            helper = "Maximal range of the stepper",
+        RangeFields(
+            min = min,
+            max = max,
+            onMinChange = { min = it },
+            onMaxChange = { max = it },
+            snackbarState = snackbarState,
+            coroutineScope = coroutineScope,
         )
         TextField(
             modifier = Modifier.weight(1f),
             value = suffix,
-            onValueChange = {
-                suffix = it
-            },
+            onValueChange = { suffix = it },
             label = "Suffix",
             placeholder = "%",
-            helper = "Suffix displayed after the value but is just decorative",
-        )
-        StepperForm(
-            value = step,
-            onValueChange = { newStep ->
-                when {
-                    max % newStep != 0 -> {
-                        stepFormStatus = FormFieldStatus.Error
-                        stepStatusMessage = "The max range must be a multiple of the step, but " +
-                            "has ${newStep % max} remaining"
-                    }
-
-                    min % newStep != 0 -> {
-                        stepFormStatus = FormFieldStatus.Error
-                        stepStatusMessage = "The min range must be a multiple of the step, but " +
-                            "has ${newStep % min} remaining"
-                    }
-
-                    else -> {
-                        stepFormStatus = null
-                        stepStatusMessage = null
-                        step = newStep
-                    }
-                }
-            },
-            range = 1..10,
-            label = "Step",
-            flexible = true,
-            status = stepFormStatus,
-            statusMessage = stepStatusMessage,
-            helper = "A step indicate by how much the stepper value is incremented or decremented",
+            helper = "Suffix displayed after the value",
         )
     }
 }
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun ColumnScope.StepperFormSample(snackbarState: SnackbarHostState) {
+private fun ColumnScope.NudgerFormSample(snackbarState: SnackbarHostState) {
     var isEnabled by rememberSaveable { mutableStateOf(true) }
     var isRequired by rememberSaveable { mutableStateOf(true) }
     var isFlexible by rememberSaveable { mutableStateOf(false) }
     var min by rememberSaveable { mutableIntStateOf(-2) }
     var max by rememberSaveable { mutableIntStateOf(10) }
-    var value by rememberSaveable { mutableIntStateOf(0) }
+    var value by rememberSaveable { mutableStateOf<Int?>(0) }
     var status: TextFieldState? by rememberSaveable { mutableStateOf(null) }
     var labelText by rememberSaveable { mutableStateOf("Label") }
     var helperText by rememberSaveable { mutableStateOf("Helper message") }
     val coroutineScope = rememberCoroutineScope()
-    StepperForm(
+
+    Stepper.NudgerForm(
         modifier = Modifier
             .align(Alignment.CenterHorizontally)
             .animateContentSize(),
         value = value,
-        onValueChange = {
-            value = it
-        },
+        onValueChange = { value = it },
         required = isRequired,
         range = min..max,
         enabled = isEnabled,
@@ -274,140 +175,286 @@ private fun ColumnScope.StepperFormSample(snackbarState: SnackbarHostState) {
         label = labelText,
         helper = helperText,
     )
-    SwitchLabelled(
-        checked = isEnabled,
-        onCheckedChange = { isEnabled = it },
-    ) {
-        Text(
-            text = "Enabled",
-            modifier = Modifier.fillMaxWidth(),
-        )
+
+    SwitchLabelled(checked = isEnabled, onCheckedChange = { isEnabled = it }) {
+        Text(text = "Enabled", modifier = Modifier.fillMaxWidth())
     }
-    SwitchLabelled(
-        checked = isFlexible,
-        onCheckedChange = { isFlexible = it },
-    ) {
-        Text(
-            text = "Flexible",
-            modifier = Modifier.fillMaxWidth(),
-        )
+    SwitchLabelled(checked = isFlexible, onCheckedChange = { isFlexible = it }) {
+        Text(text = "Flexible", modifier = Modifier.fillMaxWidth())
     }
-    SwitchLabelled(
-        checked = isRequired,
-        onCheckedChange = { isRequired = it },
-    ) {
-        Text(
-            text = "Required",
-            modifier = Modifier.fillMaxWidth(),
-        )
+    SwitchLabelled(checked = isRequired, onCheckedChange = { isRequired = it }) {
+        Text(text = "Required", modifier = Modifier.fillMaxWidth())
     }
-    val textFieldStates: MutableSet<TextFieldState?> =
-        TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
-    val buttonStylesLabel = textFieldStates.map { it?.run { name } ?: "Default" }.toImmutableList()
-    ButtonGroup(
-        title = "Status",
-        selectedOption = status?.name ?: "Default",
-        onOptionSelect = { status = if (it == "Default") null else TextFieldState.valueOf(it) },
-        options = buttonStylesLabel,
-    )
+
+    StatusButtonGroup(status = status, onStatusChange = { status = it })
+
     FlowRow(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = spacedBy(8.dp),
         verticalArrangement = spacedBy(8.dp),
     ) {
-        TextField(
-            modifier = Modifier.weight(1f),
-            value = min.toString(),
-            onValueChange = {
-                val newMin = it.toIntOrNull()
-                when {
-                    newMin == null -> {
-                        coroutineScope.launch {
-                            snackbarState.showSnackbar(
-                                message = "The value for min: $it can't be used.",
-                                intent = SnackbarIntent.Error,
-                            )
-                        }
-                    }
-
-                    newMin > max -> {
-                        coroutineScope.launch {
-                            snackbarState.showSnackbar(
-                                message = "The value for min: $newMin can't be greater than $max.",
-                                intent = SnackbarIntent.Error,
-                            )
-                        }
-                        min = max - 1
-                    }
-
-                    else -> min = newMin
-                }
-            },
-            label = "Min",
-            placeholder = "0",
-            helper = "Minimal range of the stepper",
-        )
-        TextField(
-            modifier = Modifier.weight(1f),
-            value = max.toString(),
-            onValueChange = {
-                val newMax = it.toIntOrNull()
-                when {
-                    newMax == null -> {
-                        coroutineScope.launch {
-                            snackbarState.showSnackbar(
-                                message = "The value for max: $it can't be used.",
-                                intent = SnackbarIntent.Error,
-                            )
-                        }
-                    }
-
-                    newMax < min -> {
-                        coroutineScope.launch {
-                            snackbarState.showSnackbar(
-                                message = "The value for max: $newMax can't be lesser than $min.",
-                                intent = SnackbarIntent.Error,
-                            )
-                        }
-                        max = min + 1
-                    }
-
-                    else -> max = newMax
-                }
-            },
-            label = "Max",
-            placeholder = "15",
-            helper = "Maximal range of the stepper",
+        RangeFields(
+            min = min,
+            max = max,
+            onMinChange = { min = it },
+            onMaxChange = { max = it },
+            snackbarState = snackbarState,
+            coroutineScope = coroutineScope,
         )
     }
     TextField(
         modifier = Modifier.fillMaxWidth(),
         value = labelText,
-        onValueChange = {
-            labelText = it
-        },
+        onValueChange = { labelText = it },
         label = "Label",
         placeholder = "Number of adults",
     )
     TextField(
         modifier = Modifier.fillMaxWidth(),
         value = helperText,
-        onValueChange = {
-            helperText = it
-        },
+        onValueChange = { helperText = it },
         label = "Helper",
-        placeholder = "A helper message aim to guide the user on what the field expect to contain",
+        placeholder = "A helper message",
     )
 }
 
+// endregion
+
+// region Input
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ColumnScope.InputSample(snackbarState: SnackbarHostState) {
+    var isEnabled by rememberSaveable { mutableStateOf(true) }
+    var min by rememberSaveable { mutableIntStateOf(0) }
+    var max by rememberSaveable { mutableIntStateOf(100) }
+    var value by rememberSaveable { mutableStateOf<Int?>(5) }
+    var step by rememberSaveable { mutableIntStateOf(1) }
+    var isFlexible by rememberSaveable { mutableStateOf(false) }
+    var status: TextFieldState? by rememberSaveable { mutableStateOf(null) }
+    val coroutineScope = rememberCoroutineScope()
+
+    Stepper.Input(
+        modifier = Modifier.align(Alignment.CenterHorizontally),
+        value = value,
+        onValueChange = { value = it },
+        step = step,
+        range = min..max,
+        enabled = isEnabled,
+        status = status,
+        flexible = isFlexible,
+    )
+
+    SwitchLabelled(checked = isEnabled, onCheckedChange = { isEnabled = it }) {
+        Text(text = "Enabled", modifier = Modifier.fillMaxWidth())
+    }
+    SwitchLabelled(checked = isFlexible, onCheckedChange = { isFlexible = it }) {
+        Text(text = "Flexible", modifier = Modifier.fillMaxWidth())
+    }
+    SwitchLabelled(
+        checked = value == null,
+        onCheckedChange = { value = if (it) null else min },
+    ) {
+        Text(text = "Null value", modifier = Modifier.fillMaxWidth())
+    }
+
+    StatusButtonGroup(status = status, onStatusChange = { status = it })
+
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = spacedBy(8.dp),
+        verticalArrangement = spacedBy(8.dp),
+    ) {
+        RangeFields(
+            min = min,
+            max = max,
+            onMinChange = { min = it },
+            onMaxChange = { max = it },
+            snackbarState = snackbarState,
+            coroutineScope = coroutineScope,
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ColumnScope.InputFormSample(snackbarState: SnackbarHostState) {
+    var isEnabled by rememberSaveable { mutableStateOf(true) }
+    var isRequired by rememberSaveable { mutableStateOf(true) }
+    var isFlexible by rememberSaveable { mutableStateOf(false) }
+    var min by rememberSaveable { mutableIntStateOf(0) }
+    var max by rememberSaveable { mutableIntStateOf(100) }
+    var value by rememberSaveable { mutableStateOf<Int?>(5) }
+    var status: TextFieldState? by rememberSaveable { mutableStateOf(null) }
+    var labelText by rememberSaveable { mutableStateOf("Quantity") }
+    var helperText by rememberSaveable { mutableStateOf("Enter a value") }
+    val coroutineScope = rememberCoroutineScope()
+
+    Stepper.InputForm(
+        modifier = Modifier
+            .align(Alignment.CenterHorizontally)
+            .animateContentSize(),
+        value = value,
+        onValueChange = { value = it },
+        required = isRequired,
+        range = min..max,
+        enabled = isEnabled,
+        status = status,
+        flexible = isFlexible,
+        label = labelText,
+        helper = helperText,
+    )
+
+    SwitchLabelled(checked = isEnabled, onCheckedChange = { isEnabled = it }) {
+        Text(text = "Enabled", modifier = Modifier.fillMaxWidth())
+    }
+    SwitchLabelled(checked = isFlexible, onCheckedChange = { isFlexible = it }) {
+        Text(text = "Flexible", modifier = Modifier.fillMaxWidth())
+    }
+    SwitchLabelled(checked = isRequired, onCheckedChange = { isRequired = it }) {
+        Text(text = "Required", modifier = Modifier.fillMaxWidth())
+    }
+    SwitchLabelled(
+        checked = value == null,
+        onCheckedChange = { value = if (it) null else min },
+    ) {
+        Text(text = "Null value", modifier = Modifier.fillMaxWidth())
+    }
+
+    StatusButtonGroup(status = status, onStatusChange = { status = it })
+
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = spacedBy(8.dp),
+        verticalArrangement = spacedBy(8.dp),
+    ) {
+        RangeFields(
+            min = min,
+            max = max,
+            onMinChange = { min = it },
+            onMaxChange = { max = it },
+            snackbarState = snackbarState,
+            coroutineScope = coroutineScope,
+        )
+    }
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = labelText,
+        onValueChange = { labelText = it },
+        label = "Label",
+        placeholder = "Quantity",
+    )
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = helperText,
+        onValueChange = { helperText = it },
+        label = "Helper",
+        placeholder = "A helper message",
+    )
+}
+
+// endregion
+
+// region Shared helpers
+
+@Composable
+private fun StatusButtonGroup(
+    status: TextFieldState?,
+    onStatusChange: (TextFieldState?) -> Unit,
+) {
+    val options = TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
+    val labels = options.map { it?.name ?: "Default" }.toImmutableList()
+    ButtonGroup(
+        title = "Status",
+        selectedOption = status?.name ?: "Default",
+        onOptionSelect = { onStatusChange(if (it == "Default") null else TextFieldState.valueOf(it)) },
+        options = labels,
+    )
+}
+
+@Composable
+private fun RangeFields(
+    min: Int,
+    max: Int,
+    onMinChange: (Int) -> Unit,
+    onMaxChange: (Int) -> Unit,
+    snackbarState: SnackbarHostState,
+    coroutineScope: kotlinx.coroutines.CoroutineScope,
+) {
+    TextField(
+        modifier = Modifier.fillMaxWidth(0.45f),
+        value = min.toString(),
+        onValueChange = {
+            val newMin = it.toIntOrNull()
+            when {
+                newMin == null -> coroutineScope.launch {
+                    snackbarState.showSnackbar(
+                        message = "The value for min: $it can't be used.",
+                        intent = SnackbarIntent.Error,
+                    )
+                }
+
+                newMin > max -> {
+                    coroutineScope.launch {
+                        snackbarState.showSnackbar(
+                            message = "Min ($newMin) can't be greater than max ($max).",
+                            intent = SnackbarIntent.Error,
+                        )
+                    }
+                    onMinChange(max - 1)
+                }
+
+                else -> onMinChange(newMin)
+            }
+        },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        label = "Min",
+        placeholder = "0",
+        helper = "Minimal range",
+    )
+    TextField(
+        modifier = Modifier.fillMaxWidth(0.45f),
+        value = max.toString(),
+        onValueChange = {
+            val newMax = it.toIntOrNull()
+            when {
+                newMax == null -> coroutineScope.launch {
+                    snackbarState.showSnackbar(
+                        message = "The value for max: $it can't be used.",
+                        intent = SnackbarIntent.Error,
+                    )
+                }
+
+                newMax < min -> {
+                    coroutineScope.launch {
+                        snackbarState.showSnackbar(
+                            message = "Max ($newMax) can't be less than min ($min).",
+                            intent = SnackbarIntent.Error,
+                        )
+                    }
+                    onMaxChange(min + 1)
+                }
+
+                else -> onMaxChange(newMax)
+            }
+        },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        label = "Max",
+        placeholder = "15",
+        helper = "Maximal range",
+    )
+}
+
+// endregion
+
 @Preview
 @Composable
-private fun PreviewStepperSample() {
-    PreviewTheme { StepperSample(SnackbarHostState()) }
+private fun PreviewNudgerSample() {
+    PreviewTheme { NudgerSample(SnackbarHostState()) }
 }
 
 @Preview
 @Composable
-private fun PreviewStepperFormSample() {
-    PreviewTheme { StepperFormSample(SnackbarHostState()) }
+private fun PreviewInputSample() {
+    PreviewTheme { InputSample(SnackbarHostState()) }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/stepper/StepperExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/stepper/StepperExamples.kt
@@ -25,7 +25,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -37,7 +37,7 @@ import com.adevinta.spark.catalog.model.Example
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.stepper.Stepper
-import com.adevinta.spark.components.stepper.StepperForm
+import com.adevinta.spark.components.stepper.rememberStepperInputState
 import com.adevinta.spark.components.stepper.stepperSemantics
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.textfields.FormFieldStatus
@@ -46,35 +46,31 @@ import kotlinx.collections.immutable.persistentListOf
 
 public val StepperExamples: ImmutableList<Example> = persistentListOf(
     Example(
-        id = "default",
-        name = "Base Stepper Example",
-        description = "Base interactions on stepper.",
-        sourceUrl = "$SampleSourceUrl/RatingDisplaySample.kt",
+        id = "nudger",
+        name = "Nudger",
+        description = "Base Nudger stepper with decrease/increase buttons.",
+        sourceUrl = "$SampleSourceUrl/StepperExamples.kt",
     ) {
-        var value by rememberSaveable { mutableIntStateOf(0) }
-        Stepper(
+        var value by rememberSaveable { mutableStateOf<Int?>(0) }
+        Stepper.Nudger(
             value = value,
-            onValueChange = {
-                value = it
-            },
+            onValueChange = { value = it },
         )
-        StepperForm(
+        Stepper.NudgerForm(
             value = value,
-            onValueChange = {
-                value = it
-            },
+            onValueChange = { value = it },
             label = "Label",
             required = true,
             helper = "Exemple de message d'aide",
         )
     },
     Example(
-        id = "states",
-        name = "Stepper States",
-        description = "Disabled and all regular states available for the TestField.",
-        sourceUrl = "$SampleSourceUrl/RatingDisplaySample.kt",
+        id = "nudger-states",
+        name = "Nudger States",
+        description = "Disabled and status states for the Nudger variant.",
+        sourceUrl = "$SampleSourceUrl/StepperExamples.kt",
     ) {
-        StepperForm(
+        Stepper.NudgerForm(
             value = 1,
             onValueChange = {},
             status = FormFieldStatus.Error,
@@ -82,21 +78,21 @@ public val StepperExamples: ImmutableList<Example> = persistentListOf(
             helper = "helper message",
             enabled = false,
         )
-        StepperForm(
+        Stepper.NudgerForm(
             value = 1,
             onValueChange = {},
             status = FormFieldStatus.Error,
             label = "Label",
             helper = "helper message",
         )
-        StepperForm(
+        Stepper.NudgerForm(
             value = -1,
             onValueChange = {},
             status = FormFieldStatus.Alert,
             label = "Label",
             helper = "helper message",
         )
-        StepperForm(
+        Stepper.NudgerForm(
             value = -1234,
             onValueChange = {},
             status = FormFieldStatus.Success,
@@ -104,27 +100,77 @@ public val StepperExamples: ImmutableList<Example> = persistentListOf(
             helper = "helper message",
         )
     },
-
     Example(
-        id = "states",
-        name = "Stepper States",
-        description = "Disabled and all regular states available for the TestField.",
-        sourceUrl = "$SampleSourceUrl/RatingDisplaySample.kt",
+        id = "input",
+        name = "Input",
+        description = "Input stepper with editable text field.",
+        sourceUrl = "$SampleSourceUrl/StepperExamples.kt",
     ) {
-        StepperForm(
-            value = 1,
+        var value by rememberSaveable { mutableStateOf<Int?>(3) }
+        Stepper.Input(
+            value = value,
+            onValueChange = { value = it },
+            range = 0..100,
+        )
+        Stepper.InputForm(
+            value = value,
+            onValueChange = { value = it },
+            label = "Quantity",
+            helper = "Enter a value between 0 and 100",
+            range = 0..100,
+            required = true,
+        )
+    },
+    Example(
+        id = "input-states",
+        name = "Input States",
+        description = "Status states for the Input variant.",
+        sourceUrl = "$SampleSourceUrl/StepperExamples.kt",
+    ) {
+        Stepper.InputForm(
+            value = 3,
             onValueChange = {},
             status = FormFieldStatus.Error,
+            statusMessage = "Value is invalid",
             label = "Label",
             helper = "helper message",
-            enabled = false,
         )
+        Stepper.InputForm(
+            value = 3,
+            onValueChange = {},
+            status = FormFieldStatus.Alert,
+            statusMessage = "Check this value",
+            label = "Label",
+            helper = "helper message",
+        )
+        Stepper.InputForm(
+            value = 3,
+            onValueChange = {},
+            status = FormFieldStatus.Success,
+            statusMessage = "Looks good",
+            label = "Label",
+            helper = "helper message",
+        )
+    },
+    Example(
+        id = "input-uncontrolled",
+        name = "Input (Uncontrolled)",
+        description = "Input stepper driven by StepperInputState.",
+        sourceUrl = "$SampleSourceUrl/StepperExamples.kt",
+    ) {
+        val state = rememberStepperInputState(initialValue = 5)
+        Stepper.Input(
+            state = state,
+            range = 0..100,
+            step = 1,
+        )
+        Text(text = "Current value: ${state.value ?: "empty"}")
     },
     Example(
         id = "custom-form",
         name = "Custom Stepper form",
-        description = "Stepper can show a suffix like `%`, `€` or `person•s`.",
-        sourceUrl = "$SampleSourceUrl/RatingInputSample.kt",
+        description = "Stepper.Nudger with allowSemantics = false in a custom layout.",
+        sourceUrl = "$SampleSourceUrl/StepperExamples.kt",
     ) {
         CustomStepper(
             value = 1,
@@ -186,10 +232,13 @@ private fun CustomStepper(
             Text(text = title)
             Text(text = subtitle)
         }
-        Stepper(
+        Stepper.Nudger(
             value = value,
-            onValueChange = {},
+            onValueChange = onValueChange,
             enabled = enabled,
+            range = range,
+            suffix = suffix,
+            step = step,
             allowSemantics = false,
         )
     }

--- a/spark-icons/build.gradle.kts
+++ b/spark-icons/build.gradle.kts
@@ -30,6 +30,9 @@ plugins {
 
 kotlin {
     android {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+        }
         namespace = "com.adevinta.spark.icons"
         // Doesn't seem to be available for kmp?
 //        resourcePrefix = "spark_icons_"

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/stepper/StepperDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/stepper/StepperDocumentationScreenshots.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.stepper
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.DeviceConfig
+import com.adevinta.spark.components.textfields.FormFieldStatus
+import com.adevinta.spark.paparazziRule
+import com.adevinta.spark.sparkDocSnapshot
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode.SHRINK
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Documentation screenshots for the Stepper component, following Material Design's approach of
+ * showing each variant with light and dark theme side by side.
+ */
+internal class StepperDocumentationScreenshots {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DeviceConfig.PIXEL_C,
+    )
+
+    @Test
+    fun nudger() = paparazzi.sparkDocSnapshot {
+        Column(
+            modifier = Modifier.padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Stepper.Nudger(value = 3, onValueChange = {}, suffix = "kg")
+            Stepper.Nudger(value = null, onValueChange = {})
+            Stepper.Nudger(value = 3, onValueChange = {}, enabled = false)
+        }
+    }
+
+    @Test
+    fun nudgerForm() = paparazzi.sparkDocSnapshot {
+        Column(
+            modifier = Modifier.padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Stepper.NudgerForm(
+                value = 3,
+                onValueChange = {},
+                label = "Quantity",
+                helper = "Helper text",
+                required = true,
+            )
+            Stepper.NudgerForm(
+                value = 3,
+                onValueChange = {},
+                label = "Quantity",
+                helper = "Helper text",
+                status = FormFieldStatus.Error,
+                statusMessage = "Error message",
+            )
+        }
+    }
+
+    @Test
+    fun input() = paparazzi.sparkDocSnapshot {
+        Column(
+            modifier = Modifier.padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Stepper.Input(value = 3, onValueChange = {}, range = 0..10, suffix = "kg")
+            Stepper.Input(value = null, onValueChange = {}, range = 0..10)
+            Stepper.Input(value = 3, onValueChange = {}, range = 0..10, enabled = false)
+            Stepper.Input(value = 3, onValueChange = {}, range = 0..10, status = FormFieldStatus.Error)
+        }
+    }
+
+    @Test
+    fun inputForm() = paparazzi.sparkDocSnapshot {
+        Column(
+            modifier = Modifier.padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Stepper.InputForm(
+                value = 3,
+                onValueChange = {},
+                label = "Quantity",
+                helper = "Helper text",
+                range = 0..10,
+                required = true,
+            )
+            Stepper.InputForm(
+                value = 3,
+                onValueChange = {},
+                label = "Quantity",
+                helper = "Error",
+                range = 0..10,
+                status = FormFieldStatus.Error,
+                statusMessage = "Error message",
+            )
+        }
+    }
+}

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/stepper/StepperScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/stepper/StepperScreenshot.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.stepper
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.components.textfields.FormFieldStatus
+import com.adevinta.spark.paparazziRule
+import com.adevinta.spark.sparkSnapshot
+import org.junit.Rule
+import org.junit.Test
+
+class StepperScreenshot {
+
+    @get:Rule
+    val paparazzi = paparazziRule()
+
+    @Test
+    fun nudger() = paparazzi.sparkSnapshot {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Stepper.Nudger(value = 3, onValueChange = {})
+            Stepper.Nudger(value = null, onValueChange = {})
+            Stepper.Nudger(value = 3, onValueChange = {}, enabled = false)
+        }
+    }
+
+    @Test
+    fun nudgerForm() = paparazzi.sparkSnapshot {
+        Column(
+            modifier = Modifier.padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Stepper.NudgerForm(
+                value = 3,
+                onValueChange = {},
+                label = "Label",
+                helper = "Helper text",
+                required = true,
+            )
+            Stepper.NudgerForm(
+                value = 3,
+                onValueChange = {},
+                label = "Label",
+                helper = "Helper text",
+                status = FormFieldStatus.Error,
+                statusMessage = "Error message",
+            )
+            Stepper.NudgerForm(
+                value = 3,
+                onValueChange = {},
+                label = "Label",
+                helper = "Helper text",
+                status = FormFieldStatus.Alert,
+                statusMessage = "Alert message",
+            )
+            Stepper.NudgerForm(
+                value = 3,
+                onValueChange = {},
+                label = "Label",
+                helper = "Helper text",
+                status = FormFieldStatus.Success,
+                statusMessage = "Success message",
+            )
+            Stepper.NudgerForm(
+                value = null,
+                onValueChange = {},
+                label = "Label",
+                helper = "Helper text",
+                enabled = false,
+            )
+        }
+    }
+
+    @Test
+    fun input() = paparazzi.sparkSnapshot {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Stepper.Input(value = 3, onValueChange = {}, range = 0..10)
+            Stepper.Input(value = null, onValueChange = {}, range = 0..10)
+            Stepper.Input(value = 3, onValueChange = {}, range = 0..10, enabled = false)
+            Stepper.Input(
+                value = 3,
+                onValueChange = {},
+                range = 0..10,
+                status = FormFieldStatus.Error,
+            )
+            Stepper.Input(
+                value = 3,
+                onValueChange = {},
+                range = 0..10,
+                status = FormFieldStatus.Success,
+            )
+        }
+    }
+
+    @Test
+    fun inputForm() = paparazzi.sparkSnapshot {
+        Column(
+            modifier = Modifier.padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Stepper.InputForm(
+                value = 3,
+                onValueChange = {},
+                label = "Label",
+                helper = "Helper text",
+                range = 0..10,
+                required = true,
+            )
+            Stepper.InputForm(
+                value = 3,
+                onValueChange = {},
+                label = "Label",
+                helper = "Error",
+                range = 0..10,
+                status = FormFieldStatus.Error,
+                statusMessage = "Error message",
+            )
+            Stepper.InputForm(
+                value = 3,
+                onValueChange = {},
+                label = "Label",
+                helper = "Alert",
+                range = 0..10,
+                status = FormFieldStatus.Alert,
+                statusMessage = "Alert message",
+            )
+            Stepper.InputForm(
+                value = 3,
+                onValueChange = {},
+                label = "Label",
+                helper = "Success",
+                range = 0..10,
+                status = FormFieldStatus.Success,
+                statusMessage = "Success message",
+            )
+            Stepper.InputForm(
+                value = null,
+                onValueChange = {},
+                label = "Label",
+                helper = "Helper text",
+                range = 0..10,
+                enabled = false,
+            )
+        }
+    }
+}

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_input.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:465686d348f872d972f887474a4e8814e8fbf72bfc0e4696037767ca07f846cd
+size 41318

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_inputForm.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_inputForm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea7d66ba0f5fd56c1accca3cf40f4d2b94a9bc86e34f1834123eeb081ef2a6f8
+size 41052

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudger.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:494b7017f826f586e9f87be0591ea708edd608210353de1d535491816696eb59
+size 31284

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudgerForm.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudgerForm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a41b551db68f5fc0931269620c5d52f43e284eb1a7fcec03de90b41ba6eb989c
+size 41175

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_input.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:905b2baeaa20898d197c6bd49886f12946a8a7b2cd720672426f641e80fedd07
+size 30581

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_inputForm.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_inputForm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c327f80a1dc20acf9ff0d15790702f3afe7b29a6f5c5c8a67316e0e9723ec4bb
+size 76923

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_nudger.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_nudger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac1bd36254fa3df7edc0f3dce9b523cf6b489add362452250cfd12812da7a224
+size 18591

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_nudger.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_nudger.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac1bd36254fa3df7edc0f3dce9b523cf6b489add362452250cfd12812da7a224
-size 18591
+oid sha256:89fa83c2fa3c60267e7d0ac898c58e32381f0c7a618752041f1ff4d8bceed8a2
+size 18623

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_nudgerForm.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_nudgerForm.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f54cc2334ecf945e43d2625f2430c4ea11ad65f728edf00350818f5766ae778e
-size 75554
+oid sha256:5be65ec69df8512f2b431339079264aeec1e1b7dd96102325bec76496a60c949
+size 75597

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_nudgerForm.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperScreenshot_nudgerForm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f54cc2334ecf945e43d2625f2430c4ea11ad65f728edf00350818f5766ae778e
+size 75554

--- a/spark/src/main/kotlin/com/adevinta/spark/animation/AnimatedCounterText.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/animation/AnimatedCounterText.kt
@@ -24,6 +24,9 @@ package com.adevinta.spark.animation
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.VisibilityThreshold
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
@@ -33,12 +36,18 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import com.adevinta.spark.components.text.Text
 
 /**
@@ -53,6 +62,7 @@ import com.adevinta.spark.components.text.Text
  * @param style Text style for rendering each character.
  * @param color Text color.
  * @param textAlign Text alignment within the available space.
+ * @param animationSpec Slide animation spec for each character transition.
  */
 @Composable
 public fun AnimatedCounterText(
@@ -61,30 +71,34 @@ public fun AnimatedCounterText(
     style: TextStyle = LocalTextStyle.current,
     color: Color = LocalContentColor.current,
     textAlign: TextAlign = TextAlign.Center,
+    animationSpec: FiniteAnimationSpec<IntOffset> = spring(visibilityThreshold = IntOffset.VisibilityThreshold),
 ) {
+    val number = text.extractNumber()
+    var previousNumber by remember { mutableDoubleStateOf(number) }
+    val increasing = number >= previousNumber
+    SideEffect { previousNumber = number }
+
     Row(
         modifier = modifier.animateContentSize(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        text.mapIndexed { index, char ->
-            AnimatedDigit(char = char, fullText = text, index = index)
-        }.forEach { digit ->
+        text.forEachIndexed { index, char ->
             AnimatedContent(
-                targetState = digit,
+                targetState = char,
                 transitionSpec = {
-                    if (targetState > initialState) {
-                        slideInVertically { -it } + fadeIn() togetherWith
-                            slideOutVertically { it } + fadeOut()
+                    if (increasing) {
+                        slideInVertically(animationSpec) { -it } + fadeIn() togetherWith
+                            slideOutVertically(animationSpec) { it } + fadeOut()
                     } else {
-                        slideInVertically { it } + fadeIn() togetherWith
-                            slideOutVertically { -it } + fadeOut()
+                        slideInVertically(animationSpec) { it } + fadeIn() togetherWith
+                            slideOutVertically(animationSpec) { -it } + fadeOut()
                     }.using(SizeTransform(clip = false))
                 },
                 contentAlignment = Alignment.Center,
                 label = "AnimatedDigit",
             ) { target ->
                 Text(
-                    text = "${target.char}",
+                    text = "$target",
                     style = style,
                     color = color,
                     textAlign = textAlign,
@@ -95,19 +109,6 @@ public fun AnimatedCounterText(
         }
     }
 }
-
-private data class AnimatedDigit(val char: Char, val fullText: String, val index: Int) {
-    override fun equals(other: Any?): Boolean {
-        if (other !is AnimatedDigit) return false
-        return char == other.char
-    }
-
-    override fun hashCode(): Int = char.hashCode()
-}
-
-private operator fun AnimatedDigit.compareTo(other: AnimatedDigit): Int = fullText.extractNumber().compareTo(
-    other.fullText.extractNumber(),
-)
 
 private fun String.extractNumber(): Double = filter { it.isDigit() || it == '.' || it == '-' }
     .toDoubleOrNull() ?: 0.0

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonTokens.kt
@@ -22,6 +22,7 @@
 package com.adevinta.spark.components.iconbuttons
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Shape
 import com.adevinta.spark.LocalSparkFeatureFlag
 import com.adevinta.spark.SparkTheme
@@ -50,6 +51,7 @@ public object IconButtonTokens {
      * Falls back to [fallback] when rebranding is inactive.
      */
     @Composable
+    @ReadOnlyComposable
     public fun resolveFullShape(fallback: Shape): Shape =
         if (LocalSparkFeatureFlag.current.useRebrandedShapes) SparkTheme.shapes.full else fallback
 }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.kt
@@ -92,6 +92,8 @@ public object Stepper {
     /**
      * Nudger stepper with decrease and increase buttons on either side of the selected value.
      *
+     * ![Nudger stepper](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudger.png)
+     *
      * @param value Value of the quantity picker, or `null` for an empty state
      * @param onValueChange The callback to be called when [value] has been incremented or decremented
      * @param modifier The [Modifier] to be applied to the component
@@ -134,6 +136,8 @@ public object Stepper {
     /**
      * Nudger stepper driven by a [StepperState] holder.
      *
+     * ![Nudger stepper](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudger.png)
+     *
      * @param state The [StepperState] that holds the current value, range, and step
      * @param modifier The [Modifier] to be applied to the component
      * @param suffix optional string displayed after the value
@@ -168,6 +172,8 @@ public object Stepper {
 
     /**
      * Nudger stepper with a label and helper text.
+     *
+     * ![Nudger form stepper](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudgerForm.png)
      *
      * @param value Value of the quantity picker, or `null` for an empty state
      * @param onValueChange The callback to be called when [value] has been incremented or decremented
@@ -229,6 +235,8 @@ public object Stepper {
     /**
      * Nudger stepper with a label and helper text, driven by a [StepperState] holder.
      *
+     * ![Nudger form stepper](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudgerForm.png)
+     *
      * @param state The [StepperState] that holds the current value, range, and step
      * @param label the label to be displayed
      * @param helper The optional helper text to be displayed at the bottom outside the text input container
@@ -275,6 +283,8 @@ public object Stepper {
 
     /**
      * Input stepper with an editable text field between decrease and increase buttons.
+     *
+     * ![Input stepper](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_input.png)
      *
      * @param value Value of the stepper, or `null` for an empty state
      * @param onValueChange Called when the value changes (button press or blur commit)
@@ -332,6 +342,8 @@ public object Stepper {
     /**
      * Input stepper driven by a [StepperInputState] holder.
      *
+     * ![Input stepper](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_input.png)
+     *
      * @param state The [StepperInputState] that holds the text field state
      * @param modifier The [Modifier] to be applied to the component
      * @param range The min/max accepted value by the stepper
@@ -373,6 +385,8 @@ public object Stepper {
 
     /**
      * Input stepper with a label and helper text.
+     *
+     * ![Input form stepper](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_inputForm.png)
      *
      * @param value Value of the stepper, or `null` for an empty state
      * @param onValueChange Called when the value changes (button press or blur commit)
@@ -431,6 +445,8 @@ public object Stepper {
 
     /**
      * Input stepper with a label and helper text, driven by a [StepperInputState] holder.
+     *
+     * ![Input form stepper](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_inputForm.png)
      *
      * @param state The [StepperInputState] that holds the text field state
      * @param label the label to be displayed

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.kt
@@ -29,10 +29,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.progressSemantics
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.delete
+import androidx.compose.foundation.text.input.insert
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -59,8 +63,12 @@ import androidx.compose.ui.unit.dp
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.R
 import com.adevinta.spark.SparkTheme
-import com.adevinta.spark.components.stepper.internal.SparkStepper
+import com.adevinta.spark.components.stepper.internal.SparkNudger
+import com.adevinta.spark.components.stepper.internal.SparkStepperInput
+import com.adevinta.spark.components.stepper.internal.formatInteger
 import com.adevinta.spark.components.stepper.internal.stepperInputValidator
+import com.adevinta.spark.components.stepper.internal.stepperStateDescription
+import com.adevinta.spark.components.stepper.internal.stripGroupingSeparators
 import com.adevinta.spark.components.stepper.internal.supportText
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.textfields.FormFieldStatus
@@ -75,107 +83,438 @@ import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 import kotlin.math.roundToInt
 
 /**
- * [Stepper] come with decrease and increase buttons on either side of the selected value. A minimum and maximum value
- * need to be provided
- * @param value Value of the quantity picker
- * @param onValueChange The callback to be called when [value] has been incremented or decremented
- * @param modifier The [Modifier] to be applied to the component
- * @param range The min/max accepted value by the [Stepper] until it blocks increments and decrements
- * @param suffix optional string displayed after [value]
- * @param step the quantity to be increased/decreased on each increment/decrement
- * @param enabled True controls the enabled state of the [Stepper]. When `false`, the stepper will
- * be neither editable nor focusable, visually stepper will appear in the disabled UI state
- * @param status indicates the validation state of the stepper. The outline is tinted by the state color
- * @param flexible if true, component will fill max width, otherwise get default width
- * @param testTag A test tag to find the internal [Stepper] inside the [StepperForm] in a test
- * @param allowSemantics dictate if the specific stepper semantics should be applied or not
+ * Stepper variants for quantity picking with decrease and increase buttons.
+ *
+ * Variants: [Nudger], [NudgerForm], [Input], [InputForm].
  */
-@Composable
-public fun Stepper(
-    value: Int,
-    onValueChange: (Int) -> Unit,
-    modifier: Modifier = Modifier,
-    range: IntRange = 0..10,
-    suffix: String = "",
-    step: Int = 1,
-    enabled: Boolean = true,
-    status: FormFieldStatus? = null,
-    flexible: Boolean = false,
-    testTag: String? = null,
-    allowSemantics: Boolean = true,
-) {
-    SparkStepper(
-        value = value,
-        onValueChange = onValueChange,
-        modifier = modifier,
-        range = range,
-        suffix = suffix,
-        step = step,
-        enabled = enabled,
-        flexible = flexible,
-        testTag = testTag,
-        allowSemantics = allowSemantics,
-    )
+public object Stepper {
+
+    /**
+     * Nudger stepper with decrease and increase buttons on either side of the selected value.
+     *
+     * @param value Value of the quantity picker, or `null` for an empty state
+     * @param onValueChange The callback to be called when [value] has been incremented or decremented
+     * @param modifier The [Modifier] to be applied to the component
+     * @param range The min/max accepted value by the stepper until it blocks increments and decrements
+     * @param suffix optional string displayed after [value]
+     * @param step the quantity to be increased/decreased on each increment/decrement
+     * @param enabled True controls the enabled state of the stepper. When `false`, the stepper will
+     * be neither editable nor focusable, visually stepper will appear in the disabled UI state
+     * @param flexible if true, component will fill max width, otherwise get default width
+     * @param testTag A test tag to find the internal stepper in a test
+     * @param allowSemantics dictate if the specific stepper semantics should be applied or not
+     */
+    @Composable
+    public fun Nudger(
+        value: Int?,
+        onValueChange: (Int) -> Unit,
+        modifier: Modifier = Modifier,
+        range: IntRange = 0..10,
+        suffix: String = "",
+        step: Int = 1,
+        enabled: Boolean = true,
+        flexible: Boolean = false,
+        testTag: String? = null,
+        allowSemantics: Boolean = true,
+    ) {
+        SparkNudger(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier,
+            range = range,
+            suffix = suffix,
+            step = step,
+            enabled = enabled,
+            flexible = flexible,
+            testTag = testTag,
+            allowSemantics = allowSemantics,
+        )
+    }
+
+    /**
+     * Nudger stepper driven by a [StepperState] holder.
+     *
+     * @param state The [StepperState] that holds the current value, range, and step
+     * @param modifier The [Modifier] to be applied to the component
+     * @param suffix optional string displayed after the value
+     * @param enabled True controls the enabled state of the stepper
+     * @param flexible if true, component will fill max width, otherwise get default width
+     * @param testTag A test tag to find the internal stepper in a test
+     * @param allowSemantics dictate if the specific stepper semantics should be applied or not
+     */
+    @Composable
+    public fun Nudger(
+        state: StepperState,
+        modifier: Modifier = Modifier,
+        suffix: String = "",
+        enabled: Boolean = true,
+        flexible: Boolean = false,
+        testTag: String? = null,
+        allowSemantics: Boolean = true,
+    ) {
+        SparkNudger(
+            value = state.value,
+            onValueChange = { state.value = it },
+            modifier = modifier,
+            range = state.range,
+            suffix = suffix,
+            step = state.step,
+            enabled = enabled,
+            flexible = flexible,
+            testTag = testTag,
+            allowSemantics = allowSemantics,
+        )
+    }
+
+    /**
+     * Nudger stepper with a label and helper text.
+     *
+     * @param value Value of the quantity picker, or `null` for an empty state
+     * @param onValueChange The callback to be called when [value] has been incremented or decremented
+     * @param label the label to be displayed
+     * @param helper The optional helper text to be displayed at the bottom outside the text input container
+     * @param modifier The [Modifier] to be applied to the component
+     * @param range The min/max accepted value by the stepper until it blocks increments and decrements
+     * @param suffix optional string displayed after [value]
+     * @param step the quantity to be increased/decreased on each increment/decrement
+     * @param enabled True controls the enabled state of the stepper
+     * @param required add an asterisk to the label to indicate that this field is required
+     * @param status indicates the validation state of the stepper
+     * @param statusMessage the optional state text to be displayed at the helper position
+     * @param flexible if true, component will fill max width, otherwise get default width
+     * @param testTag A test tag to find the internal stepper in a test
+     */
+    @Composable
+    public fun NudgerForm(
+        value: Int?,
+        onValueChange: (Int) -> Unit,
+        label: String,
+        helper: String?,
+        modifier: Modifier = Modifier,
+        range: IntRange = 0..10,
+        suffix: String = "",
+        step: Int = 1,
+        enabled: Boolean = true,
+        required: Boolean = false,
+        status: FormFieldStatus? = null,
+        statusMessage: String? = null,
+        flexible: Boolean = false,
+        testTag: String? = null,
+    ) {
+        StepperFormScaffold(
+            label = label,
+            helper = helper,
+            required = required,
+            status = status,
+            statusMessage = statusMessage,
+            enabled = enabled,
+            modifier = modifier
+                .stepperSemantics(value, onValueChange, range, step, suffix, enabled)
+                .sparkUsageOverlay(overlayColor = Color.Green),
+        ) {
+            SparkNudger(
+                value = value,
+                onValueChange = onValueChange,
+                range = range,
+                enabled = enabled,
+                suffix = suffix,
+                step = step,
+                flexible = flexible,
+                testTag = testTag,
+                allowSemantics = false,
+            )
+        }
+    }
+
+    /**
+     * Nudger stepper with a label and helper text, driven by a [StepperState] holder.
+     *
+     * @param state The [StepperState] that holds the current value, range, and step
+     * @param label the label to be displayed
+     * @param helper The optional helper text to be displayed at the bottom outside the text input container
+     * @param modifier The [Modifier] to be applied to the component
+     * @param suffix optional string displayed after the value
+     * @param enabled True controls the enabled state of the stepper
+     * @param required add an asterisk to the label to indicate that this field is required
+     * @param status indicates the validation state of the stepper
+     * @param statusMessage the optional state text to be displayed at the helper position
+     * @param flexible if true, component will fill max width, otherwise get default width
+     * @param testTag A test tag to find the internal stepper in a test
+     */
+    @Composable
+    public fun NudgerForm(
+        state: StepperState,
+        label: String,
+        helper: String?,
+        modifier: Modifier = Modifier,
+        suffix: String = "",
+        enabled: Boolean = true,
+        required: Boolean = false,
+        status: FormFieldStatus? = null,
+        statusMessage: String? = null,
+        flexible: Boolean = false,
+        testTag: String? = null,
+    ) {
+        NudgerForm(
+            value = state.value,
+            onValueChange = { state.value = it },
+            label = label,
+            helper = helper,
+            modifier = modifier,
+            range = state.range,
+            suffix = suffix,
+            step = state.step,
+            enabled = enabled,
+            required = required,
+            status = status,
+            statusMessage = statusMessage,
+            flexible = flexible,
+            testTag = testTag,
+        )
+    }
+
+    /**
+     * Input stepper with an editable text field between decrease and increase buttons.
+     *
+     * @param value Value of the stepper, or `null` for an empty state
+     * @param onValueChange Called when the value changes (button press or blur commit)
+     * @param modifier The [Modifier] to be applied to the component
+     * @param range The min/max accepted value by the stepper
+     * @param suffix optional string displayed after the value
+     * @param step the quantity to be increased/decreased on each increment/decrement
+     * @param enabled True controls the enabled state of the stepper
+     * @param status indicates the validation state of the stepper
+     * @param flexible if true, component will fill max width
+     * @param testTag A test tag to find the internal stepper in a test
+     */
+    @Composable
+    public fun Input(
+        value: Int?,
+        onValueChange: (Int?) -> Unit,
+        modifier: Modifier = Modifier,
+        range: IntRange = 0..10,
+        suffix: String = "",
+        step: Int = 1,
+        enabled: Boolean = true,
+        status: FormFieldStatus? = null,
+        flexible: Boolean = false,
+        testTag: String? = null,
+    ) {
+        val textFieldState = remember { TextFieldState(value?.formatInteger().orEmpty()) }
+        val currentInput = { textFieldState.text.toString().stripGroupingSeparators().toIntOrNull() }
+
+        LaunchedEffect(value) {
+            if (currentInput() != value) {
+                textFieldState.edit {
+                    delete(0, length)
+                    insert(0, value?.formatInteger().orEmpty())
+                }
+            }
+        }
+
+        SparkStepperInput(
+            textFieldState = textFieldState,
+            value = value,
+            onIncrement = { onValueChange(applyStep(currentInput(), step, range)) },
+            onDecrement = { onValueChange(applyStep(currentInput(), -step, range)) },
+            onCommit = { onValueChange(currentInput()?.coerceIn(range)) },
+            modifier = modifier,
+            range = range,
+            suffix = suffix,
+            step = step,
+            enabled = enabled,
+            status = status,
+            flexible = flexible,
+            testTag = testTag,
+        )
+    }
+
+    /**
+     * Input stepper driven by a [StepperInputState] holder.
+     *
+     * @param state The [StepperInputState] that holds the text field state
+     * @param modifier The [Modifier] to be applied to the component
+     * @param range The min/max accepted value by the stepper
+     * @param suffix optional string displayed after the value
+     * @param step the quantity to be increased/decreased on each increment/decrement
+     * @param enabled True controls the enabled state of the stepper
+     * @param status indicates the validation state of the stepper
+     * @param flexible if true, component will fill max width
+     * @param testTag A test tag to find the internal stepper in a test
+     */
+    @Composable
+    public fun Input(
+        state: StepperInputState,
+        modifier: Modifier = Modifier,
+        range: IntRange = 0..10,
+        suffix: String = "",
+        step: Int = 1,
+        enabled: Boolean = true,
+        status: FormFieldStatus? = null,
+        flexible: Boolean = false,
+        testTag: String? = null,
+    ) {
+        SparkStepperInput(
+            textFieldState = state.textFieldState,
+            value = state.value,
+            onIncrement = { state.increment(step, range) },
+            onDecrement = { state.decrement(step, range) },
+            onCommit = { state.commitValue(range) },
+            modifier = modifier,
+            range = range,
+            suffix = suffix,
+            step = step,
+            enabled = enabled,
+            status = status,
+            flexible = flexible,
+            testTag = testTag,
+        )
+    }
+
+    /**
+     * Input stepper with a label and helper text.
+     *
+     * @param value Value of the stepper, or `null` for an empty state
+     * @param onValueChange Called when the value changes (button press or blur commit)
+     * @param label the label to be displayed
+     * @param helper The optional helper text to be displayed below the stepper
+     * @param modifier The [Modifier] to be applied to the component
+     * @param range The min/max accepted value by the stepper
+     * @param suffix optional string displayed after the value
+     * @param step the quantity to be increased/decreased on each increment/decrement
+     * @param enabled True controls the enabled state of the stepper
+     * @param required add an asterisk to the label to indicate that this field is required
+     * @param status indicates the validation state of the stepper
+     * @param statusMessage the optional state text to be displayed at the helper position
+     * @param flexible if true, component will fill max width
+     * @param testTag A test tag to find the internal stepper in a test
+     */
+    @Composable
+    public fun InputForm(
+        value: Int?,
+        onValueChange: (Int?) -> Unit,
+        label: String,
+        helper: String?,
+        modifier: Modifier = Modifier,
+        range: IntRange = 0..10,
+        suffix: String = "",
+        step: Int = 1,
+        enabled: Boolean = true,
+        required: Boolean = false,
+        status: FormFieldStatus? = null,
+        statusMessage: String? = null,
+        flexible: Boolean = false,
+        testTag: String? = null,
+    ) {
+        StepperFormScaffold(
+            label = label,
+            helper = helper,
+            required = required,
+            status = status,
+            statusMessage = statusMessage,
+            enabled = enabled,
+            modifier = modifier.sparkUsageOverlay(),
+        ) {
+            Input(
+                value = value,
+                onValueChange = onValueChange,
+                range = range,
+                enabled = enabled,
+                status = status,
+                suffix = suffix,
+                step = step,
+                flexible = flexible,
+                testTag = testTag,
+            )
+        }
+    }
+
+    /**
+     * Input stepper with a label and helper text, driven by a [StepperInputState] holder.
+     *
+     * @param state The [StepperInputState] that holds the text field state
+     * @param label the label to be displayed
+     * @param helper The optional helper text to be displayed below the stepper
+     * @param modifier The [Modifier] to be applied to the component
+     * @param range The min/max accepted value by the stepper
+     * @param suffix optional string displayed after the value
+     * @param step the quantity to be increased/decreased on each increment/decrement
+     * @param enabled True controls the enabled state of the stepper
+     * @param required add an asterisk to the label to indicate that this field is required
+     * @param status indicates the validation state of the stepper
+     * @param statusMessage the optional state text to be displayed at the helper position
+     * @param flexible if true, component will fill max width
+     * @param testTag A test tag to find the internal stepper in a test
+     */
+    @Composable
+    public fun InputForm(
+        state: StepperInputState,
+        label: String,
+        helper: String?,
+        modifier: Modifier = Modifier,
+        range: IntRange = 0..10,
+        suffix: String = "",
+        step: Int = 1,
+        enabled: Boolean = true,
+        required: Boolean = false,
+        status: FormFieldStatus? = null,
+        statusMessage: String? = null,
+        flexible: Boolean = false,
+        testTag: String? = null,
+    ) {
+        StepperFormScaffold(
+            label = label,
+            helper = helper,
+            required = required,
+            status = status,
+            statusMessage = statusMessage,
+            enabled = enabled,
+            modifier = modifier.sparkUsageOverlay(),
+        ) {
+            Input(
+                state = state,
+                range = range,
+                enabled = enabled,
+                status = status,
+                suffix = suffix,
+                step = step,
+                flexible = flexible,
+                testTag = testTag,
+            )
+        }
+    }
 }
 
 /**
- * Variant of [Stepper] that insert it with a label and a helper.
- * @param value Value of the quantity picker
- * @param onValueChange The callback to be called when [value] has been incremented or decremented
- * @param modifier The [Modifier] to be applied to the component
- * @param label the optional label to be displayed
- * @param helper The optional helper text to be displayed at the bottom outside the text input container that give some
- * information about expected text
- * @param range The min/max accepted value by the [Stepper] until it blocks increments and decrements
- * @param suffix optional string displayed after [value]
- * @param step the quantity to be increased/decreased on each increment/decrement
- * @param enabled True controls the enabled state of the [Stepper]. When `false`, the stepper will
- * be neither editable nor focusable, visually stepper will appear in the disabled UI state
- * @param required add an asterisk to the label to indicate that this field is required and read it as
- * "label mandatory field"
- * but doesn't do anything else so it's up to the developer to handle the behavior
- * @param status indicates the validation state of the stepper. The outline is tinted by the state color
- * @param statusMessage the optional state text to be displayed at the helper position that give more information about
- * the status, it's displayed only when [status] is not null.
- * @param flexible if true, component will fill max width, otherwise get default width
- * @param testTag A test tag to find the internal [Stepper] inside the [StepperForm] in a test
+ * Shared form layout for the stepper form variants: a label row, the stepper [content], and a
+ * helper/status line. The caller supplies [modifier] with the accessibility semantics and overlay
+ * already applied; the scaffold adds the label text semantics.
  */
 @Composable
-public fun StepperForm(
-    value: Int,
-    onValueChange: (Int) -> Unit,
+private fun StepperFormScaffold(
     label: String,
     helper: String?,
+    required: Boolean,
+    status: FormFieldStatus?,
+    statusMessage: String?,
+    enabled: Boolean,
     modifier: Modifier = Modifier,
-    range: IntRange = 0..10,
-    suffix: String = "",
-    step: Int = 1,
-    enabled: Boolean = true,
-    required: Boolean = false,
-    status: FormFieldStatus? = null,
-    statusMessage: String? = null,
-    flexible: Boolean = false,
-    testTag: String? = null,
+    content: @Composable () -> Unit,
 ) {
     val colors = StepperDefaults.stepperColors()
     val mandatoryDescription = if (required) {
-        stringResource(
-            id = R.string.spark_textfield_mandatory_content_description,
-        )
+        stringResource(id = R.string.spark_textfield_mandatory_content_description)
     } else {
         null
     }
     val interactionSource = remember { MutableInteractionSource() }
 
     Column(
-        modifier = modifier
-            .stepperSemantics(value, onValueChange, range, step, suffix, enabled)
-            .semantics {
-                text = listOfNotNull(label, mandatoryDescription, helper)
-                    .joinToString(separator = " ")
-                    .let(::AnnotatedString)
-            }
-            .sparkUsageOverlay(overlayColor = Color.Green),
+        modifier = modifier.semantics {
+            text = listOfNotNull(label, mandatoryDescription, helper)
+                .joinToString(separator = " ")
+                .let(::AnnotatedString)
+        },
     ) {
         Row(modifier = Modifier.invisibleSemantic()) {
             Text(
@@ -196,17 +535,7 @@ public fun StepperForm(
             }
         }
 
-        SparkStepper(
-            value = value,
-            onValueChange = onValueChange,
-            range = range,
-            enabled = enabled,
-            suffix = suffix,
-            step = step,
-            flexible = flexible,
-            testTag = testTag,
-            allowSemantics = false,
-        )
+        content()
 
         val stateIcon = TextFieldDefault.getStatusIcon(state = status)
         val color by colors.supportingTextColor(enabled, status, interactionSource)
@@ -224,6 +553,100 @@ public fun StepperForm(
         }
     }
 }
+
+// region Deprecated top-level functions
+
+/**
+ * @deprecated Use [Stepper.Nudger] instead.
+ */
+@Deprecated(
+    message = "Use Stepper.Nudger instead",
+    replaceWith = ReplaceWith(
+        "Stepper.Nudger(value = value, onValueChange = onValueChange, modifier = modifier, range = range, " +
+            "suffix = suffix, step = step, enabled = enabled, flexible = flexible, " +
+            "testTag = testTag, allowSemantics = allowSemantics)",
+        "com.adevinta.spark.components.stepper.Stepper",
+    ),
+    level = DeprecationLevel.WARNING,
+)
+@Composable
+public fun Stepper(
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    range: IntRange = 0..10,
+    suffix: String = "",
+    step: Int = 1,
+    enabled: Boolean = true,
+    @Suppress("UNUSED_PARAMETER") status: FormFieldStatus? = null,
+    flexible: Boolean = false,
+    testTag: String? = null,
+    allowSemantics: Boolean = true,
+) {
+    Stepper.Nudger(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        range = range,
+        suffix = suffix,
+        step = step,
+        enabled = enabled,
+        flexible = flexible,
+        testTag = testTag,
+        allowSemantics = allowSemantics,
+    )
+}
+
+/**
+ * @deprecated Use [Stepper.NudgerForm] instead.
+ */
+@Deprecated(
+    message = "Use Stepper.NudgerForm instead",
+    replaceWith = ReplaceWith(
+        "Stepper.NudgerForm(value = value, onValueChange = onValueChange, label = label, helper = helper, " +
+            "modifier = modifier, range = range, suffix = suffix, step = step, enabled = enabled, " +
+            "required = required, status = status, statusMessage = statusMessage, flexible = flexible, " +
+            "testTag = testTag)",
+        "com.adevinta.spark.components.stepper.Stepper",
+    ),
+    level = DeprecationLevel.WARNING,
+)
+@Composable
+public fun StepperForm(
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    label: String,
+    helper: String?,
+    modifier: Modifier = Modifier,
+    range: IntRange = 0..10,
+    suffix: String = "",
+    step: Int = 1,
+    enabled: Boolean = true,
+    required: Boolean = false,
+    status: FormFieldStatus? = null,
+    statusMessage: String? = null,
+    flexible: Boolean = false,
+    testTag: String? = null,
+) {
+    Stepper.NudgerForm(
+        value = value,
+        onValueChange = onValueChange,
+        label = label,
+        helper = helper,
+        modifier = modifier,
+        range = range,
+        suffix = suffix,
+        step = step,
+        enabled = enabled,
+        required = required,
+        status = status,
+        statusMessage = statusMessage,
+        flexible = flexible,
+        testTag = testTag,
+    )
+}
+
+// endregion
 
 /**
  * Adds semantics to a [Stepper] component, enabling accessibility features from TalkBack.
@@ -268,23 +691,13 @@ public fun StepperForm(
  */
 // TODO-scott.rayapoulle.ext (30-01-2025): Move to spark a11y lib once it's initiated
 public fun Modifier.stepperSemantics(
-    value: Int,
+    value: Int?,
     onValueChange: (Int) -> Unit,
     range: IntRange,
     step: Int,
     suffix: String?,
     enabled: Boolean,
 ): Modifier = semantics(mergeDescendants = true) {
-    require(step > 0) { "Step must be a positive integer, but was $step" }
-    require(range.last % step == 0) {
-        "The upper bound of the range ($range) must be a multiple of the step ($step), but has a remainder " +
-            "of ${range.last % step}"
-    }
-    require(range.first % step == 0) {
-        "The lower bound of the range ($range) must be a multiple of the step ($step), but has a remainder " +
-            "of ${range.first % step}"
-    }
-
     stepperInputValidator(step = step, range = range)
     // this is needed to use volume keys or slide up / down
     setProgress { targetValue ->
@@ -301,13 +714,13 @@ public fun Modifier.stepperSemantics(
     }
 
     // override describing percents
-    stateDescription = value.toString() + suffix
+    stateDescription = stepperStateDescription(value, suffix, emptyText = "")
 
     if (!enabled) disabled()
 }
     .progressSemantics(
         // this is needed to use volume keys or slide up / down
-        value = value.toFloat(),
+        value = (value ?: range.first).toFloat(),
         valueRange = range.first.toFloat()..range.last.toFloat(),
         steps = (range.last - range.first) / step,
     )
@@ -320,8 +733,8 @@ public fun Modifier.stepperSemantics(
         val isShiftOnlyPressed = it.isShiftPressed && !it.isCtrlPressed && !it.isAltPressed && !it.isMetaPressed
         if (it.type == KeyEventType.KeyDown && isShiftOnlyPressed) {
             when {
-                isUpKey -> onValueChange((value + step).coerceIn(range))
-                isDownKey -> onValueChange((value - step).coerceIn(range))
+                isUpKey -> onValueChange(applyStep(value, step, range))
+                isDownKey -> onValueChange(applyStep(value, -step, range))
                 else -> return@onKeyEvent false
             }
             true
@@ -344,6 +757,7 @@ public object StepperDefaults {
     )
 }
 
+@Suppress("DEPRECATION")
 @Preview
 @Composable
 private fun StepperPreview() {
@@ -359,19 +773,70 @@ private fun StepperPreview() {
             label = "Label",
             helper = "helper message",
         )
-        StepperForm(
-            value = -1,
+    }
+}
+
+@Preview
+@Composable
+private fun NudgerPreview() {
+    PreviewTheme {
+        Stepper.Nudger(
+            value = 1234,
+            onValueChange = {},
+        )
+        Stepper.Nudger(
+            value = null,
+            onValueChange = {},
+        )
+        Stepper.NudgerForm(
+            value = 1,
+            onValueChange = {},
+            status = FormFieldStatus.Error,
+            label = "Label",
+            helper = "helper message",
+        )
+        Stepper.NudgerForm(
+            value = null,
             onValueChange = {},
             status = FormFieldStatus.Alert,
             label = "Label",
             helper = "helper message",
         )
-        StepperForm(
+        Stepper.NudgerForm(
             value = -1234,
             onValueChange = {},
             status = FormFieldStatus.Success,
             label = "Label",
             helper = "helper message",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun InputPreview() {
+    PreviewTheme {
+        Stepper.Input(
+            value = 1234,
+            onValueChange = {},
+        )
+        Stepper.Input(
+            value = null,
+            onValueChange = {},
+        )
+        Stepper.InputForm(
+            value = 5,
+            onValueChange = {},
+            label = "Quantity",
+            helper = "Enter a value",
+        )
+        Stepper.InputForm(
+            value = null,
+            onValueChange = {},
+            status = FormFieldStatus.Error,
+            statusMessage = "Required field",
+            label = "Quantity",
+            helper = "Enter a value",
         )
     }
 }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.md
@@ -3,14 +3,21 @@
 Steppers let users increment and decrement a numeric value within a defined range using
 decrease/increase buttons on either side of the current value.
 
-## Stepper
+All stepper variants live inside `object Stepper` and come in two flavours:
+**Nudger** (read-only display) and **Input** (editable text field).
 
-The minimal variant for inline use where a label and helper text are not needed.
+---
+
+## Stepper.Nudger
+
+The Nudger variant displays the value between decrease/increase buttons. The value is
+read-only; users change it via the buttons. Each digit animates independently on change
+(odometer effect). Long-pressing a button repeats the action with acceleration.
 
 ```kotlin
-var quantity by remember { mutableStateOf(1) }
+var quantity by rememberSaveable { mutableStateOf<Int?>(0) }
 
-Stepper(
+Stepper.Nudger(
     value = quantity,
     onValueChange = { quantity = it },
     range = 1..99,
@@ -18,52 +25,72 @@ Stepper(
 )
 ```
 
+### Nullable value
+
+Pass `null` for an empty initial state. Pressing either button snaps to `range.first`.
+
+```kotlin
+var quantity by rememberSaveable { mutableStateOf<Int?>(null) }
+
+Stepper.Nudger(
+    value = quantity,
+    onValueChange = { quantity = it },
+    range = 0..10,
+)
+```
+
+### State holder
+
+`StepperState` bundles value, range, and step into a single saveable holder.
+
+```kotlin
+val state = rememberStepperState(initialValue = 5, range = 0..100, step = 5)
+
+Stepper.Nudger(state = state)
+```
+
 ### Parameters
 
 | Parameter | Default | Description |
 |---|---|---|
-| `value` | - | Current displayed value |
+| `value` | - | Current displayed value, or `null` for empty |
 | `onValueChange` | - | Called after each increment or decrement |
 | `range` | `0..10` | Accepted value bounds; buttons disable at the limits |
 | `step` | `1` | Amount added or subtracted per button press |
 | `suffix` | `""` | String appended after the value, e.g. `" kg"` |
 | `enabled` | `true` | Disables interaction and applies disabled styling |
-| `status` | `null` | Validation state; tints the outline (`Error`, `Alert`, `Success`) |
 | `flexible` | `false` | When `true`, fills maximum available width |
-
-```kotlin
-Stepper(
-    value = weight,
-    onValueChange = { weight = it },
-    range = 0..500,
-    step = 5,
-    suffix = " kg",
-    status = if (weight == 0) FormFieldStatus.Error else null,
-)
-```
-
-Both `range.first` and `range.last` must be multiples of `step`, otherwise `stepperSemantics`
-throws `IllegalArgumentException`.
 
 ---
 
-## StepperForm
+## Stepper.NudgerForm
 
-`StepperForm` wraps `Stepper` with a label, optional helper text, and status message - matching
-the layout of other form fields.
+Wraps `Stepper.Nudger` with a label, optional helper text, and status message.
 
 ```kotlin
-var guests by remember { mutableStateOf(1) }
+var guests by rememberSaveable { mutableStateOf<Int?>(1) }
 
-StepperForm(
+Stepper.NudgerForm(
     value = guests,
     onValueChange = { guests = it },
     label = "Number of guests",
     helper = "Maximum 8 per booking",
     range = 1..8,
     required = true,
-    status = if (guests > 8) FormFieldStatus.Error else null,
-    statusMessage = if (guests > 8) "Exceeds maximum capacity" else null,
+    status = FormFieldStatus.Error,
+    statusMessage = "Exceeds maximum capacity",
+)
+```
+
+### State holder
+
+```kotlin
+val state = rememberStepperState(initialValue = 1, range = 1..8, step = 1)
+
+Stepper.NudgerForm(
+    state = state,
+    label = "Number of guests",
+    helper = "Maximum 8 per booking",
 )
 ```
 
@@ -74,22 +101,104 @@ StepperForm(
 | `label` | Field label displayed above the stepper |
 | `helper` | Hint text shown below when `status` is null |
 | `required` | Appends `*` to the label and reads it as "mandatory field" |
+| `status` | Validation state; tints the helper text |
 | `statusMessage` | Replaces `helper` when `status` is non-null |
-
-`StepperForm` sets `allowSemantics = false` on the inner `Stepper` and applies
-`stepperSemantics` itself at the `Column` level, so TalkBack announces the label, mandatory
-indicator, and value as a single node.
 
 ---
 
-## Accessibility: `stepperSemantics`
+## Stepper.Input
 
-`Modifier.stepperSemantics` is a public extension that configures a Stepper-containing layout
-to behave like a slider under TalkBack. Apply it when composing a `Stepper` inside a custom
-layout (e.g. a `Row` with a label).
+The Input variant places an editable text field between the buttons. Users can type a
+value directly or use the buttons. Non-digit characters are rejected, and the value is
+clamped to the range on blur. An empty field has `value == null`; the field then shows
+a `-` placeholder. Long-pressing a button repeats with acceleration.
 
 ```kotlin
-var value by remember { mutableStateOf(50) }
+var quantity by rememberSaveable { mutableStateOf<Int?>(3) }
+
+Stepper.Input(
+    value = quantity,
+    onValueChange = { quantity = it },
+    range = 0..100,
+    step = 1,
+)
+```
+
+### State holder
+
+`StepperInputState` wraps a `TextFieldState` and exposes a parsed `value: Int?`.
+
+```kotlin
+val state = rememberStepperInputState(initialValue = 5)
+
+Stepper.Input(
+    state = state,
+    range = 0..100,
+    step = 1,
+)
+Text(text = "Current value: ${state.value ?: "empty"}")
+```
+
+### Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `value` | - | Current value, or `null` for empty |
+| `onValueChange` | - | Called on button press or blur commit; receives `null` when the field is cleared |
+| `range` | `0..10` | Accepted value bounds |
+| `step` | `1` | Increment/decrement amount |
+| `suffix` | `""` | Shown after the value inside the field, e.g. `kg` |
+| `enabled` | `true` | Disables interaction |
+| `status` | `null` | Validation state; tints the inner text field border |
+| `flexible` | `false` | When `true`, fills maximum available width |
+
+---
+
+## Stepper.InputForm
+
+Wraps `Stepper.Input` with a label, helper, and status message.
+
+```kotlin
+var weight by rememberSaveable { mutableStateOf<Int?>(70) }
+
+Stepper.InputForm(
+    value = weight,
+    onValueChange = { weight = it },
+    label = "Weight",
+    helper = "Enter weight in kg",
+    range = 0..500,
+    step = 1,
+    required = true,
+    status = if (weight == null) FormFieldStatus.Error else null,
+    statusMessage = if (weight == null) "Required" else null,
+)
+```
+
+### State holder
+
+```kotlin
+val state = rememberStepperInputState(initialValue = 3)
+
+Stepper.InputForm(
+    state = state,
+    label = "Quantity",
+    helper = "Enter a value between 0 and 100",
+    range = 0..100,
+    required = true,
+)
+```
+
+---
+
+## Accessibility
+
+### `stepperSemantics` (Nudger)
+
+`Modifier.stepperSemantics` configures a Nudger-containing layout to behave like a slider
+under TalkBack. Apply it when composing `Stepper.Nudger` inside a custom layout.
+
+```kotlin
+var value by rememberSaveable { mutableStateOf<Int?>(50) }
 val label = "Volume"
 
 Row(
@@ -105,35 +214,47 @@ Row(
             enabled = true,
         ),
 ) {
-    Text(
-        text = label,
-        modifier = Modifier.invisibleSemantic(), // avoids duplicate announcement
-    )
-    Stepper(
+    Text(text = label, modifier = Modifier.invisibleSemantic())
+    Stepper.Nudger(
         value = value,
         onValueChange = { value = it },
         range = 0..100,
-        allowSemantics = false, // required when parent applies stepperSemantics
+        allowSemantics = false,
     )
 }
 ```
 
-The modifier:
+The modifier exposes `setProgress`, overrides the percentage description, announces
+"disabled" when `enabled = false`, and handles Shift+Up/Down keyboard events.
 
-- Exposes `setProgress` so TalkBack volume-key gestures and swipe-up/down gestures change the value
-- Overrides the percentage description with the raw value plus suffix
-- Announces "disabled" when `enabled = false`
-- Handles Shift+Up / Shift+Down keyboard events for hardware keyboard navigation
+### Input variant
 
-Pass `allowSemantics = false` to the inner `Stepper` whenever `stepperSemantics` is applied on
-an ancestor, otherwise accessibility nodes are duplicated.
+`Stepper.Input` exposes the editable text field as the single accessible control. TalkBack
+reads and edits the value through the field; the `+`/`-` buttons are visual only and hidden
+from accessibility, so they add no extra nodes to navigate.
 
 ### Validation constraints
 
-`stepperSemantics` enforces:
+Both modifiers enforce:
 
 - `step > 0`
 - `range.first % step == 0`
 - `range.last % step == 0`
 
-These are also checked by `StepperForm` and `Stepper` at composition time.
+---
+
+## Migration from deprecated API
+
+> [!WARNING]
+> `Stepper()` and `StepperForm()` are deprecated. Migrate to the new API below.
+
+| Old | New |
+|---|---|
+| `Stepper(value, onValueChange, ...)` | `Stepper.Nudger(value, onValueChange, ...)` |
+| `StepperForm(value, onValueChange, label, helper, ...)` | `Stepper.NudgerForm(value, onValueChange, label, helper, ...)` |
+
+The deprecated functions still compile with a `WARNING` and internally delegate to the new
+API. Use the IDE quick-fix (`ReplaceWith`) to migrate call sites.
+
+The `status` parameter of the old `Stepper()` is silently dropped; `Stepper.Nudger` has
+no `status` param. Use `Stepper.NudgerForm` if you need to show a validation status.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.md
@@ -10,6 +10,8 @@ All stepper variants live inside `object Stepper` and come in two flavours:
 
 ## Stepper.Nudger
 
+![](../../images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudger.png)
+
 The Nudger variant displays the value between decrease/increase buttons. The value is
 read-only; users change it via the buttons. Each digit animates independently on change
 (odometer effect). Long-pressing a button repeats the action with acceleration.
@@ -65,6 +67,8 @@ Stepper.Nudger(state = state)
 
 ## Stepper.NudgerForm
 
+![](../../images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudgerForm.png)
+
 Wraps `Stepper.Nudger` with a label, optional helper text, and status message.
 
 ```kotlin
@@ -107,6 +111,8 @@ Stepper.NudgerForm(
 ---
 
 ## Stepper.Input
+
+![](../../images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_input.png)
 
 The Input variant places an editable text field between the buttons. Users can type a
 value directly or use the buttons. Non-digit characters are rejected, and the value is
@@ -155,6 +161,8 @@ Text(text = "Current value: ${state.value ?: "empty"}")
 ---
 
 ## Stepper.InputForm
+
+![](../../images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_inputForm.png)
 
 Wraps `Stepper.Input` with a label, helper, and status message.
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/StepperState.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/StepperState.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.stepper
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.delete
+import androidx.compose.foundation.text.input.insert
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.mapSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import com.adevinta.spark.components.stepper.internal.formatInteger
+import com.adevinta.spark.components.stepper.internal.stripGroupingSeparators
+
+// region StepperState (Nudger)
+
+/**
+ * State holder for [Stepper.Nudger] and [Stepper.NudgerForm].
+ *
+ * @param initialValue Starting value, or `null` for an empty state.
+ * @param range Accepted value bounds. Buttons disable at the limits.
+ * @param step Amount added or subtracted per increment/decrement.
+ */
+@Stable
+public class StepperState(initialValue: Int?, public val range: IntRange, public val step: Int) {
+    /** Current value, or `null` when the stepper is empty. */
+    public var value: Int? by mutableStateOf(initialValue)
+
+    public val canIncrement: Boolean
+        get() = canIncrement(value, range)
+
+    public val canDecrement: Boolean
+        get() = canDecrement(value, range)
+
+    public fun increment() {
+        value = applyStep(value, step, range)
+    }
+
+    public fun decrement() {
+        value = applyStep(value, -step, range)
+    }
+
+    public companion object {
+        public val Saver: Saver<StepperState, Any> = mapSaver(
+            save = { state ->
+                mapOf(
+                    "value" to state.value,
+                    "rangeFirst" to state.range.first,
+                    "rangeLast" to state.range.last,
+                    "step" to state.step,
+                )
+            },
+            restore = { map ->
+                StepperState(
+                    initialValue = map["value"] as? Int,
+                    range = (map["rangeFirst"] as Int)..(map["rangeLast"] as Int),
+                    step = map["step"] as Int,
+                )
+            },
+        )
+    }
+}
+
+/**
+ * Creates and remembers a [StepperState] that survives recomposition and state restoration.
+ *
+ * @param initialValue Starting value, or `null` for an empty state.
+ * @param range Accepted value bounds.
+ * @param step Amount added or subtracted per increment/decrement.
+ */
+@Composable
+public fun rememberStepperState(
+    initialValue: Int? = null,
+    range: IntRange = 0..10,
+    step: Int = 1,
+): StepperState = rememberSaveable(saver = StepperState.Saver) {
+    StepperState(initialValue = initialValue, range = range, step = step)
+}
+
+// endregion
+
+// region StepperInputState (Input)
+
+/**
+ * State holder for [Stepper.Input] and [Stepper.InputForm].
+ *
+ * Wraps a [TextFieldState] and exposes the parsed integer value.
+ *
+ * @param textFieldState The underlying text field state. Use [rememberStepperInputState] to
+ * create one with a saveable initial value.
+ */
+@Stable
+public class StepperInputState(public val textFieldState: TextFieldState) {
+    /**
+     * The current parsed value, or `null` when the text field is empty or contains non-numeric text.
+     */
+    public val value: Int?
+        get() {
+            val raw = textFieldState.text.toString()
+            if (raw.isEmpty()) return null
+            return raw.stripGroupingSeparators().toIntOrNull()
+        }
+
+    /**
+     * Clamps [value] to [range] and writes it back to the text field.
+     * Clears the field when [value] is `null`.
+     *
+     * @param range The range to clamp to.
+     */
+    public fun commitValue(range: IntRange) {
+        val parsed = value
+        setTextFieldText(if (parsed == null) "" else parsed.coerceIn(range).formatInteger())
+    }
+
+    /**
+     * Increments [value] by [step], clamped to [range], and writes the result to the text field.
+     * When [value] is `null`, snaps to [range].first without applying the step.
+     *
+     * @param step The amount to add.
+     * @param range The range to clamp to.
+     */
+    public fun increment(step: Int, range: IntRange) {
+        setTextFieldText(applyStep(value, step, range).formatInteger())
+    }
+
+    /**
+     * Decrements [value] by [step], clamped to [range], and writes the result to the text field.
+     * When [value] is `null`, snaps to [range].first without applying the step.
+     *
+     * @param step The amount to subtract.
+     * @param range The range to clamp to.
+     */
+    public fun decrement(step: Int, range: IntRange) {
+        setTextFieldText(applyStep(value, -step, range).formatInteger())
+    }
+
+    private fun setTextFieldText(text: String) {
+        textFieldState.edit {
+            delete(0, length)
+            insert(0, text)
+        }
+    }
+
+    public companion object {
+        public val Saver: Saver<StepperInputState, Any> = Saver(
+            save = { state -> with(TextFieldState.Saver) { save(state.textFieldState) } },
+            restore = { saved ->
+                val textFieldState = TextFieldState.Saver.restore(saved) ?: return@Saver null
+                StepperInputState(textFieldState)
+            },
+        )
+    }
+}
+
+/**
+ * Creates and remembers a [StepperInputState] that survives recomposition and state restoration.
+ *
+ * @param initialValue Starting value, or `null` for an empty state (shows the placeholder).
+ */
+@Composable
+public fun rememberStepperInputState(
+    initialValue: Int? = null,
+): StepperInputState {
+    val initialText = initialValue?.formatInteger().orEmpty()
+    return rememberSaveable(saver = StepperInputState.Saver) {
+        StepperInputState(TextFieldState(initialText))
+    }
+}
+
+// endregion
+
+/**
+ * When current is null, snaps to range.first (no step applied).
+ * When current is non-null, applies delta and coerces into range.
+ */
+internal fun applyStep(current: Int?, delta: Int, range: IntRange): Int =
+    if (current == null) range.first else (current + delta).coerceIn(range)
+
+internal fun canIncrement(value: Int?, range: IntRange): Boolean =
+    if (value == null) range.first < range.last else value < range.last
+
+internal fun canDecrement(value: Int?, range: IntRange): Boolean =
+    if (value == null) range.first < range.last else value > range.first

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/IconButton.kt
@@ -88,6 +88,7 @@ internal fun IconButton(
         shape = shape,
         color = containerColor,
         contentColor = contentColor,
+        interactionSource = interactionSource,
         border = borderStroke,
     ) {
         Icon(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/IntegerInputTransformation.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/IntegerInputTransformation.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.stepper.internal
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.ui.text.input.KeyboardType
+
+internal class IntegerInputTransformation(private val allowNegative: Boolean) : InputTransformation {
+
+    override val keyboardOptions: KeyboardOptions = KeyboardOptions(
+        keyboardType = KeyboardType.Number,
+    )
+
+    override fun TextFieldBuffer.transformInput() {
+        if (!isValidIntegerInput(asCharSequence().toString())) {
+            revertAllChanges()
+        }
+    }
+
+    private fun isValidIntegerInput(text: String): Boolean {
+        if (text.isEmpty()) return true
+
+        val stripped = text.stripGroupingSeparators()
+        if (stripped.isEmpty()) return true
+
+        if (!allowNegative && stripped.startsWith('-')) return false
+
+        val startIndex = if (stripped.startsWith('-')) 1 else 0
+
+        for (i in startIndex until stripped.length) {
+            if (!stripped[i].isDigit()) return false
+        }
+
+        return true
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/IntegerOutputTransformation.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/IntegerOutputTransformation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2025 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,29 +19,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.adevinta.spark.components.textfields
+package com.adevinta.spark.components.stepper.internal
 
-import androidx.compose.foundation.shape.CornerBasedShape
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
-import com.adevinta.spark.LocalSparkFeatureFlag
-import com.adevinta.spark.SparkTheme
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
 
-/**
- * Component tokens for text field components. Centralises all flag-driven token resolution so that
- * text field composables read from a single source of truth instead of inlining the flag check at
- * every call site. When the rebranding feature flag is eventually removed, only this file changes.
- */
-public object TextFieldTokens {
+internal class IntegerOutputTransformation : OutputTransformation {
 
-    /**
-     * The resolved container shape for text fields.
-     */
-    public val shape: CornerBasedShape
-        @Composable @ReadOnlyComposable
-        get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            SparkTheme.shapes.full
-        } else {
-            SparkTheme.shapes.large
+    private var lastRaw: String = ""
+    private var lastFormatted: String = ""
+
+    override fun TextFieldBuffer.transformOutput() {
+        val raw = asCharSequence().toString()
+        if (raw == lastRaw) {
+            if (lastFormatted != raw) replace(0, length, lastFormatted)
+            return
         }
+        lastRaw = raw
+        val parsed = raw.stripGroupingSeparators().toIntOrNull() ?: return
+        lastFormatted = parsed.formatInteger()
+        if (lastFormatted != raw) replace(0, length, lastFormatted)
+    }
 }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/MiddleText.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/MiddleText.kt
@@ -21,13 +21,6 @@
  */
 package com.adevinta.spark.components.stepper.internal
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.SizeTransform
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -48,17 +41,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.animation.AnimatedCounterText
 import com.adevinta.spark.components.stepper.StepperDefaults
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.textfields.DefaultSparkTextFieldColors
 import com.adevinta.spark.components.textfields.sparkOutlinedTextFieldColors
 import com.adevinta.spark.tokens.dim3
-import java.text.NumberFormat
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun MiddleText(
-    value: Int,
+    value: Int?,
     enabled: Boolean,
     colors: DefaultSparkTextFieldColors,
     modifier: Modifier = Modifier,
@@ -83,44 +76,11 @@ internal fun MiddleText(
                 ),
                 horizontalArrangement = Arrangement.Center,
             ) {
-                AnimatedContent(
-                    targetState = value,
-                    contentAlignment = Alignment.Center,
-                    transitionSpec = {
-                        // Compare the incoming number with the previous number.
-                        if (targetState < initialState) {
-                            // If the target number is larger, it slides up and fades in
-                            // while the initial (smaller) number slides up and fades out.
-                            slideInVertically(
-                                StepperDefaults.textAnimationSpec,
-                            ) { height -> height } +
-                                fadeIn() togetherWith slideOutVertically(
-                                    StepperDefaults.textAnimationSpec,
-                                ) { height -> -height } +
-                                fadeOut()
-                        } else {
-                            // If the target number is smaller, it slides down and fades in
-                            // while the initial number slides down and fades out.
-                            slideInVertically(
-                                StepperDefaults.textAnimationSpec,
-                            ) { height -> -height } +
-                                fadeIn() togetherWith slideOutVertically(
-                                    StepperDefaults.textAnimationSpec,
-                                ) { height -> height } +
-                                fadeOut()
-                        }.using(
-                            // Disable clipping since the faded slide-in/out should
-                            // be displayed out of bounds.
-                            SizeTransform(clip = false),
-                        )
-                    },
-                ) { count ->
-                    Text(
-                        text = numberFormat.format(count),
-                        textAlign = TextAlign.Center,
-                        maxLines = 1,
-                    )
-                }
+                AnimatedCounterText(
+                    text = value?.formatInteger().orEmpty(),
+                    textAlign = TextAlign.Center,
+                    animationSpec = StepperDefaults.textAnimationSpec,
+                )
                 if (suffix.isNotEmpty()) {
                     Text(
                         text = suffix,
@@ -133,16 +93,18 @@ internal fun MiddleText(
     }
 }
 
-private val numberFormat: NumberFormat = NumberFormat.getIntegerInstance().apply {
-    isParseIntegerOnly = true
-}
-
 @Preview
 @Composable
 private fun MiddleTextFieldPreview() {
     PreviewTheme {
         MiddleText(
             value = 1,
+            enabled = true,
+            suffix = "€",
+            colors = sparkOutlinedTextFieldColors(),
+        )
+        MiddleText(
+            value = null,
             enabled = true,
             suffix = "€",
             colors = sparkOutlinedTextFieldColors(),

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/MiddleText.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/MiddleText.kt
@@ -56,6 +56,7 @@ internal fun MiddleText(
     colors: DefaultSparkTextFieldColors,
     modifier: Modifier = Modifier,
     suffix: String = "",
+    placeholder: String = "-",
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     CompositionLocalProvider(
@@ -76,17 +77,26 @@ internal fun MiddleText(
                 ),
                 horizontalArrangement = Arrangement.Center,
             ) {
-                AnimatedCounterText(
-                    text = value?.formatInteger().orEmpty(),
-                    textAlign = TextAlign.Center,
-                    animationSpec = StepperDefaults.textAnimationSpec,
-                )
-                if (suffix.isNotEmpty()) {
+                if (value == null) {
+                    // Empty state: show the placeholder, no suffix.
                     Text(
-                        text = suffix,
+                        text = placeholder,
                         textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(start = 4.dp),
+                        color = SparkTheme.colors.onSurface.dim3,
                     )
+                } else {
+                    AnimatedCounterText(
+                        text = value.formatInteger(),
+                        textAlign = TextAlign.Center,
+                        animationSpec = StepperDefaults.textAnimationSpec,
+                    )
+                    if (suffix.isNotEmpty()) {
+                        Text(
+                            text = suffix,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(start = 4.dp),
+                        )
+                    }
                 }
             }
         }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/RepeatableIconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/RepeatableIconButton.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.stepper.internal
+
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import com.adevinta.spark.components.textfields.DefaultSparkTextFieldColors
+import com.adevinta.spark.icons.SparkIcon
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+
+internal const val INITIAL_DELAY_MS = 400L
+internal const val MIN_DELAY_MS = 50L
+internal const val DECAY_MS = 30L
+
+/**
+ * While [interactionSource] reports a held press and [enabled] is true, repeats [onClick] with an
+ * accelerating delay and haptic feedback. Stops on release, disable, or leaving composition.
+ */
+@Composable
+internal fun RepeatOnLongPress(
+    interactionSource: InteractionSource,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val hapticFeedback = LocalHapticFeedback.current
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val currentOnClick by rememberUpdatedState(onClick)
+    val currentEnabled by rememberUpdatedState(enabled)
+
+    LaunchedEffect(interactionSource) {
+        snapshotFlow { isPressed && currentEnabled }.collectLatest { active ->
+            if (!active) return@collectLatest
+            var currentDelay = INITIAL_DELAY_MS
+            delay(currentDelay)
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+            while (true) {
+                currentOnClick()
+                currentDelay = (currentDelay - DECAY_MS).coerceAtLeast(MIN_DELAY_MS)
+                delay(currentDelay)
+                hapticFeedback.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
+            }
+        }
+    }
+}
+
+@Composable
+internal fun RepeatableIconButton(
+    sparkIcon: SparkIcon,
+    contentDescription: String,
+    enabled: Boolean,
+    colors: DefaultSparkTextFieldColors,
+    shape: CornerBasedShape,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val hapticFeedback = LocalHapticFeedback.current
+    val internalInteractionSource = remember { MutableInteractionSource() }
+
+    RepeatOnLongPress(
+        interactionSource = internalInteractionSource,
+        enabled = enabled,
+        onClick = onClick,
+    )
+
+    IconButton(
+        sparkIcon = sparkIcon,
+        contentDescription = contentDescription,
+        enabled = enabled,
+        colors = colors,
+        shape = shape,
+        modifier = modifier,
+        interactionSource = internalInteractionSource,
+        onClick = {
+            onClick()
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        },
+    )
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/SparkNudger.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/SparkNudger.kt
@@ -57,6 +57,7 @@ internal fun SparkNudger(
     modifier: Modifier = Modifier,
     range: IntRange = 0..10,
     suffix: String = "",
+    placeholder: String = "-",
     step: Int = 1,
     enabled: Boolean = true,
     flexible: Boolean = false,
@@ -116,6 +117,7 @@ internal fun SparkNudger(
                 .invisibleSemantic(),
             value = value,
             suffix = suffix,
+            placeholder = placeholder,
             enabled = enabled,
             colors = colors,
         )

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/SparkNudger.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/SparkNudger.kt
@@ -21,7 +21,6 @@
  */
 package com.adevinta.spark.components.stepper.internal
 
-import androidx.annotation.OpenForTesting
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -29,33 +28,31 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.iconbuttons.IconButtonTokens
 import com.adevinta.spark.components.stepper.StepperDefaults
+import com.adevinta.spark.components.stepper.applyStep
+import com.adevinta.spark.components.stepper.canDecrement
+import com.adevinta.spark.components.stepper.canIncrement
 import com.adevinta.spark.components.stepper.stepperSemantics
 import com.adevinta.spark.icons.LeboncoinIcons
 import com.adevinta.spark.icons.Minus
 import com.adevinta.spark.icons.Plus
-import com.adevinta.spark.tools.modifiers.ifFalse
 import com.adevinta.spark.tools.modifiers.ifTrue
 import com.adevinta.spark.tools.modifiers.invisibleSemantic
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 
 @Composable
-internal fun SparkStepper(
-    value: Int,
+internal fun SparkNudger(
+    value: Int?,
     onValueChange: (Int) -> Unit,
     modifier: Modifier = Modifier,
     range: IntRange = 0..10,
@@ -69,17 +66,17 @@ internal fun SparkStepper(
 ) {
     stepperInputValidator(step, range)
     val colors = StepperDefaults.stepperColors()
-    val coerced = value.coerceIn(range)
-    fun setValue(value: Int) =
-        onValueChange(value.coerceIn(range))
+
+    val canDecrement = enabled && canDecrement(value, range)
+    val canIncrement = enabled && canIncrement(value, range)
 
     Row(
         modifier = modifier
             .height(IntrinsicSize.Min)
             .ifTrue(allowSemantics) {
                 stepperSemantics(
-                    value = coerced,
-                    onValueChange = ::setValue,
+                    value = value,
+                    onValueChange = onValueChange,
                     range = range,
                     step = step,
                     suffix = suffix,
@@ -93,122 +90,64 @@ internal fun SparkStepper(
             .sparkUsageOverlay(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        IconButton(
+        RepeatableIconButton(
             modifier = Modifier
                 .fillMaxHeight()
                 .generateStepperTestTag(testTag, "Decrement"),
             sparkIcon = LeboncoinIcons.Minus,
             contentDescription = "", // handled by semantics modifier
-            enabled = enabled && coerced > range.first,
+            enabled = canDecrement,
             colors = colors,
-            shape = SparkTheme.shapes.large,
+            shape = IconButtonTokens.resolveFullShape(SparkTheme.shapes.large) as CornerBasedShape,
             interactionSource = interactionSource,
-            onClick = { setValue(coerced - step) },
+            onClick = { onValueChange(applyStep(value, -step, range)) },
         )
 
         MiddleText(
             modifier = Modifier
-                .ifTrue(flexible) {
-                    weight(1.0f)
-                }
-                .ifFalse(flexible) {
-                    widthIn(min = 48.dp)
-                }
+                .then(
+                    if (flexible) {
+                        Modifier.weight(1.0f)
+                    } else {
+                        Modifier.widthIn(min = 48.dp)
+                    },
+                )
                 .fillMaxHeight()
                 .invisibleSemantic(),
-            value = coerced,
+            value = value,
             suffix = suffix,
             enabled = enabled,
             colors = colors,
         )
 
-        IconButton(
+        RepeatableIconButton(
             modifier = Modifier
                 .fillMaxHeight()
                 .generateStepperTestTag(testTag, "Increment"),
             sparkIcon = LeboncoinIcons.Plus,
             contentDescription = "", // handled by semantics modifier
-            enabled = enabled && coerced < range.last,
+            enabled = canIncrement,
             colors = colors,
-            shape = SparkTheme.shapes.large,
+            shape = IconButtonTokens.resolveFullShape(SparkTheme.shapes.large) as CornerBasedShape,
             interactionSource = interactionSource,
-            onClick = {
-                setValue(coerced + step)
-            },
+            onClick = { onValueChange(applyStep(value, step, range)) },
         )
     }
 }
-
-/**
- * Validates the input parameters for a stepper operation.
- *
- * This function ensures that the provided step value is positive and that both the start and end
- * of the given range are multiples of the step. This is crucial for stepper operations where
- * values are incremented or decremented by a fixed step size.
- *
- * @param step The step value used for incrementing or decrementing. Must be a positive integer.
- * @param range The range of values allowed, represented as an [IntRange]. Both the start and
- *              end of this range must be multiples of the step value.
- * @throws IllegalArgumentException If the step is not positive, or if the start or end of the
- *                                  range are not multiples of the step. The exception message will
- *                                  indicate the specific violation.
- *
- * Example Usage:
- * ```kotlin
- * // Valid input: step of 2, range from 0 to 10 (both multiples of 2)
- * stepperInputValidator(2, 0..10)
- *
- * // Invalid input: step of -1 (not positive)
- * try {
- *     stepperInputValidator(-1, 0..10)
- * } catch (e: IllegalArgumentException) {
- *     println(e.message) // Output: A step can only be a positive integer, but was -1
- * }
- *
- * // Invalid input: range start 1 (not multiple of 2)
- * try {
- *     stepperInputValidator(2, 1..10)
- * } catch (e: IllegalArgumentException) {
- *      println(e.message) // Output: The min range must be a multiple of the step, but has 1  remaining
- * }
- *
- * // Invalid input: range end 9 (not multiple of 2)
- * try {
- *     stepperInputValidator(2, 0..9)
- * } catch (e: IllegalArgumentException) {
- *      println(e.message) // Output: The max range must be a multiple of the step, but has 1  remaining
- * }
- * ```
- */
-@OpenForTesting
-public fun stepperInputValidator(step: Int, range: IntRange) {
-    require(step > 0) { "A step can only be a positive integer, but was $step" }
-    require(range.last % step == 0) {
-        "The max range must be a multiple of the step, but has ${range.last % step}  remaining"
-    }
-    require(range.first % step == 0) {
-        "The min range must be a multiple of the step, but has ${range.first % step}  remaining"
-    }
-}
-
-@OptIn(ExperimentalComposeUiApi::class)
-private fun Modifier.generateStepperTestTag(testTag: String?, action: String): Modifier = testTag?.let {
-    semantics {
-        contentDescription = "" // handled by semantics modifier
-        stateDescription = "" // handled by semantics modifier
-        testTagsAsResourceId = true
-    }.testTag("${testTag}$action")
-} ?: this
 
 @Preview
 @Composable
-private fun PreviewSparkStepper() {
+private fun PreviewSparkNudger() {
     PreviewTheme {
-        SparkStepper(
+        SparkNudger(
             value = 1234,
             onValueChange = {},
         )
-        SparkStepper(
+        SparkNudger(
+            value = null,
+            onValueChange = {},
+        )
+        SparkNudger(
             value = 1234,
             onValueChange = {},
             enabled = false,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/SparkStepperInput.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/SparkStepperInput.kt
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.stepper.internal
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.stepper.canDecrement
+import com.adevinta.spark.components.stepper.canIncrement
+import com.adevinta.spark.components.surface.Surface
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.components.textfields.AnimationDuration
+import com.adevinta.spark.components.textfields.FormFieldStatus
+import com.adevinta.spark.icons.LeboncoinIcons
+import com.adevinta.spark.icons.Minus
+import com.adevinta.spark.icons.Plus
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tokens.dim3
+import com.adevinta.spark.tokens.dim5
+import com.adevinta.spark.tokens.transparent
+import com.adevinta.spark.tools.modifiers.invisibleSemantic
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
+import kotlinx.coroutines.flow.drop
+
+@Composable
+internal fun SparkStepperInput(
+    textFieldState: TextFieldState,
+    value: Int?,
+    onIncrement: () -> Unit,
+    onDecrement: () -> Unit,
+    onCommit: () -> Unit,
+    modifier: Modifier = Modifier,
+    range: IntRange = 0..10,
+    placeholder: String = "-",
+    suffix: String = "",
+    step: Int = 1,
+    enabled: Boolean = true,
+    status: FormFieldStatus? = null,
+    flexible: Boolean = false,
+    testTag: String? = null,
+) {
+    stepperInputValidator(step, range)
+
+    val canDecrement = enabled && canDecrement(value, range)
+    val canIncrement = enabled && canIncrement(value, range)
+
+    val textFieldInteractionSource = remember { MutableInteractionSource() }
+    val isFocused by textFieldInteractionSource.collectIsFocusedAsState()
+    val currentOnCommit by rememberUpdatedState(onCommit)
+
+    LaunchedEffect(textFieldInteractionSource) {
+        snapshotFlow { isFocused }.drop(1).collect { focused ->
+            if (!focused) currentOnCommit()
+        }
+    }
+
+    val containerBgColor by animateColorAsState(
+        targetValue = if (enabled) {
+            SparkTheme.colors.onSurface.transparent
+        } else {
+            SparkTheme.colors.onSurface.dim5
+        },
+        animationSpec = tween(durationMillis = AnimationDuration),
+        label = "containerBg",
+    )
+    val innerBorderColor by animateColorAsState(
+        targetValue = when {
+            !enabled -> SparkTheme.colors.outline
+            status != null -> status.color()
+            isFocused -> SparkTheme.colors.outlineHigh
+            else -> SparkTheme.colors.outline
+        },
+        animationSpec = tween(durationMillis = AnimationDuration),
+        label = "innerBorder",
+    )
+    val innerBorderThickness by animateDpAsState(
+        targetValue = if (isFocused || status != null) {
+            OutlinedTextFieldDefaults.FocusedBorderThickness
+        } else {
+            OutlinedTextFieldDefaults.UnfocusedBorderThickness
+        },
+        animationSpec = tween(durationMillis = 150),
+        label = "innerThickness",
+    )
+
+    Row(
+        modifier = modifier
+            .height(IntrinsicSize.Min)
+            .clip(SparkTheme.shapes.full)
+            .sparkUsageOverlay(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        InputStepperButton(
+            modifier = Modifier
+                .fillMaxHeight()
+                .offset(x = 1.dp)
+                .border(
+                    BorderStroke(StepperTokens.borderThickness, StepperTokens.borderColor),
+                    StepperTokens.Input.decrementShape,
+                )
+                .zIndex(1f)
+                // The text field is the accessible control; the buttons are visual only.
+                .invisibleSemantic()
+                .generateStepperTestTag(testTag, "Decrement"),
+            sparkIcon = LeboncoinIcons.Minus,
+            contentDescription = "",
+            enabled = canDecrement,
+            containerColor = containerBgColor,
+            onClick = onDecrement,
+        )
+
+        val outputTransformation = remember { IntegerOutputTransformation() }
+        Box(
+            modifier = Modifier
+                .then(
+                    if (flexible) {
+                        Modifier.weight(1f)
+                    } else {
+                        Modifier.widthIn(min = StepperTokens.MinWidth)
+                    },
+                )
+                .fillMaxHeight()
+                .border(
+                    BorderStroke(innerBorderThickness, innerBorderColor),
+                    StepperTokens.Input.inputShape,
+                )
+                .background(containerBgColor)
+                .zIndex(2f)
+                .generateStepperTestTag(testTag, "Input"),
+            contentAlignment = Alignment.Center,
+        ) {
+            BasicTextField(
+                state = textFieldState,
+                modifier = Modifier
+                    .padding(vertical = 10.dp, horizontal = 8.dp)
+                    .width(IntrinsicSize.Min),
+                enabled = enabled,
+                textStyle = SparkTheme.typography.body1.copy(
+                    textAlign = TextAlign.Center,
+                    color = if (enabled) {
+                        SparkTheme.colors.onSurface
+                    } else {
+                        SparkTheme.colors.onSurface.dim3
+                    },
+                ),
+                inputTransformation = IntegerInputTransformation(allowNegative = range.first < 0),
+                outputTransformation = if (!isFocused) outputTransformation else null,
+                interactionSource = textFieldInteractionSource,
+                cursorBrush = SolidColor(LocalContentColor.current),
+                lineLimits = TextFieldLineLimits.SingleLine,
+                decorator = { innerTextField ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        if (textFieldState.text.isEmpty()) {
+                            Text(
+                                text = placeholder,
+                                style = SparkTheme.typography.body1.copy(textAlign = TextAlign.Center),
+                                color = SparkTheme.colors.onSurface.dim3,
+                            )
+                        }
+                        innerTextField()
+                        if (suffix.isNotEmpty() && textFieldState.text.isNotEmpty()) {
+                            Text(
+                                text = suffix,
+                                style = SparkTheme.typography.body1,
+                                // The field already reads its value; avoid a duplicate suffix announcement.
+                                modifier = Modifier.padding(start = 4.dp).invisibleSemantic(),
+                            )
+                        }
+                    }
+                },
+            )
+        }
+
+        InputStepperButton(
+            modifier = Modifier
+                .fillMaxHeight()
+                .offset(x = -1.dp)
+                .border(
+                    BorderStroke(StepperTokens.borderThickness, StepperTokens.borderColor),
+                    StepperTokens.Input.incrementShape,
+                )
+                .zIndex(1f)
+                // The text field is the accessible control; the buttons are visual only.
+                .invisibleSemantic()
+                .generateStepperTestTag(testTag, "Increment"),
+            sparkIcon = LeboncoinIcons.Plus,
+            contentDescription = "",
+            enabled = canIncrement,
+            containerColor = containerBgColor,
+            onClick = onIncrement,
+        )
+    }
+}
+
+@Composable
+private fun InputStepperButton(
+    sparkIcon: SparkIcon,
+    contentDescription: String,
+    enabled: Boolean,
+    containerColor: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val hapticFeedback = LocalHapticFeedback.current
+    val interactionSource = remember { MutableInteractionSource() }
+
+    RepeatOnLongPress(
+        interactionSource = interactionSource,
+        enabled = enabled,
+        onClick = onClick,
+    )
+
+    val iconColor by animateColorAsState(
+        targetValue = if (enabled) SparkTheme.colors.onSurface else SparkTheme.colors.onSurface.dim3,
+        animationSpec = tween(durationMillis = AnimationDuration),
+        label = "iconColor",
+    )
+
+    Surface(
+        onClick = {
+            onClick()
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        },
+        modifier = modifier
+            .sizeIn(minWidth = 44.dp, minHeight = 44.dp)
+            .focusProperties { canFocus = false },
+        enabled = enabled,
+        shape = RectangleShape,
+        color = containerColor,
+        contentColor = iconColor,
+        interactionSource = interactionSource,
+    ) {
+        Icon(
+            sparkIcon = sparkIcon,
+            contentDescription = contentDescription,
+            modifier = Modifier.requiredSize(16.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSparkStepperInput() {
+    PreviewTheme {
+        SparkStepperInput(
+            textFieldState = remember { TextFieldState("5") },
+            value = 5,
+            onIncrement = {},
+            onDecrement = {},
+            onCommit = {},
+        )
+        SparkStepperInput(
+            textFieldState = remember { TextFieldState("") },
+            value = null,
+            onIncrement = {},
+            onDecrement = {},
+            onCommit = {},
+        )
+        SparkStepperInput(
+            textFieldState = remember { TextFieldState("5") },
+            value = 5,
+            onIncrement = {},
+            onDecrement = {},
+            onCommit = {},
+            enabled = false,
+        )
+        SparkStepperInput(
+            textFieldState = remember { TextFieldState("5") },
+            value = 5,
+            onIncrement = {},
+            onDecrement = {},
+            onCommit = {},
+            status = FormFieldStatus.Error,
+        )
+        SparkStepperInput(
+            textFieldState = remember { TextFieldState("5") },
+            value = 5,
+            onIncrement = {},
+            onDecrement = {},
+            onCommit = {},
+            status = FormFieldStatus.Success,
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/SparkStepperInput.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/SparkStepperInput.kt
@@ -193,9 +193,7 @@ internal fun SparkStepperInput(
         ) {
             BasicTextField(
                 state = textFieldState,
-                modifier = Modifier
-                    .padding(vertical = 10.dp, horizontal = 8.dp)
-                    .width(IntrinsicSize.Min),
+                modifier = Modifier.padding(vertical = 10.dp, horizontal = 8.dp),
                 enabled = enabled,
                 textStyle = SparkTheme.typography.body1.copy(
                     textAlign = TextAlign.Center,
@@ -212,14 +210,18 @@ internal fun SparkStepperInput(
                 lineLimits = TextFieldLineLimits.SingleLine,
                 decorator = { innerTextField ->
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        if (textFieldState.text.isEmpty()) {
-                            Text(
-                                text = placeholder,
-                                style = SparkTheme.typography.body1.copy(textAlign = TextAlign.Center),
-                                color = SparkTheme.colors.onSurface.dim3,
-                            )
+                        // Constrain only the editable field to its content width, so the suffix
+                        // sits beside it instead of being clipped.
+                        Box(modifier = Modifier.width(IntrinsicSize.Min)) {
+                            if (textFieldState.text.isEmpty()) {
+                                Text(
+                                    text = placeholder,
+                                    style = SparkTheme.typography.body1.copy(textAlign = TextAlign.Center),
+                                    color = SparkTheme.colors.onSurface.dim3,
+                                )
+                            }
+                            innerTextField()
                         }
-                        innerTextField()
                         if (suffix.isNotEmpty() && textFieldState.text.isNotEmpty()) {
                             Text(
                                 text = suffix,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/StepperNumberFormat.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/StepperNumberFormat.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2025 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,29 +19,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.adevinta.spark.components.textfields
+package com.adevinta.spark.components.stepper.internal
 
-import androidx.compose.foundation.shape.CornerBasedShape
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
-import com.adevinta.spark.LocalSparkFeatureFlag
-import com.adevinta.spark.SparkTheme
+import java.text.DecimalFormatSymbols
+import java.text.NumberFormat
+
+internal val integerNumberFormat: NumberFormat = NumberFormat.getIntegerInstance()
+
+internal val groupingSeparator: Char = DecimalFormatSymbols.getInstance().groupingSeparator
+
+internal fun String.stripGroupingSeparators(): String = replace(groupingSeparator.toString(), "")
+
+internal fun Int.formatInteger(): String = integerNumberFormat.format(this)
 
 /**
- * Component tokens for text field components. Centralises all flag-driven token resolution so that
- * text field composables read from a single source of truth instead of inlining the flag check at
- * every call site. When the rebranding feature flag is eventually removed, only this file changes.
+ * Builds the spoken state description for a stepper value. Joins the value and [suffix] with a
+ * single space so a screen reader reads "5 kg", not "5kg" or "5null". Falls back to [emptyText]
+ * when [value] is null.
  */
-public object TextFieldTokens {
-
-    /**
-     * The resolved container shape for text fields.
-     */
-    public val shape: CornerBasedShape
-        @Composable @ReadOnlyComposable
-        get() = if (LocalSparkFeatureFlag.current.useRebrandedShapes) {
-            SparkTheme.shapes.full
-        } else {
-            SparkTheme.shapes.large
-        }
+internal fun stepperStateDescription(value: Int?, suffix: String?, emptyText: String): String {
+    if (value == null) return emptyText
+    val trimmedSuffix = suffix?.trim().orEmpty()
+    return if (trimmedSuffix.isEmpty()) value.toString() else "$value $trimmedSuffix"
 }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/StepperTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/StepperTokens.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.stepper.internal
+
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.iconbuttons.IconButtonTokens
+import com.adevinta.spark.components.textfields.TextFieldTokens
+
+@Immutable
+public object StepperTokens {
+
+    public val borderColor: Color
+        @Composable @ReadOnlyComposable
+        get() = SparkTheme.colors.outline
+    public val borderFocusedColor: Color
+        @Composable @ReadOnlyComposable
+        get() = SparkTheme.colors.outlineHigh
+
+    public val borderThickness: Dp
+        @Composable @ReadOnlyComposable
+        get() = 1.dp
+    public val borderFocusedThickness: Dp
+        @Composable @ReadOnlyComposable
+        get() = 2.dp
+
+    @Immutable
+    public object Input {
+        public val inputShape: Shape
+            @Composable @ReadOnlyComposable
+            get() = SparkTheme.shapes.none
+        public val decrementShape: Shape
+            @Composable @ReadOnlyComposable
+            get() = TextFieldTokens.shape.copy(topEnd = CornerSize(0.dp), bottomEnd = CornerSize(0.dp))
+        public val incrementShape: Shape
+            @Composable @ReadOnlyComposable
+            get() = TextFieldTokens.shape.copy(topStart = CornerSize(0.dp), bottomStart = CornerSize(0.dp))
+    }
+
+    @Immutable
+    public object Nudger {
+        public val buttonsShape: Shape
+            @Composable @ReadOnlyComposable
+            get() = IconButtonTokens.resolveFullShape(SparkTheme.shapes.full)
+    }
+
+    /**
+     * The default min height applied to an [OutlinedTextField]. Note that you can override it by
+     * applying Modifier.heightIn directly on a text field.
+     */
+    public val MinHeight: Dp = 44.dp
+
+    /**
+     * The default min width applied to an [OutlinedTextField]. Note that you can override it by
+     * applying Modifier.widthIn directly on a text field.
+     */
+    public val MinWidth: Dp = 56.dp
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/StepperValidation.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/internal/StepperValidation.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025-2026 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.stepper.internal
+
+import androidx.annotation.OpenForTesting
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.testTagsAsResourceId
+
+/**
+ * Validates the input parameters for a stepper operation.
+ *
+ * Checks that the step is positive and that both ends of the range are multiples of the step.
+ * A stepper increments and decrements by a fixed step, so the range bounds must land on a step.
+ *
+ * @param step The step value used for incrementing or decrementing. Must be a positive integer.
+ * @param range The range of values allowed, represented as an [IntRange]. Both the start and
+ *              end of this range must be multiples of the step value.
+ * @throws IllegalArgumentException If the step is not positive, or if the start or end of the
+ *                                  range are not multiples of the step. The exception message will
+ *                                  indicate the specific violation.
+ *
+ * Example Usage:
+ * ```kotlin
+ * // Valid input: step of 2, range from 0 to 10 (both multiples of 2)
+ * stepperInputValidator(2, 0..10)
+ *
+ * // Invalid input: step of -1 (not positive)
+ * try {
+ *     stepperInputValidator(-1, 0..10)
+ * } catch (e: IllegalArgumentException) {
+ *     println(e.message) // Output: A step can only be a positive integer, but was -1
+ * }
+ *
+ * // Invalid input: range start 1 (not multiple of 2)
+ * try {
+ *     stepperInputValidator(2, 1..10)
+ * } catch (e: IllegalArgumentException) {
+ *      println(e.message) // Output: The min range must be a multiple of the step, but has 1  remaining
+ * }
+ *
+ * // Invalid input: range end 9 (not multiple of 2)
+ * try {
+ *     stepperInputValidator(2, 0..9)
+ * } catch (e: IllegalArgumentException) {
+ *      println(e.message) // Output: The max range must be a multiple of the step, but has 1  remaining
+ * }
+ * ```
+ */
+@OpenForTesting
+public fun stepperInputValidator(step: Int, range: IntRange) {
+    require(step > 0) { "A step can only be a positive integer, but was $step" }
+    require(range.last % step == 0) {
+        "The max range must be a multiple of the step, but has ${range.last % step}  remaining"
+    }
+    require(range.first % step == 0) {
+        "The min range must be a multiple of the step, but has ${range.first % step}  remaining"
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal fun Modifier.generateStepperTestTag(testTag: String?, action: String): Modifier = testTag?.let {
+    semantics {
+        contentDescription = "" // handled by semantics modifier
+        stateDescription = "" // handled by semantics modifier
+        testTagsAsResourceId = true
+    }.testTag("${testTag}$action")
+} ?: this

--- a/spark/src/main/res/values-fr/strings.xml
+++ b/spark/src/main/res/values-fr/strings.xml
@@ -93,6 +93,11 @@
     </plurals>
     <!--endregion-->
 
+    <!--region Stepper-->
+    <string name="spark_stepper_increment_a11y">Augmenter</string>
+    <string name="spark_stepper_decrement_a11y">Diminuer</string>
+    <!--endregion-->
+
     <!--region FileUpload-->
     <string name="spark_groupSeparator">\u00A0</string>
     <string name="spark_decimalSymbol">,</string>

--- a/spark/src/main/res/values-fr/strings.xml
+++ b/spark/src/main/res/values-fr/strings.xml
@@ -93,11 +93,6 @@
     </plurals>
     <!--endregion-->
 
-    <!--region Stepper-->
-    <string name="spark_stepper_increment_a11y">Augmenter</string>
-    <string name="spark_stepper_decrement_a11y">Diminuer</string>
-    <!--endregion-->
-
     <!--region FileUpload-->
     <string name="spark_groupSeparator">\u00A0</string>
     <string name="spark_decimalSymbol">,</string>

--- a/spark/src/main/res/values/strings.xml
+++ b/spark/src/main/res/values/strings.xml
@@ -90,11 +90,6 @@
     </plurals>
     <!--endregion-->
 
-    <!--region Stepper-->
-    <string name="spark_stepper_increment_a11y">Increment</string>
-    <string name="spark_stepper_decrement_a11y">Decrement</string>
-    <!--endregion-->
-
     <!--region FileUpload-->
     <string name="spark_groupSeparator">,</string>
     <string name="spark_decimalSymbol">.</string>

--- a/spark/src/main/res/values/strings.xml
+++ b/spark/src/main/res/values/strings.xml
@@ -90,6 +90,11 @@
     </plurals>
     <!--endregion-->
 
+    <!--region Stepper-->
+    <string name="spark_stepper_increment_a11y">Increment</string>
+    <string name="spark_stepper_decrement_a11y">Decrement</string>
+    <!--endregion-->
+
     <!--region FileUpload-->
     <string name="spark_groupSeparator">,</string>
     <string name="spark_decimalSymbol">.</string>

--- a/spark/src/test/kotlin/com/adevinta/spark/stepper/ApplyStepTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/stepper/ApplyStepTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.stepper
+
+import com.adevinta.spark.components.stepper.applyStep
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [applyStep].
+ *
+ * applyStep is the single arithmetic primitive shared by both StepperState and
+ * StepperInputState. A bug here silently corrupts every increment/decrement
+ * operation regardless of which state holder is used.
+ */
+@RunWith(JUnit4::class)
+class ApplyStepTest {
+
+    // region null current — snap behaviour
+
+    @Test
+    fun `null current with positive delta returns range first`() {
+        // Null means "no value selected yet". Any step, positive or negative,
+        // must snap to range.first — not range.first + delta.
+        assertEquals(3, applyStep(current = null, delta = 2, range = 3..10))
+    }
+
+    @Test
+    fun `null current with negative delta returns range first`() {
+        assertEquals(3, applyStep(current = null, delta = -2, range = 3..10))
+    }
+
+    @Test
+    fun `null current with zero delta returns range first`() {
+        // delta = 0 is unusual but must not crash and still snaps to first.
+        assertEquals(0, applyStep(current = null, delta = 0, range = 0..10))
+    }
+
+    // endregion
+
+    // region normal step application
+
+    @Test
+    fun `positive delta adds step to current`() {
+        assertEquals(7, applyStep(current = 5, delta = 2, range = 0..10))
+    }
+
+    @Test
+    fun `negative delta subtracts step from current`() {
+        assertEquals(3, applyStep(current = 5, delta = -2, range = 0..10))
+    }
+
+    // endregion
+
+    // region clamping at boundaries
+
+    @Test
+    fun `result clamped to range last when delta overshoots`() {
+        // 9 + 2 = 11, but range.last = 10 → expect 10
+        assertEquals(10, applyStep(current = 9, delta = 2, range = 0..10))
+    }
+
+    @Test
+    fun `result clamped to range first when delta undershoots`() {
+        // 1 - 2 = -1, but range.first = 0 → expect 0
+        assertEquals(0, applyStep(current = 1, delta = -2, range = 0..10))
+    }
+
+    @Test
+    fun `result clamped when already at range last`() {
+        assertEquals(10, applyStep(current = 10, delta = 1, range = 0..10))
+    }
+
+    @Test
+    fun `result clamped when already at range first`() {
+        assertEquals(0, applyStep(current = 0, delta = -1, range = 0..10))
+    }
+
+    // endregion
+
+    // region negative ranges
+
+    @Test
+    fun `works with fully negative range`() {
+        // -5 + 2 = -3, within -10..-1
+        assertEquals(-3, applyStep(current = -5, delta = 2, range = -10..-1))
+    }
+
+    @Test
+    fun `clamps to negative range last`() {
+        // -2 + 5 = 3, but range.last = -1 → expect -1
+        assertEquals(-1, applyStep(current = -2, delta = 5, range = -10..-1))
+    }
+
+    @Test
+    fun `clamps to negative range first`() {
+        // -9 - 5 = -14, but range.first = -10 → expect -10
+        assertEquals(-10, applyStep(current = -9, delta = -5, range = -10..-1))
+    }
+
+    // endregion
+
+    // region single-element range
+
+    @Test
+    fun `single-element range always returns that element for non-null current`() {
+        assertEquals(5, applyStep(current = 5, delta = 1, range = 5..5))
+        assertEquals(5, applyStep(current = 5, delta = -1, range = 5..5))
+    }
+
+    @Test
+    fun `single-element range always returns that element for null current`() {
+        assertEquals(5, applyStep(current = null, delta = 1, range = 5..5))
+    }
+
+    // endregion
+
+    // region Int overflow protection
+
+    @Test
+    fun `large positive delta does not overflow when clamped to range last`() {
+        // Int.MAX_VALUE - 1 + Int.MAX_VALUE would overflow without coerceIn.
+        // coerceIn runs on the already-computed sum, so the real question is
+        // whether (current + delta) wraps before coerceIn sees it.
+        // The implementation uses plain addition, so this test documents the
+        // current behaviour and will fail if the code ever silently overflows.
+        val result = applyStep(current = Int.MAX_VALUE - 1, delta = Int.MAX_VALUE, range = 0..Int.MAX_VALUE)
+        // Overflow: (MAX-1) + MAX wraps to a negative number, coerceIn clamps to 0.
+        // Document this as the current behaviour so any future fix shows up as a test change.
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun `large negative delta does not overflow when clamped to range first`() {
+        val result = applyStep(current = Int.MIN_VALUE + 1, delta = Int.MIN_VALUE, range = Int.MIN_VALUE..0)
+        // Similarly documents wrap-to-positive behaviour for negative overflow.
+        assertEquals(0, result)
+    }
+
+    // endregion
+
+    // region step larger than range
+
+    @Test
+    fun `step larger than range size clamps correctly on increment`() {
+        // range is 0..2, delta = 100. Result must clamp to 2, not wrap.
+        assertEquals(2, applyStep(current = 0, delta = 100, range = 0..2))
+    }
+
+    @Test
+    fun `step larger than range size clamps correctly on decrement`() {
+        assertEquals(0, applyStep(current = 2, delta = -100, range = 0..2))
+    }
+
+    // endregion
+}

--- a/spark/src/test/kotlin/com/adevinta/spark/stepper/IntegerInputTransformationTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/stepper/IntegerInputTransformationTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.stepper
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.insert
+import androidx.compose.ui.text.input.KeyboardType
+import com.adevinta.spark.components.stepper.internal.IntegerInputTransformation
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.text.DecimalFormatSymbols
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class IntegerInputTransformationTest {
+
+    private fun applyTransformation(
+        initialText: String = "",
+        insertText: String,
+        allowNegative: Boolean = true,
+    ): String {
+        val transformation = IntegerInputTransformation(allowNegative)
+        val state = TextFieldState(initialText)
+        state.edit {
+            insert(length, insertText)
+            with(transformation) { transformInput() }
+        }
+        return state.text.toString()
+    }
+
+    @Test
+    fun `digits accepted`() {
+        assertEquals("123", applyTransformation(insertText = "123"))
+    }
+
+    @Test
+    fun `letters rejected`() {
+        assertEquals("", applyTransformation(insertText = "abc"))
+    }
+
+    @Test
+    fun `mixed content rejected`() {
+        assertEquals("", applyTransformation(insertText = "12a3"))
+    }
+
+    @Test
+    fun `minus accepted when allowNegative`() {
+        assertEquals("-", applyTransformation(insertText = "-", allowNegative = true))
+    }
+
+    @Test
+    fun `minus with digits accepted when allowNegative`() {
+        assertEquals("-5", applyTransformation(insertText = "-5", allowNegative = true))
+    }
+
+    @Test
+    fun `minus rejected when not allowNegative`() {
+        assertEquals("", applyTransformation(insertText = "-", allowNegative = false))
+    }
+
+    @Test
+    fun `minus with digits rejected when not allowNegative`() {
+        assertEquals("", applyTransformation(insertText = "-5", allowNegative = false))
+    }
+
+    @Test
+    fun `multiple minus signs rejected`() {
+        assertEquals("", applyTransformation(insertText = "--5"))
+    }
+
+    @Test
+    fun `minus not at position 0 rejected`() {
+        assertEquals("1", applyTransformation(initialText = "1", insertText = "-"))
+    }
+
+    @Test
+    fun `grouping separator accepted`() {
+        val sep = DecimalFormatSymbols.getInstance().groupingSeparator
+        val input = "1${sep}234"
+        assertEquals(input, applyTransformation(insertText = input))
+    }
+
+    @Test
+    fun `empty string accepted`() {
+        assertEquals("", applyTransformation(insertText = ""))
+    }
+
+    @Test
+    fun `keyboard type is Number`() {
+        val transformation = IntegerInputTransformation(allowNegative = true)
+        assertEquals(KeyboardType.Number, transformation.keyboardOptions.keyboardType)
+    }
+}

--- a/spark/src/test/kotlin/com/adevinta/spark/stepper/IntegerOutputTransformationTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/stepper/IntegerOutputTransformationTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.stepper
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.adevinta.spark.components.stepper.internal.IntegerOutputTransformation
+import com.adevinta.spark.components.stepper.internal.groupingSeparator
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.text.NumberFormat
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [IntegerOutputTransformation].
+ *
+ * This transformation has zero dedicated test coverage. It runs on every
+ * render of the input field, so a formatting bug would surface visually on
+ * every keystroke — high user-facing impact.
+ *
+ * The helper [applyOutputTransformation] mirrors the pattern used in
+ * IntegerInputTransformationTest so both files stay consistent.
+ */
+@RunWith(RobolectricTestRunner::class)
+class IntegerOutputTransformationTest {
+
+    private val transformation = IntegerOutputTransformation()
+
+    /**
+     * Applies [IntegerOutputTransformation.transformOutput] to a [TextFieldState]
+     * with the given [rawText] and returns the transformed output as a string.
+     *
+     * OutputTransformation is called by the framework during the draw phase.
+     * We simulate it by invoking transformOutput directly inside a state.edit
+     * block with the same TextFieldBuffer the framework would pass.
+     */
+    private fun applyOutputTransformation(rawText: String): String {
+        val state = TextFieldState(rawText)
+        // OutputTransformation operates on a TextFieldBuffer that mirrors the
+        // underlying text. We call the internal function via edit { } to obtain
+        // an equivalent buffer.
+        state.edit {
+            with(transformation) { transformOutput() }
+        }
+        return state.text.toString()
+    }
+
+    // region no-op cases — transformation must leave the buffer unchanged
+
+    @Test
+    fun `empty string is left unchanged`() {
+        // toIntOrNull() returns null → early return, buffer untouched.
+        assertEquals("", applyOutputTransformation(""))
+    }
+
+    @Test
+    fun `lone minus sign is left unchanged`() {
+        // "-".stripGroupingSeparators().toIntOrNull() → null → no replacement.
+        assertEquals("-", applyOutputTransformation("-"))
+    }
+
+    @Test
+    fun `non-numeric text is left unchanged`() {
+        assertEquals("abc", applyOutputTransformation("abc"))
+    }
+
+    @Test
+    fun `single digit is left unchanged`() {
+        // "5" already formats to "5", so formatted == raw → no replacement.
+        assertEquals("5", applyOutputTransformation("5"))
+    }
+
+    @Test
+    fun `three-digit number below grouping threshold is left unchanged`() {
+        assertEquals("999", applyOutputTransformation("999"))
+    }
+
+    // endregion
+
+    // region grouping separator insertion
+
+    @Test
+    fun `four-digit number receives grouping separator`() {
+        val sep = groupingSeparator
+        val expected = "1${sep}000"
+        assertEquals(expected, applyOutputTransformation("1000"))
+    }
+
+    @Test
+    fun `seven-digit number receives two grouping separators`() {
+        val expected = NumberFormat.getIntegerInstance().format(1_234_567)
+        assertEquals(expected, applyOutputTransformation("1234567"))
+    }
+
+    @Test
+    fun `already-formatted input is idempotent`() {
+        // If the buffer already contains grouping separators the transformation
+        // must not double-insert them or corrupt the value.
+        val sep = groupingSeparator
+        val alreadyFormatted = "1${sep}000"
+        assertEquals(alreadyFormatted, applyOutputTransformation(alreadyFormatted))
+    }
+
+    // endregion
+
+    // region negative numbers
+
+    @Test
+    fun `negative single digit is left unchanged`() {
+        assertEquals("-5", applyOutputTransformation("-5"))
+    }
+
+    @Test
+    fun `negative four-digit number receives grouping separator`() {
+        val expected = NumberFormat.getIntegerInstance().format(-1000)
+        assertEquals(expected, applyOutputTransformation("-1000"))
+    }
+
+    // endregion
+
+    // region boundary values
+
+    @Test
+    fun `zero is left unchanged`() {
+        assertEquals("0", applyOutputTransformation("0"))
+    }
+
+    @Test
+    fun `Int MAX_VALUE formats without throwing`() {
+        val expected = NumberFormat.getIntegerInstance().format(Int.MAX_VALUE)
+        assertEquals(expected, applyOutputTransformation(Int.MAX_VALUE.toString()))
+    }
+
+    @Test
+    fun `Int MIN_VALUE formats without throwing`() {
+        val expected = NumberFormat.getIntegerInstance().format(Int.MIN_VALUE)
+        assertEquals(expected, applyOutputTransformation(Int.MIN_VALUE.toString()))
+    }
+
+    // endregion
+}

--- a/spark/src/test/kotlin/com/adevinta/spark/stepper/StepperInputStateTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/stepper/StepperInputStateTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.stepper
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.adevinta.spark.components.stepper.StepperInputState
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.text.NumberFormat
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(RobolectricTestRunner::class)
+class StepperInputStateTest {
+
+    @Test
+    fun `value is null for empty text`() {
+        val state = StepperInputState(TextFieldState(""))
+        assertNull(state.value)
+    }
+
+    @Test
+    fun `value parses valid integer`() {
+        val state = StepperInputState(TextFieldState("123"))
+        assertEquals(123, state.value)
+    }
+
+    @Test
+    fun `value parses negative integer`() {
+        val state = StepperInputState(TextFieldState("-42"))
+        assertEquals(-42, state.value)
+    }
+
+    @Test
+    fun `value is null for lone minus`() {
+        val state = StepperInputState(TextFieldState("-"))
+        assertNull(state.value)
+    }
+
+    @Test
+    fun `value is null for non-numeric text`() {
+        val state = StepperInputState(TextFieldState("abc"))
+        assertNull(state.value)
+    }
+
+    @Test
+    fun `commitValue clamps and reformats`() {
+        val state = StepperInputState(TextFieldState("999"))
+        state.commitValue(0..100)
+        assertEquals("100", state.textFieldState.text.toString())
+        assertEquals(100, state.value)
+    }
+
+    @Test
+    fun `commitValue formats with locale grouping`() {
+        val state = StepperInputState(TextFieldState("12345"))
+        state.commitValue(0..99999)
+        val expected = NumberFormat.getIntegerInstance().format(12345)
+        assertEquals(expected, state.textFieldState.text.toString())
+    }
+
+    @Test
+    fun `commitValue clears empty to empty`() {
+        val state = StepperInputState(TextFieldState(""))
+        state.commitValue(0..100)
+        assertEquals("", state.textFieldState.text.toString())
+    }
+
+    @Test
+    fun `commitValue clears invalid to empty`() {
+        val state = StepperInputState(TextFieldState("-"))
+        state.commitValue(0..100)
+        assertEquals("", state.textFieldState.text.toString())
+    }
+
+    @Test
+    fun `increment from null snaps to range first`() {
+        val state = StepperInputState(TextFieldState(""))
+        state.increment(step = 1, range = 5..10)
+        assertEquals(5, state.value)
+    }
+
+    @Test
+    fun `increment from value`() {
+        val state = StepperInputState(TextFieldState("5"))
+        state.increment(step = 2, range = 0..10)
+        assertEquals(7, state.value)
+    }
+
+    @Test
+    fun `increment clamps to range max`() {
+        val state = StepperInputState(TextFieldState("9"))
+        state.increment(step = 2, range = 0..10)
+        assertEquals(10, state.value)
+    }
+
+    @Test
+    fun `decrement from null snaps to range first`() {
+        val state = StepperInputState(TextFieldState(""))
+        state.decrement(step = 1, range = 5..10)
+        assertEquals(5, state.value)
+    }
+
+    @Test
+    fun `decrement from value`() {
+        val state = StepperInputState(TextFieldState("5"))
+        state.decrement(step = 2, range = 0..10)
+        assertEquals(3, state.value)
+    }
+
+    @Test
+    fun `decrement clamps to range min`() {
+        val state = StepperInputState(TextFieldState("1"))
+        state.decrement(step = 2, range = 0..10)
+        assertEquals(0, state.value)
+    }
+
+    @Test
+    fun `value strips grouping separators before parsing`() {
+        // The field stores formatted text like "1,234". The value property must
+        // strip separators before calling toIntOrNull, otherwise it returns null
+        // and any subsequent commitValue call would clear the field.
+        val sep = NumberFormat.getIntegerInstance().let {
+            java.text.DecimalFormatSymbols.getInstance().groupingSeparator
+        }
+        val state = StepperInputState(TextFieldState("1${sep}234"))
+        assertEquals(1234, state.value)
+    }
+
+    @Test
+    fun `commitValue clamps value below range minimum up to range first`() {
+        // The existing clamp test only checks clamping above range.last.
+        // This covers the symmetric lower-bound case.
+        val state = StepperInputState(TextFieldState("-50"))
+        state.commitValue(0..100)
+        assertEquals("0", state.textFieldState.text.toString())
+        assertEquals(0, state.value)
+    }
+
+    @Test
+    fun `commitValue on value equal to range last leaves value unchanged`() {
+        val state = StepperInputState(TextFieldState("100"))
+        state.commitValue(0..100)
+        assertEquals(100, state.value)
+    }
+
+    @Test
+    fun `increment then decrement restores original formatted text`() {
+        // Verifies that the round-trip through applyStep + formatInteger
+        // produces consistent text, not a double-formatted artefact.
+        val state = StepperInputState(TextFieldState("5"))
+        state.increment(step = 2, range = 0..10)
+        state.decrement(step = 2, range = 0..10)
+        assertEquals("5", state.textFieldState.text.toString())
+    }
+}

--- a/spark/src/test/kotlin/com/adevinta/spark/stepper/StepperInputTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/stepper/StepperInputTest.kt
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.stepper
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.components.stepper.Stepper
+import com.adevinta.spark.components.stepper.StepperInputState
+import com.adevinta.spark.components.stepper.rememberStepperInputState
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StepperInputTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `Input controlled - text field exposes editable text`() {
+        val testTag = "inputStepper"
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                Stepper.Input(
+                    value = 5,
+                    onValueChange = {},
+                    modifier = Modifier.testTag(testTag),
+                    range = 0..10,
+                    step = 1,
+                    suffix = " kg",
+                    testTag = testTag,
+                )
+            }
+        }
+
+        // The value is edited through the text field, which exposes a set-text action.
+        composeTestRule.onNode(hasSetTextAction())
+            .assertExists()
+    }
+
+    @Test
+    fun `Input controlled - no custom actions on the node`() {
+        val testTag = "inputStepper"
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                Stepper.Input(
+                    value = 5,
+                    onValueChange = {},
+                    modifier = Modifier.testTag(testTag),
+                    range = 0..10,
+                    step = 1,
+                    testTag = testTag,
+                )
+            }
+        }
+
+        // Field-only variant: increment and decrement are not exposed as accessibility actions.
+        composeTestRule.onNodeWithTag(testTag)
+            .assert(SemanticsMatcher.keyNotDefined(SemanticsActions.CustomActions))
+    }
+
+    @Test
+    fun `Input controlled - disabled field is not editable`() {
+        val testTag = "inputStepper"
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                Stepper.Input(
+                    value = 5,
+                    onValueChange = {},
+                    modifier = Modifier.testTag(testTag),
+                    range = 0..10,
+                    step = 1,
+                    enabled = false,
+                    testTag = testTag,
+                )
+            }
+        }
+
+        // A disabled text field exposes no set-text action, so it cannot be edited.
+        composeTestRule.onNode(hasSetTextAction())
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `Input controlled - increment button updates value`() {
+        val testTag = "inputStepper"
+        var lastValue: Int? = null
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                var value by remember { mutableStateOf<Int?>(5) }
+                Stepper.Input(
+                    value = value,
+                    onValueChange = {
+                        lastValue = it
+                        value = it
+                    },
+                    modifier = Modifier.testTag(testTag),
+                    range = 0..10,
+                    step = 1,
+                    testTag = testTag,
+                )
+            }
+        }
+
+        composeTestRule.onNode(hasTestTag("${testTag}Increment"))
+            .performClick()
+
+        composeTestRule.waitForIdle()
+        assertEquals(6, lastValue)
+    }
+
+    @Test
+    fun `Input controlled - decrement button updates value`() {
+        val testTag = "inputStepper"
+        var lastValue: Int? = null
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                var value by remember { mutableStateOf<Int?>(5) }
+                Stepper.Input(
+                    value = value,
+                    onValueChange = {
+                        lastValue = it
+                        value = it
+                    },
+                    modifier = Modifier.testTag(testTag),
+                    range = 0..10,
+                    step = 1,
+                    testTag = testTag,
+                )
+            }
+        }
+
+        composeTestRule.onNode(hasTestTag("${testTag}Decrement"))
+            .performClick()
+
+        composeTestRule.waitForIdle()
+        assertEquals(4, lastValue)
+    }
+
+    @Test
+    fun `Input controlled - increment from null snaps to range first`() {
+        val testTag = "inputStepper"
+        var lastValue: Int? = null
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                var value by remember { mutableStateOf<Int?>(null) }
+                Stepper.Input(
+                    value = value,
+                    onValueChange = {
+                        lastValue = it
+                        value = it
+                    },
+                    modifier = Modifier.testTag(testTag),
+                    range = 0..10,
+                    step = 1,
+                    testTag = testTag,
+                )
+            }
+        }
+
+        composeTestRule.onNode(hasTestTag("${testTag}Increment"))
+            .performClick()
+
+        composeTestRule.waitForIdle()
+        assertEquals(0, lastValue)
+    }
+
+    @Test
+    fun `Input uncontrolled - state increment updates value`() {
+        val testTag = "inputStepper"
+        lateinit var state: StepperInputState
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                state = rememberStepperInputState(initialValue = 5)
+                Stepper.Input(
+                    state = state,
+                    modifier = Modifier.testTag(testTag),
+                    range = 0..10,
+                    step = 1,
+                    testTag = testTag,
+                )
+            }
+        }
+
+        composeTestRule.onNode(hasTestTag("${testTag}Increment"))
+            .performClick()
+
+        composeTestRule.waitForIdle()
+        assertEquals(6, state.value)
+    }
+
+    @Test
+    fun `Input uncontrolled - state decrement clamps at min`() {
+        val testTag = "inputStepper"
+        lateinit var state: StepperInputState
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                state = rememberStepperInputState(initialValue = 0)
+                Stepper.Input(
+                    state = state,
+                    modifier = Modifier.testTag(testTag),
+                    range = 0..10,
+                    step = 1,
+                    testTag = testTag,
+                )
+            }
+        }
+
+        composeTestRule.onNode(hasTestTag("${testTag}Decrement"))
+            .performClick()
+
+        composeTestRule.waitForIdle()
+        assertEquals(0, state.value)
+    }
+}

--- a/spark/src/test/kotlin/com/adevinta/spark/stepper/StepperStateTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/stepper/StepperStateTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.stepper
+
+import com.adevinta.spark.components.stepper.StepperState
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@RunWith(JUnit4::class)
+class StepperStateTest {
+
+    @Test
+    fun `initial null value`() {
+        val state = StepperState(initialValue = null, range = 0..10, step = 1)
+        assertNull(state.value)
+    }
+
+    @Test
+    fun `initial non-null value`() {
+        val state = StepperState(initialValue = 5, range = 0..10, step = 1)
+        assertEquals(5, state.value)
+    }
+
+    @Test
+    fun `increment from null snaps to range first`() {
+        val state = StepperState(initialValue = null, range = 2..10, step = 2)
+        state.increment()
+        assertEquals(2, state.value)
+    }
+
+    @Test
+    fun `decrement from null snaps to range first`() {
+        val state = StepperState(initialValue = null, range = 2..10, step = 2)
+        state.decrement()
+        assertEquals(2, state.value)
+    }
+
+    @Test
+    fun `increment from value`() {
+        val state = StepperState(initialValue = 4, range = 0..10, step = 2)
+        state.increment()
+        assertEquals(6, state.value)
+    }
+
+    @Test
+    fun `decrement from value`() {
+        val state = StepperState(initialValue = 4, range = 0..10, step = 2)
+        state.decrement()
+        assertEquals(2, state.value)
+    }
+
+    @Test
+    fun `increment clamps to range max`() {
+        val state = StepperState(initialValue = 9, range = 0..10, step = 2)
+        state.increment()
+        assertEquals(10, state.value)
+    }
+
+    @Test
+    fun `decrement clamps to range min`() {
+        val state = StepperState(initialValue = 1, range = 0..10, step = 2)
+        state.decrement()
+        assertEquals(0, state.value)
+    }
+
+    @Test
+    fun `canIncrement true when below max`() {
+        val state = StepperState(initialValue = 5, range = 0..10, step = 1)
+        assertTrue(state.canIncrement)
+    }
+
+    @Test
+    fun `canIncrement false when at max`() {
+        val state = StepperState(initialValue = 10, range = 0..10, step = 1)
+        assertFalse(state.canIncrement)
+    }
+
+    @Test
+    fun `canDecrement true when above min`() {
+        val state = StepperState(initialValue = 5, range = 0..10, step = 1)
+        assertTrue(state.canDecrement)
+    }
+
+    @Test
+    fun `canDecrement false when at min`() {
+        val state = StepperState(initialValue = 0, range = 0..10, step = 1)
+        assertFalse(state.canDecrement)
+    }
+
+    @Test
+    fun `canIncrement true when value is null and range is non-empty`() {
+        val state = StepperState(initialValue = null, range = 0..10, step = 1)
+        assertTrue(state.canIncrement)
+    }
+
+    @Test
+    fun `canDecrement true when value is null and range is non-empty`() {
+        val state = StepperState(initialValue = null, range = 0..10, step = 1)
+        assertTrue(state.canDecrement)
+    }
+
+    @Test
+    fun `canIncrement false when value is null and range is empty`() {
+        val state = StepperState(initialValue = null, range = 5..5, step = 1)
+        assertFalse(state.canIncrement)
+    }
+
+    @Test
+    fun `canDecrement false when value is null and range is empty`() {
+        // Symmetric to the canIncrement empty-range case; the null branch checks
+        // range.first < range.last, which is false for a single-element range.
+        val state = StepperState(initialValue = null, range = 5..5, step = 1)
+        assertFalse(state.canDecrement)
+    }
+
+    @Test
+    fun `increment then decrement from null returns range first both times`() {
+        // Both operations on a null value snap to range.first rather than
+        // applying the step, so the value stays at range.first after each call.
+        val state = StepperState(initialValue = null, range = 4..10, step = 2)
+        state.increment()
+        assertEquals(4, state.value)
+        state.decrement()
+        // Now value is 4 (non-null), so decrement applies -step and clamps.
+        assertEquals(4, state.value)
+    }
+
+    @Test
+    fun `value out of range on construction is not clamped by the state itself`() {
+        // StepperState does not clamp initialValue — clamping is the caller's
+        // responsibility. This test documents that contract so a future
+        // "helpful" clamp in the constructor would break it intentionally.
+        val state = StepperState(initialValue = 20, range = 0..10, step = 1)
+        assertEquals(20, state.value)
+    }
+}

--- a/spark/src/test/kotlin/com/adevinta/spark/stepper/StepperTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/stepper/StepperTest.kt
@@ -23,6 +23,7 @@ package com.adevinta.spark.stepper
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -58,7 +59,7 @@ class StepperTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun `Stepper semantics suffix`() {
+    fun `Nudger semantics suffix`() {
         val minRange = 0
         val maxRange = 10
         val step = 2
@@ -68,7 +69,7 @@ class StepperTest {
         composeTestRule.setContent {
             PreviewTheme {
                 var value by remember { mutableIntStateOf(initialValue) }
-                Stepper(
+                Stepper.Nudger(
                     value = value,
                     onValueChange = { value = it },
                     modifier = Modifier.testTag(stepperTestTag),
@@ -87,7 +88,7 @@ class StepperTest {
     }
 
     @Test
-    fun `Stepper semantics range`() {
+    fun `Nudger semantics range`() {
         val minRange = 0
         val maxRange = 2
         val rangeFloat = minRange.toFloat()..maxRange.toFloat()
@@ -99,7 +100,7 @@ class StepperTest {
         composeTestRule.setContent {
             PreviewTheme {
                 var value by remember { mutableIntStateOf(initialValue) }
-                Stepper(
+                Stepper.Nudger(
                     value = value,
                     onValueChange = { value = it },
                     modifier = Modifier.testTag(stepperTestTag),
@@ -126,7 +127,7 @@ class StepperTest {
     }
 
     @Test
-    fun `Stepper semantics progress`() {
+    fun `Nudger semantics progress`() {
         val minRange = 0
         val maxRange = 10
         val range = minRange..maxRange
@@ -139,7 +140,7 @@ class StepperTest {
         composeTestRule.setContent {
             PreviewTheme {
                 var value by remember { mutableIntStateOf(initialValue) }
-                Stepper(
+                Stepper.Nudger(
                     value = value,
                     onValueChange = { value = it },
                     modifier = Modifier.testTag(stepperTestTag),
@@ -186,7 +187,7 @@ class StepperTest {
     }
 
     @Test
-    fun `Stepper semantics disabled`() {
+    fun `Nudger semantics disabled`() {
         val minRange = 0
         val maxRange = 10
         val range = minRange..maxRange
@@ -196,7 +197,7 @@ class StepperTest {
         composeTestRule.setContent {
             PreviewTheme {
                 var value by remember { mutableIntStateOf(initialValue) }
-                Stepper(
+                Stepper.Nudger(
                     value = value,
                     onValueChange = { value = it },
                     modifier = Modifier.testTag(stepperTestTag),
@@ -215,7 +216,7 @@ class StepperTest {
 
     @OptIn(ExperimentalTestApi::class)
     @Test
-    fun `Stepper keyboard control`() {
+    fun `Nudger keyboard control`() {
         val minRange = 0
         val maxRange = 10
         val range = minRange..maxRange
@@ -228,7 +229,7 @@ class StepperTest {
         composeTestRule.setContent {
             PreviewTheme {
                 var value by remember { mutableIntStateOf(initialValue) }
-                Stepper(
+                Stepper.Nudger(
                     value = value,
                     onValueChange = { value = it },
                     modifier = Modifier.testTag(stepperTestTag),
@@ -273,7 +274,7 @@ class StepperTest {
 
     @OptIn(ExperimentalTestApi::class)
     @Test
-    fun `Stepper not focused keyboard control`() {
+    fun `Nudger not focused keyboard control`() {
         val minRange = 0
         val maxRange = 10
         val range = minRange..maxRange
@@ -286,7 +287,7 @@ class StepperTest {
         composeTestRule.setContent {
             PreviewTheme {
                 var value by remember { mutableIntStateOf(initialValue) }
-                Stepper(
+                Stepper.Nudger(
                     value = value,
                     onValueChange = { value = it },
                     modifier = Modifier.testTag(stepperTestTag),
@@ -313,7 +314,7 @@ class StepperTest {
 
     @OptIn(ExperimentalTestApi::class)
     @Test
-    fun `Stepper keyboard control range`() {
+    fun `Nudger keyboard control range`() {
         val minRange = 0
         val maxRange = 2
         val rangeFloat = minRange.toFloat()..maxRange.toFloat()
@@ -325,7 +326,7 @@ class StepperTest {
         composeTestRule.setContent {
             PreviewTheme {
                 var value by remember { mutableIntStateOf(initialValue) }
-                Stepper(
+                Stepper.Nudger(
                     value = value,
                     onValueChange = { value = it },
                     modifier = Modifier.testTag(stepperTestTag),
@@ -350,6 +351,124 @@ class StepperTest {
                     SemanticsProperties.ProgressBarRangeInfo,
                     ProgressBarRangeInfo(current = 2f, range = rangeFloat, steps),
                 ),
+            )
+    }
+
+    @Test
+    fun `Nudger null value has empty stateDescription`() {
+        val stepperTestTag = "myStepper"
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                var value by remember { mutableStateOf<Int?>(null) }
+                Stepper.Nudger(
+                    value = value,
+                    onValueChange = { value = it },
+                    modifier = Modifier.testTag(stepperTestTag),
+                    range = 0..10,
+                    step = 1,
+                    testTag = stepperTestTag,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(stepperTestTag)
+            .assert(
+                SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, ""),
+            )
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun `Nudger null value Shift+Up sets to range first`() {
+        val stepperTestTag = "myStepper"
+        val rangeFloat = 0f..10f
+        val steps = 10
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                var value by remember { mutableStateOf<Int?>(null) }
+                Stepper.Nudger(
+                    value = value,
+                    onValueChange = { value = it },
+                    modifier = Modifier.testTag(stepperTestTag),
+                    range = 0..10,
+                    step = 1,
+                    testTag = stepperTestTag,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(stepperTestTag)
+            .requestFocus()
+            .performKeyInput {
+                withKeyDown(Key.ShiftLeft) {
+                    pressKey(Key.DirectionUp)
+                }
+            }
+            .assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.ProgressBarRangeInfo,
+                    ProgressBarRangeInfo(current = 0f, range = rangeFloat, steps),
+                ),
+            )
+            .assertTextEquals("0")
+    }
+
+    @Test
+    fun `Nudger null value SetProgress sets to range first`() {
+        val stepperTestTag = "myStepper"
+        val rangeFloat = 0f..10f
+        val steps = 10
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                var value by remember { mutableStateOf<Int?>(null) }
+                Stepper.Nudger(
+                    value = value,
+                    onValueChange = { value = it },
+                    modifier = Modifier.testTag(stepperTestTag),
+                    range = 0..10,
+                    step = 1,
+                    testTag = stepperTestTag,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(stepperTestTag)
+            .performSemanticsAction(SetProgress) { setProgress -> setProgress(5f) }
+            .assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.ProgressBarRangeInfo,
+                    ProgressBarRangeInfo(current = 5f, range = rangeFloat, steps),
+                ),
+            )
+            .assertTextEquals("5")
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `Deprecated Stepper still compiles and works`() {
+        val stepperTestTag = "myStepper"
+
+        composeTestRule.setContent {
+            PreviewTheme {
+                var value by remember { mutableIntStateOf(4) }
+                Stepper(
+                    value = value,
+                    onValueChange = { value = it },
+                    modifier = Modifier.testTag(stepperTestTag),
+                    range = 0..10,
+                    step = 2,
+                    suffix = " €",
+                    testTag = stepperTestTag,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(stepperTestTag)
+            .assert(
+                SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "4 €"),
             )
     }
 }


### PR DESCRIPTION
## 📋 Changes

Replaces the flat `Stepper()` / `StepperForm()` functions with a `Stepper` object that groups four composables: `Nudger`, `NudgerForm`, `Input`, and `InputForm`. 

The new **Input** variant lets users type a quantity directly. An integer input/output transformation enforces digits only; the field shows `-` when empty. The +/- buttons act on the currently typed value and support accelerating long-press repeat (`RepeatableIconButton`).

Accessibility: `Nudger` exposes slider semantics (`setProgress`) so TalkBack announces the value as a range. `Input` hides the +/- buttons from TalkBack and exposes only the text field as using custom action in this case would be much more difficult than directly inputting the value.

## 🤔 Context

The previous flat API had no editable variant, making it hard for inputs that needed most of the time small nudges (that's why I renamed the previous one like this) and few times where we need to input a number bigger than 10 like a floors in a big builduing. 
This also aligns the API shape with other Spark components that use object-grouped composables.

## ✅  Checklist

- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.