### PR TITLE
fix(ci): restore credentials in dependabot baseline job

### DIFF
--- a/.github/workflows/dependabot-dependency-guard.yml
+++ b/.github/workflows/dependabot-dependency-guard.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/gradle/')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7 # zizmor: ignore[artipacked] job pushes a baseline commit, needs persisted credentials
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.PAT_SPARK }}
-          persist-credentials: false
+          persist-credentials: true
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-gradle
       - uses: ./.github/actions/setup-gradle-properties


### PR DESCRIPTION
<!-- Describe your changes in details -->
The dependabot baseline job pushes a commit back to the branch, so it needs persisted credentials. 
Setting `persist-credentials: false` broke that push. 

This restores it to `true` and adds a zizmor suppression comment to explain the intentional exception.