### PR TITLE
refactor(dialog): remove landscape illustration from ModalScaffold

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
@@ -372,7 +372,6 @@ private fun PhoneLandscapeModalScaffold(
     title: @Composable () -> Unit = {},
     actions: @Composable RowScope.() -> Unit = {},
     contentWindowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
-    illustrationContentScale: ContentScale = ContentScale.Fit,
     inEdgeToEdge: Boolean = false,
     content: @Composable (PaddingValues) -> Unit,
 ) {
@@ -430,19 +429,6 @@ private fun PhoneLandscapeModalScaffold(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(Layout.gutter),
             ) {
-                illustration?.let {
-                    Box(
-                        modifier = Modifier.weight(.8f),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Illustration(
-                            drawableRes = it,
-                            contentDescription = null,
-                            modifier = Modifier.fillMaxWidth(.8f),
-                            contentScale = illustrationContentScale,
-                        )
-                    }
-                }
                 Box(
                     modifier = Modifier
                         .weight(1f)


### PR DESCRIPTION
## 📋 Changes

Removes `illustrationContentScale` and the illustration rendering block from `PhoneLandscapeModalScaffold`.

## 🤔 Context

The block was unreachable: the only call site never passes an illustration in landscape mode, so the parameter and its rendering logic were dead code.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.