### PR TITLE
chore(deps): remove unused compose material3 dependency

### DIFF
--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -54,7 +54,6 @@ android {
 dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.constraintlayout.compose)
-    implementation(libs.androidx.compose.material3)
     lintPublish(projects.sparkLint)
     lintChecks(libs.slack.lint.compose)
 


### PR DESCRIPTION
## 📋 Changes

Removes `implementation(libs.androidx.compose.material3)` from `spark/build.gradle.kts`. The module already declares the same artifact with `api(...)`, making this line redundant.

## 🤔 Context

The `implementation` entry was a duplicate of the existing `api` declaration for the same artifact. Removing it avoids confusion about which configuration is authoritative.

## ✅ Checklist

- [x] I have reviewed the submitted code.
