### PR TITLE
fix(res): key annotated plural string caches on count and format args

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/res/AnnotatedStringResource.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/res/AnnotatedStringResource.kt
@@ -184,7 +184,7 @@ public fun annotatedPluralStringResource(
     val density = LocalDensity.current
     val colors = SparkTheme.colors
     val typography = SparkTheme.typography
-    return remember(id) {
+    return remember(id, count) {
         val text = resources.getQuantityText(id, count)
         text.asAnnotatedString(density, colors, typography)
     }
@@ -208,7 +208,7 @@ public fun annotatedPluralStringResource(
     val density = LocalDensity.current
     val colors = SparkTheme.colors
     val typography = SparkTheme.typography
-    return remember(id) {
+    return remember(id, count, formatArgs) {
         val text = resources.buildSpannedStringWithArgs(id, count, formatArgs)
         text.asAnnotatedString(density, colors, typography)
     }
@@ -236,7 +236,7 @@ public fun annotatedPluralStringResource(
     val density = LocalDensity.current
     val colors = SparkTheme.colors
     val typography = SparkTheme.typography
-    return remember(id) {
+    return remember(id, count, formatArgs) {
         val text = resources.getQuantityText(id, count, *formatArgs)
         text.asAnnotatedString(density, colors, typography)
     }


### PR DESCRIPTION
## 📋 Changes

Adds `count` and `formatArgs` to the `remember` keys in the three `annotatedPluralStringResource` overloads in `AnnotatedStringResource.kt`.

## 🤔 Context

The plural form depends on `count`, but neither `count` nor `formatArgs` was included in the `remember` key. When `count` changed, the composable returned the cached string instead of recomputing, so the displayed quantity was wrong.

## ✅ Checklist

- [ ] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.