### PR TITLE
fix(build): support Gradle Isolated Projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: ./.github/actions/setup-gradle-properties
       - name: 🧑‍🔬 Test
         id: test
-        run: ./gradlew globalCiUnitTest verifyPaparazziRelease
+        run: ./gradlew ciUnitTest verifyPaparazziRelease
       - name: 📦 Archive JUnit reports
         if: ${{ always() && contains(fromJSON('["success", "failure"]'), steps.test.outcome) }}
         uses: ./.github/actions/archive-junit-reports

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkProperties.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkProperties.kt
@@ -29,7 +29,7 @@ import kotlin.reflect.KProperty
 internal fun Project.spark() = SparkProperties(this)
 
 internal class SparkProperties private constructor(project: Project) {
-    private val catalog by lazy(project.rootProject::getVersionsCatalog)
+    private val catalog by lazy(project::getVersionsCatalog)
     val libraries by lazy { SparkLibraries(catalog) }
     val versions by lazy { SparkVersions(catalog) }
     val ciUnitTestVariant = project.providers.gradleProperty("spark.ci-unit-test.variant").orElse("release")

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublication.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkPublication.kt
@@ -73,7 +73,7 @@ internal object SparkPublication {
         repositories {
             mavenLocal {
                 name = "Local"
-                url = uri(rootProject.layout.buildDirectory.dir(".m2/repository"))
+                url = uri(layout.buildDirectory.dir(".m2/repository"))
             }
         }
     }

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkRootPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkRootPlugin.kt
@@ -29,7 +29,6 @@ internal class SparkRootPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             apply<SparkSpotlessPlugin>()
-            SparkUnitTests.configureRootProject(project)
             SparkPublication.configureRootProject(project)
         }
     }

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkSpotlessPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkSpotlessPlugin.kt
@@ -34,7 +34,7 @@ internal class SparkSpotlessPlugin : Plugin<Project> {
 
             val ktlint = spark().libraries.`ktlint-bom`.get().version
             configure<SpotlessExtension> {
-                val licenseHeader = rootProject.file("spotless/spotless.kt")
+                val licenseHeader = rootDir.resolve("spotless/spotless.kt")
                 format("misc") {
                     target("*.md", "src/**/*.md", "*.xml", "src/**/*.xml", ".gitignore")
                     targetExclude("dependencies/*.txt")

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkUnitTests.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkUnitTests.kt
@@ -22,8 +22,6 @@
 package com.adevinta.spark
 
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
@@ -37,57 +35,41 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
  * Inspired by https://github.com/slackhq/slack-gradle-plugin
  */
 internal object SparkUnitTests {
-    private const val GLOBAL_CI_UNIT_TEST_TASK_NAME = "globalCiUnitTest"
     private const val CI_UNIT_TEST_TASK_NAME = "ciUnitTest"
     private const val COMPILE_CI_UNIT_TEST_NAME = "compileCiUnitTest"
     private const val LOG = "SparkUnitTests:"
 
-    fun configureRootProject(project: Project): TaskProvider<Task> =
-        project.tasks.register(GLOBAL_CI_UNIT_TEST_TASK_NAME) {
-            group = LifecycleBasePlugin.VERIFICATION_GROUP
-            description = "Global lifecycle task to run all ciUnitTest tasks."
-        }
-
     fun configureSubproject(project: Project) {
-        val globalTask = project.rootProject.tasks.named(GLOBAL_CI_UNIT_TEST_TASK_NAME)
         project.pluginManager.withPlugin("com.android.base") {
-            createAndroidCiUnitTestTask(project, globalTask)
+            createAndroidCiUnitTestTask(project)
         }
         project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-            createJvmCiUnitTestTask(project, globalTask)
+            createJvmCiUnitTestTask(project)
         }
         configureTestTasks(project)
     }
 
-    private fun createJvmCiUnitTestTask(
-        project: Project,
-        globalTask: TaskProvider<Task>,
-    ) {
+    private fun createJvmCiUnitTestTask(project: Project) {
         project.logger.debug("$LOG Creating CI unit test tasks for project '$project'")
-        val ciUnitTest = project.tasks.register(CI_UNIT_TEST_TASK_NAME) {
+        project.tasks.register(CI_UNIT_TEST_TASK_NAME) {
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             dependsOn("test")
         }
-        globalTask.configure { dependsOn(ciUnitTest) }
         project.tasks.register(COMPILE_CI_UNIT_TEST_NAME) {
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             dependsOn("testClasses")
         }
     }
 
-    private fun createAndroidCiUnitTestTask(
-        project: Project,
-        globalTask: TaskProvider<Task>,
-    ) {
+    private fun createAndroidCiUnitTestTask(project: Project) {
         val variant = project.spark().ciUnitTestVariant.get().capitalized()
         val variantUnitTestTaskName = "test${variant}UnitTest"
         val variantCompileUnitTestTaskName = "compile${variant}UnitTestSources"
         project.logger.debug("$LOG Creating CI unit test tasks for project '$project' and variant '$variant'")
-        val ciUnitTest = project.tasks.register(CI_UNIT_TEST_TASK_NAME) {
+        project.tasks.register(CI_UNIT_TEST_TASK_NAME) {
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             dependsOn(variantUnitTestTaskName)
         }
-        globalTask.configure { dependsOn(ciUnitTest) }
         project.tasks.register(COMPILE_CI_UNIT_TEST_NAME) {
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             dependsOn(variantCompileUnitTestTaskName)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,3 @@ plugins {
     alias(libs.plugins.spark.root)
     alias(libs.plugins.spark.dokka)
 }
-
-allprojects {
-    apply(plugin = "com.adevinta.spark.spotless")
-}

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
     alias(libs.plugins.spark.compose)
     id("kotlin-parcelize")
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.spark.spotless)
 }
 
 android {
@@ -42,7 +43,7 @@ android {
 
     compileOptions.isCoreLibraryDesugaringEnabled = true
 
-    val keystore = rootProject.file("keystore.properties")
+    val keystore = rootDir.resolve("keystore.properties")
         .takeIf { it.exists() }
         ?.let { Properties().apply { load(it.inputStream()) } }
 

--- a/spark-bom/build.gradle.kts
+++ b/spark-bom/build.gradle.kts
@@ -22,6 +22,7 @@
 plugins {
     `java-platform`
     alias(libs.plugins.spark.publishing)
+    alias(libs.plugins.spark.spotless)
 }
 
 dependencies {

--- a/spark-icons/build.gradle.kts
+++ b/spark-icons/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
     alias(libs.plugins.spark.dokka)
     alias(libs.plugins.spark.publishing)
     alias(libs.plugins.spark.dependencyGuard)
+    alias(libs.plugins.spark.spotless)
 }
 
 kotlin {

--- a/spark-lint/build.gradle.kts
+++ b/spark-lint/build.gradle.kts
@@ -22,6 +22,7 @@
 plugins {
     alias(libs.plugins.spark.kotlinJvm)
     alias(libs.plugins.spark.lint)
+    alias(libs.plugins.spark.spotless)
 }
 
 java {

--- a/spark-screenshot-testing/build.gradle.kts
+++ b/spark-screenshot-testing/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
     alias(libs.plugins.paparazzi)
     alias(libs.plugins.spark.library)
     alias(libs.plugins.spark.compose)
+    alias(libs.plugins.spark.spotless)
 }
 
 android {

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
     alias(libs.plugins.spark.publishing)
     alias(libs.plugins.spark.dependencyGuard)
     alias(libs.plugins.spark.dokka)
+    alias(libs.plugins.spark.spotless)
 }
 
 android {


### PR DESCRIPTION
## 📋 Changes

Make the Gradle build compatible with Isolated Projects (`-Dorg.gradle.unsafe.isolated-projects=true`). 
Previously, `./gradlew help` and `:spark:assemble` failed the configuration cache with at least 1 visible problem (4 after unmasking). 
Both now store the configuration cache with 0 problems.

- Remove the root `allprojects { apply spotless }` block; apply the spotless convention plugin per module by alias instead.
- Read the version catalog from the project itself, not `rootProject.extensions`, in `SparkProperties`.
- Resolve file paths via `rootDir.resolve(...)` instead of `rootProject.file(...)` in `SparkSpotlessPlugin` and the catalog build file.
- Use the subproject's own `layout.buildDirectory` for the local Maven repo in `SparkPublication`.
- Drop the `globalCiUnitTest` aggregator task, which mutated a root task from each subproject. CI now runs `./gradlew ciUnitTest` directly. This matches the `android-app`
repo, which runs Isolated Projects by default. Test coverage is unchanged: the same 4 modules resolve.

## 🤔 Context

Enabling Gradle Isolated Projects here made the build fail at configuration time.

The `globalCiUnitTest` removal is the one behaviour change worth reviewing: CI used to invoke a single aggregator task; it now runs `ciUnitTest`, which Gradle resolves
across all modules the same way.

## ✅ Checklist
- [ ] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.