### PR TITLE
fix(popover): remove empty CompositionLocalProvider wrapper

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
@@ -126,9 +126,7 @@ public fun Popover(
                             .padding(all = PopoverContentPadding)
                             .weight(1f, fill = true),
                     ) {
-                        CompositionLocalProvider(
-                            content = popover,
-                        )
+                        popover()
                     }
                     if (isDismissButtonEnabled) {
                         IconButtonGhost(


### PR DESCRIPTION
## 📋 Changes

`CompositionLocalProvider` wrapped the `popover` content lambda but provided no values. Replace it with a direct `popover()` call.

## 🤔 Context

The wrapper was a no-op that added an unnecessary composition node. Removing it has no effect on callers.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.

## 📸 Screenshots

No visual change.