### PR TITLE
Fix compilation errors in Chip.md example

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.md
@@ -114,11 +114,11 @@ FlowRow(
     filters.forEach { filter ->
         val selected = filter in selectedFilters
         ChipSelectable(
-            text = filter.name,
+            text = filter,
             selected = selected,
             leadingIcon = if (selected) LeboncoinIcons.Check else null,
             onClick = {
-                unionSelected = if (selected) {
+                selectedFilters = if (selected) {
                     selectedFilters - filter
                 } else {
                     selectedFilters + filter


### PR DESCRIPTION
## Description

Fixes the compilation errors in the multiple-selection example in `Chip.md`.

## Changes

* Changed `filter.name` to `filter` since `filter` is a `String`.
* Changed `unionSelected` to `selectedFilters` to update the declared state variable.

Fixes #2104
