### PR TITLE
fix(snackbar): remove dead ImageRequest.Builder allocation

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
@@ -228,7 +228,7 @@ private fun SnackbarAction(
     BaseSparkButton(
         modifier = modifier,
         colors = colors,
-        onClick = { onClick.invoke() },
+        onClick = onClick,
         elevation = null,
         content = { Text(actionLabel) },
     )
@@ -301,7 +301,6 @@ public fun Snackbar(
 ) {
     val visuals = data.visuals
     val sparkVisuals = data.visuals as? SnackbarSparkVisuals
-    ImageRequest.Builder(LocalContext.current)
     SparkSnackbar(
         intent = sparkVisuals?.intent ?: SnackbarDefaults.intent,
         modifier = modifier.padding(12.dp),


### PR DESCRIPTION
## 📋 Changes

Remove a dead `ImageRequest.Builder(LocalContext.current)` call that was allocated and immediately discarded on every recomposition, and simplify `onClick = { onClick.invoke() }` to `onClick = onClick`.

## 🤔 Context

The `ImageRequest.Builder` instantiation had no effect: it was never assigned or used, allocating a throwaway object on every recomposition. The lambda wrapper around `onClick.invoke()` is equivalent to passing the reference directly.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.