### PR TITLE
chore(divider): remove commented-out debug text

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/divider/Divider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/divider/Divider.kt
@@ -290,7 +290,6 @@ private fun TextComposable(textOverflow: TextOverflow = TextOverflow.Ellipsis) {
         textAlign = TextAlign.Center,
         overflow = textOverflow,
         style = SparkTheme.typography.body1,
-        // text = "jdkdkskjdkkklnljxcljcxlcjvxxcljljxcsdksj\n\ndljjjcdljcjdljcljdsljfdld\nlkjkjisd\nsdsksjddsk\njdksdjslds",
         text = "label",
     )
 }


### PR DESCRIPTION
## 📋 Changes

Removes a commented-out debug string from the private `TextComposable` preview helper in `Divider.kt`.

## 🤔 Context

The string was leftover debug text that had no purpose after development.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.

## 📸 Screenshots

N/A — no visual change.

## 🗒️ Other info

Comment-only change; no runtime behaviour is affected.