### PR TITLE
fix(fileupload): forward size, icon and iconSide to the underlying button

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/fileupload/FileUploadButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/fileupload/FileUploadButton.kt
@@ -81,6 +81,9 @@ internal fun FileUploadSingleButton(
                 },
             onClick = onClick,
             text = label,
+            size = size,
+            icon = icon,
+            iconSide = iconSide,
             intent = ButtonIntent.Support,
             enabled = enabled,
         )
@@ -147,6 +150,9 @@ internal fun FileUploadButton(
                 },
             onClick = onClick,
             text = label,
+            size = size,
+            icon = icon,
+            iconSide = iconSide,
             intent = ButtonIntent.Support,
             enabled = enabled,
         )


### PR DESCRIPTION
## 📋 Changes

`size`, `icon`, and `iconSide` were accepted by `FileUploadButton` but silently dropped when constructing the underlying button. All three are now forwarded.

## 🤔 Context

The parameters are part of the public API. Callers passing them had no effect, which is a silent bug.

## ✅ Checklist

- [ ] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.