### PR TITLE
fix(progress): forward style param and use fastForEachIndexed

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressTracker.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressTracker.kt
@@ -185,6 +185,7 @@ public fun ProgressTrackerColumn(
         orientation = Vertical,
         modifier = modifier,
         intent = intent,
+        style = style,
         size = size,
         readOnly = readOnly,
         hasIndicatorContent = hasIndicatorContent,
@@ -247,7 +248,7 @@ private fun ProgressTracker(
         }
     }
     val stepIndicators = @Composable {
-        items.forEachIndexed { index, progressStep ->
+        items.fastForEachIndexed { index, progressStep ->
             // If selectedStep is null, no step is shown as selected
             val isDone = index < (selectedStep ?: -1)
             StepIndicator(


### PR DESCRIPTION
## 📋 Changes

Forwards the `style` parameter from `ProgressTrackerColumn` to the private `ProgressTracker` composable, and replaces `items.forEachIndexed` with `items.fastForEachIndexed`.

## 🤔 Context

The `style` parameter accepted by `ProgressTrackerColumn` was silently dropped and never forwarded to the internal `ProgressTracker`. Any caller passing a custom style received a default-styled component instead of the intended one.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.

## 📸 Screenshots

<!-- Insert your screenshots here -->

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->