### PR TITLE
ci: fix hotfix versioning by pinning config at branch creation

### DIFF
--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -1,0 +1,103 @@
+name: '🔧 Hotfix: create branch'
+
+on:
+  workflow_call:
+    inputs:
+      cherry_pick_sha:
+        description: 'Optional commit SHA to cherry-pick onto the hotfix branch'
+        required: false
+        type: string
+    secrets:
+      PAT_SPARK:
+        required: true
+  workflow_dispatch:
+    inputs:
+      cherry_pick_sha:
+        description: 'Optional commit SHA to cherry-pick onto the hotfix branch'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: 'create-hotfix-branch'
+  cancel-in-progress: false
+
+jobs:
+  create-hotfix-branch:
+    if: github.repository == 'leboncoin/spark-android'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT_SPARK }}
+          persist-credentials: false
+
+      - name: Find last semver tag and compute hotfix branch name
+        id: hotfix
+        run: |
+          last_tag=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$last_tag" ]; then
+            echo "::error::No semver tag found matching X.Y.Z"
+            exit 1
+          fi
+          echo "Last tag: $last_tag"
+          IFS='.' read -r major minor patch <<< "$last_tag"
+          next_patch=$((patch + 1))
+          branch="hotfix/${major}.${minor}.${next_patch}"
+          echo "tag=$last_tag" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Create or reuse hotfix branch
+        env:
+          BRANCH: ${{ steps.hotfix.outputs.branch }}
+          TAG: ${{ steps.hotfix.outputs.tag }}
+        run: |
+          if git ls-remote --exit-code --heads origin "$BRANCH"; then
+            echo "Branch $BRANCH already exists remotely, checking it out"
+            git checkout "$BRANCH"
+            git reset --hard "origin/$BRANCH"
+          else
+            git checkout -b "$BRANCH" "refs/tags/$TAG"
+          fi
+
+      - name: Pin hotfix branch to patch-only versioning
+        run: |
+          git config user.name 'spark-ui-bot'
+          git config user.email 'spark-ui-bot@users.noreply.github.com'
+          jq '.packages["."].versioning = "always-bump-patch"' release-please-config.json > tmp.json
+          mv tmp.json release-please-config.json
+          if git diff --quiet -- release-please-config.json; then
+            echo "release-please-config.json already pinned, skipping commit"
+          else
+            git add release-please-config.json
+            git commit -m 'ci: pin hotfix branch to patch-only versioning'
+          fi
+
+      - name: Cherry-pick commit
+        if: inputs.cherry_pick_sha != ''
+        env:
+          MERGE_SHA: ${{ inputs.cherry_pick_sha }}
+        run: |
+          git config user.name 'spark-ui-bot'
+          git config user.email 'spark-ui-bot@users.noreply.github.com'
+          if git merge-base --is-ancestor "$MERGE_SHA" HEAD 2>/dev/null; then
+            echo "Commit $MERGE_SHA already present on branch, skipping cherry-pick"
+          else
+            if ! git cherry-pick "$MERGE_SHA"; then
+              echo "Cherry-pick conflict detected, resolving by accepting incoming changes"
+              git checkout --theirs .
+              git add -A
+              git cherry-pick --continue --no-edit
+            fi
+          fi
+
+      - name: Push hotfix branch
+        env:
+          BRANCH: ${{ steps.hotfix.outputs.branch }}
+          PAT: ${{ secrets.PAT_SPARK }}
+        run: |
+          git remote set-url origin "https://x-access-token:${PAT}@github.com/${{ github.repository }}.git"
+          git push origin "$BRANCH"

--- a/.github/workflows/create-icon-hotfix.yml
+++ b/.github/workflows/create-icon-hotfix.yml
@@ -3,15 +3,6 @@ name: '🔧 Icon hotfix: create branch'
 on:
   pull_request:
     types: [closed]
-  workflow_dispatch:
-    inputs:
-      merge_commit_sha:
-        description: 'Merge commit SHA to cherry-pick'
-        required: true
-        type: string
-
-permissions:
-  contents: write
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.event.pull_request.number }}'
@@ -21,71 +12,13 @@ jobs:
   create-hotfix-branch:
     if: |
       github.repository == 'leboncoin/spark-android' &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (
-          github.event.pull_request.merged == true &&
-          github.event.pull_request.title == 'feat(icons): update icons' &&
-          github.event.pull_request.user.login == 'github-actions[bot]'
-        )
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7.0.1
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.PAT_SPARK }}
-          persist-credentials: false
-
-      - name: Find last semver tag and compute hotfix branch name
-        id: hotfix
-        run: |
-          last_tag=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-          if [ -z "$last_tag" ]; then
-            echo "::error::No semver tag found matching X.Y.Z"
-            exit 1
-          fi
-          echo "Last tag: $last_tag"
-          IFS='.' read -r major minor patch <<< "$last_tag"
-          next_patch=$((patch + 1))
-          branch="hotfix/${major}.${minor}.${next_patch}"
-          echo "tag=$last_tag" >> "$GITHUB_OUTPUT"
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
-
-      - name: Create or reuse hotfix branch
-        env:
-          BRANCH: ${{ steps.hotfix.outputs.branch }}
-          TAG: ${{ steps.hotfix.outputs.tag }}
-        run: |
-          if git ls-remote --exit-code --heads origin "$BRANCH"; then
-            echo "Branch $BRANCH already exists remotely, checking it out"
-            git checkout "$BRANCH"
-            git reset --hard "origin/$BRANCH"
-          else
-            git checkout -b "$BRANCH" "refs/tags/$TAG"
-          fi
-
-      - name: Cherry-pick icon update commit
-        env:
-          MERGE_SHA: ${{ inputs.merge_commit_sha || github.event.pull_request.merge_commit_sha }}
-        run: |
-          git config user.name 'spark-ui-bot'
-          git config user.email 'spark-ui-bot@users.noreply.github.com'
-          if git merge-base --is-ancestor "$MERGE_SHA" HEAD 2>/dev/null; then
-            echo "Commit $MERGE_SHA already present on branch, skipping cherry-pick"
-          else
-            if ! git cherry-pick "$MERGE_SHA"; then
-              echo "Cherry-pick conflict detected, resolving by accepting incoming changes"
-              git checkout --theirs .
-              git add -A
-              git cherry-pick --continue --no-edit
-            fi
-          fi
-
-      - name: Push hotfix branch
-        env:
-          BRANCH: ${{ steps.hotfix.outputs.branch }}
-          PAT: ${{ secrets.PAT_SPARK }}
-        run: |
-          git remote set-url origin "https://x-access-token:${PAT}@github.com/${{ github.repository }}.git"
-          git push origin "$BRANCH"
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.title == 'feat(icons): update icons' &&
+      github.event.pull_request.user.login == 'github-actions[bot]'
+    uses: ./.github/workflows/create-hotfix-branch.yml
+    permissions:
+      contents: write
+    with:
+      cherry_pick_sha: ${{ github.event.pull_request.merge_commit_sha }}
+    secrets:
+      PAT_SPARK: ${{ secrets.PAT_SPARK }}

--- a/.github/workflows/release-hotfix.yml
+++ b/.github/workflows/release-hotfix.yml
@@ -17,15 +17,6 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: actions/checkout@v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Force patch-only versioning for hotfix branches
-        run: |
-          jq '.packages["."].versioning = "always-bump-patch"' release-please-config.json > tmp.json
-          mv tmp.json release-please-config.json
-
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -74,14 +74,21 @@ the manual [Hotfix Workflow](#hotfix-workflow) instead.
 
 ## Hotfix Workflow
 
-1. Create the hotfix branch from the release tag:
-   ```bash
-   git branch hotfix/X.Y.Z+1 refs/tags/X.Y.Z
-   git push origin hotfix/X.Y.Z+1
-   ```
+1. Create the hotfix branch by running the **🔧 Hotfix: create branch** workflow
+   (`.github/workflows/create-hotfix-branch.yml`) from the Actions tab. It branches
+   off the last release tag, names the branch `hotfix/X.Y.Z+1`, and pins the branch
+   to patch-only versioning. Pass a `cherry_pick_sha` if you want a specific commit
+   applied. Do not create the branch by hand: the pin step is what stops
+   release-please from picking a wrong (e.g. minor) version.
 2. Create a working branch, commit fixes, and open a PR targeting `hotfix/X.Y.Z+1`:
    ```bash
    git switch --create fix-hotfix-X.Y.Z+1 hotfix/X.Y.Z+1
    ```
 3. Release-please opens a Release PR targeting the hotfix branch.
 4. Merge the Release PR. The tag and publish workflows fire automatically.
+
+> **Why the pin matters:** release-please reads its config and manifest from the
+> **target branch content**, not from the runner's working copy. Editing
+> `release-please-config.json` inside `release-hotfix.yml` at runtime has no effect.
+> The version override must be committed onto the hotfix branch, which the
+> create-branch workflow does once at branch creation.


### PR DESCRIPTION
release-please reads its config from the target branch, not the runner working copy, so the runtime jq edit in release-hotfix.yml was a no-op. A cherry-picked feat commit bumped minor (3.3.0 -> 3.4.0) instead of patch (3.3.1).

- Extract hotfix branch creation into create-hotfix-branch.yml, which commits versioning: always-bump-patch onto the branch at creation time
- Remove the no-op jq block from release-hotfix.yml
- Update create-icon-hotfix.yml to call the reusable workflow
- Document the required workflow use and the reason in RELEASING.md