### PR TITLE
fix(rating): read value directly without remember

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingDisplay.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingDisplay.kt
@@ -55,9 +55,7 @@ public fun RatingDisplay(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        var remainingValue = remember(value) {
-            value
-        }
+        var remainingValue = value
         repeat(5) {
             val starRating = when {
                 remainingValue == 0f -> 0f


### PR DESCRIPTION
## 📋 Changes

Removes the `remember` call wrapping `remainingValue` in `RatingDisplay`. The variable is reassigned immediately and does not need a composition slot.

## 🤔 Context

`var remainingValue = remember(value) { value }` allocates an unnecessary slot — the value is only used to drive a local loop and is never observed across recompositions.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.