### PR TITLE
chore(res): remove unused large string annotation mapping

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/res/SparkStringAnnotations.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/res/SparkStringAnnotations.kt
@@ -86,8 +86,6 @@ public object SparkStringAnnotations {
 
         "subhead" -> token.subhead
 
-        "large" -> token.body1
-
         "body1" -> token.body1
 
         "body2" -> token.body2


### PR DESCRIPTION
## 📋 Changes

Removes the `"large"` branch from the `SparkStringAnnotations` text style mapping in `SparkStringAnnotations.kt`; it was a duplicate of the `"body1"` branch immediately below, mapping to the same `token.body1` value.

## 🤔 Context

The `"large"` annotation key was not part of the documented Spark string annotation API and silently aliased `body1`. Removing it eliminates dead code without changing any observable behaviour.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.