### PR TITLE
feat(tokens): make highlight text weight themeable

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -220,12 +220,21 @@ Text(
 )
 ```
 
-Apply `highlight` to any style to switch its weight to Bold:
+Apply `highlight` to any style to switch its weight to the theme's highlight weight (Bold by
+default):
 
 ```kotlin
 Text(
     text = "Important",
     style = SparkTheme.typography.body2.highlight,
+)
+```
+
+Set `highlightWeight` on `sparkTypography` to change the weight `highlight` applies:
+
+```kotlin
+val myTypography = sparkTypography(
+    highlightWeight = FontWeight.SemiBold,
 )
 ```
 

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Type.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Type.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
@@ -129,6 +130,7 @@ public fun sparkTypography(
     caption: TextStyle = captionType,
     small: TextStyle = smallType,
     callout: TextStyle = calloutType,
+    highlightWeight: FontWeight = FontWeight.Bold,
 ): SparkTypography = SparkTypography(
     display1 = display1,
     display2 = display2,
@@ -141,6 +143,7 @@ public fun sparkTypography(
     caption = caption,
     small = small,
     callout = callout,
+    highlightWeight = highlightWeight,
 )
 
 /**
@@ -209,6 +212,11 @@ public data class SparkTypography(
      * Call to actions
      */
     val callout: TextStyle,
+
+    /**
+     * The standard weight used to emphasize a text
+     */
+    val highlightWeight: FontWeight,
 ) {
     /**
      * Required by the [Kelp](https://github.com/ozontech/kelp) Android Studio plugin to render
@@ -248,16 +256,18 @@ public fun SparkTypography.asMaterial3Typography(): Typography = Typography(
     bodyLarge = body1,
     bodyMedium = body2,
     bodySmall = caption,
-    labelLarge = body2.highlight,
+    labelLarge = body2.copy(fontWeight = highlightWeight),
     labelMedium = caption,
     labelSmall = small,
 )
 
 /**
- * Extension property to get a [TextStyle] with [FontWeight.Bold] applied
+ * Extension property to get a [TextStyle] with [SparkTypography.highlightWeight] applied
  */
 public val TextStyle.highlight: TextStyle
-    get() = this.copy(fontWeight = FontWeight.Bold)
+    @ReadOnlyComposable
+    @Composable
+    get() = this.copy(fontWeight = SparkTheme.typography.highlightWeight)
 
 @Preview(
     group = "Tokens",


### PR DESCRIPTION


<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/leboncoin/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
- Add `highlightWeight: FontWeight` parameter to `sparkTypography()` and `SparkTypography`; defaults to `FontWeight.Bold`
- `TextStyle.highlight` now reads `SparkTheme.typography.highlightWeight` instead of hard-coding `FontWeight.Bold`
- Add `@Composable`/`@ReadOnlyComposable` annotations to `highlight` getter and `asMaterial3Typography()`
- Document `highlightWeight` in docs/theming.md

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
With the rebranding we will change the default value for the `hightlight` font weight modifier from `Bold` to `Medium`. This allow us to theme it

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator
