### PR TITLE
fix(stepper): expose placeholder in public API

### DIFF
--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/stepper/StepperDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/stepper/StepperDocumentationScreenshots.kt
@@ -24,6 +24,7 @@ package com.adevinta.spark.components.stepper
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.cash.paparazzi.DeviceConfig
@@ -65,6 +66,7 @@ internal class StepperDocumentationScreenshots {
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Stepper.NudgerForm(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",
@@ -72,6 +74,7 @@ internal class StepperDocumentationScreenshots {
                 required = true,
             )
             Stepper.NudgerForm(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",
@@ -102,6 +105,7 @@ internal class StepperDocumentationScreenshots {
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Stepper.InputForm(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",
@@ -110,6 +114,7 @@ internal class StepperDocumentationScreenshots {
                 required = true,
             )
             Stepper.InputForm(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/stepper/StepperDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/stepper/StepperDocumentationScreenshots.kt
@@ -68,7 +68,7 @@ internal class StepperDocumentationScreenshots {
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Stepper.NudgerForm(
-                modifier =  Modifier.width(IntrinsicSize.Min),
+                modifier = Modifier.width(IntrinsicSize.Min),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",
@@ -76,7 +76,7 @@ internal class StepperDocumentationScreenshots {
                 required = true,
             )
             Stepper.NudgerForm(
-                modifier =  Modifier.width(IntrinsicSize.Min),
+                modifier = Modifier.width(IntrinsicSize.Min),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",
@@ -107,7 +107,7 @@ internal class StepperDocumentationScreenshots {
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Stepper.InputForm(
-                modifier =  Modifier.width(IntrinsicSize.Min),
+                modifier = Modifier.width(IntrinsicSize.Min),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",
@@ -116,7 +116,7 @@ internal class StepperDocumentationScreenshots {
                 required = true,
             )
             Stepper.InputForm(
-                modifier =  Modifier.width(IntrinsicSize.Min),
+                modifier = Modifier.width(IntrinsicSize.Min),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/stepper/StepperDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/stepper/StepperDocumentationScreenshots.kt
@@ -23,7 +23,9 @@ package com.adevinta.spark.components.stepper
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -66,7 +68,7 @@ internal class StepperDocumentationScreenshots {
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Stepper.NudgerForm(
-                modifier = Modifier.align(Alignment.CenterHorizontally),
+                modifier =  Modifier.width(IntrinsicSize.Min),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",
@@ -74,7 +76,7 @@ internal class StepperDocumentationScreenshots {
                 required = true,
             )
             Stepper.NudgerForm(
-                modifier = Modifier.align(Alignment.CenterHorizontally),
+                modifier =  Modifier.width(IntrinsicSize.Min),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",
@@ -105,7 +107,7 @@ internal class StepperDocumentationScreenshots {
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Stepper.InputForm(
-                modifier = Modifier.align(Alignment.CenterHorizontally),
+                modifier =  Modifier.width(IntrinsicSize.Min),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",
@@ -114,7 +116,7 @@ internal class StepperDocumentationScreenshots {
                 required = true,
             )
             Stepper.InputForm(
-                modifier = Modifier.align(Alignment.CenterHorizontally),
+                modifier =  Modifier.width(IntrinsicSize.Min),
                 value = 3,
                 onValueChange = {},
                 label = "Quantity",

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_inputForm.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_inputForm.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea7d66ba0f5fd56c1accca3cf40f4d2b94a9bc86e34f1834123eeb081ef2a6f8
-size 41052
+oid sha256:f26be5d543135a4af3a5c6cc12a0bd00049826554fd2bc1114b49f8fa603e193
+size 40912

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudgerForm.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.stepper_StepperDocumentationScreenshots_nudgerForm.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a41b551db68f5fc0931269620c5d52f43e284eb1a7fcec03de90b41ba6eb989c
-size 41175
+oid sha256:c187d910eb228c2629397579eb9c9675e2536e5329ec4bab927394641dc289a3
+size 41046

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.kt
@@ -63,6 +63,10 @@ import androidx.compose.ui.unit.dp
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.R
 import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.stepper.Stepper.Input
+import com.adevinta.spark.components.stepper.Stepper.InputForm
+import com.adevinta.spark.components.stepper.Stepper.Nudger
+import com.adevinta.spark.components.stepper.Stepper.NudgerForm
 import com.adevinta.spark.components.stepper.internal.SparkNudger
 import com.adevinta.spark.components.stepper.internal.SparkStepperInput
 import com.adevinta.spark.components.stepper.internal.formatInteger
@@ -603,8 +607,8 @@ private fun StepperFormScaffold(
     message = "Use Stepper.Nudger instead",
     replaceWith = ReplaceWith(
         "Stepper.Nudger(value = value, onValueChange = onValueChange, modifier = modifier, range = range, " +
-            "suffix = suffix, step = step, enabled = enabled, flexible = flexible, " +
-            "testTag = testTag, allowSemantics = allowSemantics)",
+                "suffix = suffix, step = step, enabled = enabled, flexible = flexible, " +
+                "testTag = testTag, allowSemantics = allowSemantics)",
         "com.adevinta.spark.components.stepper.Stepper",
     ),
     level = DeprecationLevel.WARNING,
@@ -644,9 +648,9 @@ public fun Stepper(
     message = "Use Stepper.NudgerForm instead",
     replaceWith = ReplaceWith(
         "Stepper.NudgerForm(value = value, onValueChange = onValueChange, label = label, helper = helper, " +
-            "modifier = modifier, range = range, suffix = suffix, step = step, enabled = enabled, " +
-            "required = required, status = status, statusMessage = statusMessage, flexible = flexible, " +
-            "testTag = testTag)",
+                "modifier = modifier, range = range, suffix = suffix, step = step, enabled = enabled, " +
+                "required = required, status = status, statusMessage = statusMessage, flexible = flexible, " +
+                "testTag = testTag)",
         "com.adevinta.spark.components.stepper.Stepper",
     ),
     level = DeprecationLevel.WARNING,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.kt
@@ -99,6 +99,7 @@ public object Stepper {
      * @param modifier The [Modifier] to be applied to the component
      * @param range The min/max accepted value by the stepper until it blocks increments and decrements
      * @param suffix optional string displayed after [value]
+     * @param placeholder text shown in the empty state when [value] is `null`
      * @param step the quantity to be increased/decreased on each increment/decrement
      * @param enabled True controls the enabled state of the stepper. When `false`, the stepper will
      * be neither editable nor focusable, visually stepper will appear in the disabled UI state
@@ -113,6 +114,7 @@ public object Stepper {
         modifier: Modifier = Modifier,
         range: IntRange = 0..10,
         suffix: String = "",
+        placeholder: String = "-",
         step: Int = 1,
         enabled: Boolean = true,
         flexible: Boolean = false,
@@ -122,9 +124,10 @@ public object Stepper {
         SparkNudger(
             value = value,
             onValueChange = onValueChange,
-            modifier = modifier,
+            modifier = modifier.sparkUsageOverlay(),
             range = range,
             suffix = suffix,
+            placeholder = placeholder,
             step = step,
             enabled = enabled,
             flexible = flexible,
@@ -141,6 +144,7 @@ public object Stepper {
      * @param state The [StepperState] that holds the current value, range, and step
      * @param modifier The [Modifier] to be applied to the component
      * @param suffix optional string displayed after the value
+     * @param placeholder text shown in the empty state
      * @param enabled True controls the enabled state of the stepper
      * @param flexible if true, component will fill max width, otherwise get default width
      * @param testTag A test tag to find the internal stepper in a test
@@ -151,6 +155,7 @@ public object Stepper {
         state: StepperState,
         modifier: Modifier = Modifier,
         suffix: String = "",
+        placeholder: String = "-",
         enabled: Boolean = true,
         flexible: Boolean = false,
         testTag: String? = null,
@@ -159,9 +164,10 @@ public object Stepper {
         SparkNudger(
             value = state.value,
             onValueChange = { state.value = it },
-            modifier = modifier,
+            modifier = modifier.sparkUsageOverlay(),
             range = state.range,
             suffix = suffix,
+            placeholder = placeholder,
             step = state.step,
             enabled = enabled,
             flexible = flexible,
@@ -182,6 +188,7 @@ public object Stepper {
      * @param modifier The [Modifier] to be applied to the component
      * @param range The min/max accepted value by the stepper until it blocks increments and decrements
      * @param suffix optional string displayed after [value]
+     * @param placeholder text shown in the empty state when [value] is `null`
      * @param step the quantity to be increased/decreased on each increment/decrement
      * @param enabled True controls the enabled state of the stepper
      * @param required add an asterisk to the label to indicate that this field is required
@@ -199,6 +206,7 @@ public object Stepper {
         modifier: Modifier = Modifier,
         range: IntRange = 0..10,
         suffix: String = "",
+        placeholder: String = "-",
         step: Int = 1,
         enabled: Boolean = true,
         required: Boolean = false,
@@ -223,6 +231,7 @@ public object Stepper {
                 onValueChange = onValueChange,
                 range = range,
                 enabled = enabled,
+                placeholder = placeholder,
                 suffix = suffix,
                 step = step,
                 flexible = flexible,
@@ -242,6 +251,7 @@ public object Stepper {
      * @param helper The optional helper text to be displayed at the bottom outside the text input container
      * @param modifier The [Modifier] to be applied to the component
      * @param suffix optional string displayed after the value
+     * @param placeholder text shown in the empty state
      * @param enabled True controls the enabled state of the stepper
      * @param required add an asterisk to the label to indicate that this field is required
      * @param status indicates the validation state of the stepper
@@ -256,6 +266,7 @@ public object Stepper {
         helper: String?,
         modifier: Modifier = Modifier,
         suffix: String = "",
+        placeholder: String = "-",
         enabled: Boolean = true,
         required: Boolean = false,
         status: FormFieldStatus? = null,
@@ -268,9 +279,10 @@ public object Stepper {
             onValueChange = { state.value = it },
             label = label,
             helper = helper,
-            modifier = modifier,
+            modifier = modifier.sparkUsageOverlay(),
             range = state.range,
             suffix = suffix,
+            placeholder = placeholder,
             step = state.step,
             enabled = enabled,
             required = required,
@@ -291,6 +303,7 @@ public object Stepper {
      * @param modifier The [Modifier] to be applied to the component
      * @param range The min/max accepted value by the stepper
      * @param suffix optional string displayed after the value
+     * @param placeholder text shown in the empty state when [value] is `null`
      * @param step the quantity to be increased/decreased on each increment/decrement
      * @param enabled True controls the enabled state of the stepper
      * @param status indicates the validation state of the stepper
@@ -304,6 +317,7 @@ public object Stepper {
         modifier: Modifier = Modifier,
         range: IntRange = 0..10,
         suffix: String = "",
+        placeholder: String = "-",
         step: Int = 1,
         enabled: Boolean = true,
         status: FormFieldStatus? = null,
@@ -328,9 +342,10 @@ public object Stepper {
             onIncrement = { onValueChange(applyStep(currentInput(), step, range)) },
             onDecrement = { onValueChange(applyStep(currentInput(), -step, range)) },
             onCommit = { onValueChange(currentInput()?.coerceIn(range)) },
-            modifier = modifier,
+            modifier = modifier.sparkUsageOverlay(),
             range = range,
             suffix = suffix,
+            placeholder = placeholder,
             step = step,
             enabled = enabled,
             status = status,
@@ -348,6 +363,7 @@ public object Stepper {
      * @param modifier The [Modifier] to be applied to the component
      * @param range The min/max accepted value by the stepper
      * @param suffix optional string displayed after the value
+     * @param placeholder text shown in the empty state
      * @param step the quantity to be increased/decreased on each increment/decrement
      * @param enabled True controls the enabled state of the stepper
      * @param status indicates the validation state of the stepper
@@ -360,6 +376,7 @@ public object Stepper {
         modifier: Modifier = Modifier,
         range: IntRange = 0..10,
         suffix: String = "",
+        placeholder: String = "-",
         step: Int = 1,
         enabled: Boolean = true,
         status: FormFieldStatus? = null,
@@ -372,9 +389,10 @@ public object Stepper {
             onIncrement = { state.increment(step, range) },
             onDecrement = { state.decrement(step, range) },
             onCommit = { state.commitValue(range) },
-            modifier = modifier,
+            modifier = modifier.sparkUsageOverlay(),
             range = range,
             suffix = suffix,
+            placeholder = placeholder,
             step = step,
             enabled = enabled,
             status = status,
@@ -395,6 +413,7 @@ public object Stepper {
      * @param modifier The [Modifier] to be applied to the component
      * @param range The min/max accepted value by the stepper
      * @param suffix optional string displayed after the value
+     * @param placeholder text shown in the empty state when [value] is `null`
      * @param step the quantity to be increased/decreased on each increment/decrement
      * @param enabled True controls the enabled state of the stepper
      * @param required add an asterisk to the label to indicate that this field is required
@@ -412,6 +431,7 @@ public object Stepper {
         modifier: Modifier = Modifier,
         range: IntRange = 0..10,
         suffix: String = "",
+        placeholder: String = "-",
         step: Int = 1,
         enabled: Boolean = true,
         required: Boolean = false,
@@ -436,6 +456,7 @@ public object Stepper {
                 enabled = enabled,
                 status = status,
                 suffix = suffix,
+                placeholder = placeholder,
                 step = step,
                 flexible = flexible,
                 testTag = testTag,
@@ -454,6 +475,7 @@ public object Stepper {
      * @param modifier The [Modifier] to be applied to the component
      * @param range The min/max accepted value by the stepper
      * @param suffix optional string displayed after the value
+     * @param placeholder text shown in the empty state
      * @param step the quantity to be increased/decreased on each increment/decrement
      * @param enabled True controls the enabled state of the stepper
      * @param required add an asterisk to the label to indicate that this field is required
@@ -470,6 +492,7 @@ public object Stepper {
         modifier: Modifier = Modifier,
         range: IntRange = 0..10,
         suffix: String = "",
+        placeholder: String = "-",
         step: Int = 1,
         enabled: Boolean = true,
         required: Boolean = false,
@@ -493,6 +516,7 @@ public object Stepper {
                 enabled = enabled,
                 status = status,
                 suffix = suffix,
+                placeholder = placeholder,
                 step = step,
                 flexible = flexible,
                 testTag = testTag,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.kt
@@ -607,8 +607,8 @@ private fun StepperFormScaffold(
     message = "Use Stepper.Nudger instead",
     replaceWith = ReplaceWith(
         "Stepper.Nudger(value = value, onValueChange = onValueChange, modifier = modifier, range = range, " +
-                "suffix = suffix, step = step, enabled = enabled, flexible = flexible, " +
-                "testTag = testTag, allowSemantics = allowSemantics)",
+            "suffix = suffix, step = step, enabled = enabled, flexible = flexible, " +
+            "testTag = testTag, allowSemantics = allowSemantics)",
         "com.adevinta.spark.components.stepper.Stepper",
     ),
     level = DeprecationLevel.WARNING,
@@ -648,9 +648,9 @@ public fun Stepper(
     message = "Use Stepper.NudgerForm instead",
     replaceWith = ReplaceWith(
         "Stepper.NudgerForm(value = value, onValueChange = onValueChange, label = label, helper = helper, " +
-                "modifier = modifier, range = range, suffix = suffix, step = step, enabled = enabled, " +
-                "required = required, status = status, statusMessage = statusMessage, flexible = flexible, " +
-                "testTag = testTag)",
+            "modifier = modifier, range = range, suffix = suffix, step = step, enabled = enabled, " +
+            "required = required, status = status, statusMessage = statusMessage, flexible = flexible, " +
+            "testTag = testTag)",
         "com.adevinta.spark.components.stepper.Stepper",
     ),
     level = DeprecationLevel.WARNING,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/stepper/Stepper.md
@@ -60,6 +60,7 @@ Stepper.Nudger(state = state)
 | `range` | `0..10` | Accepted value bounds; buttons disable at the limits |
 | `step` | `1` | Amount added or subtracted per button press |
 | `suffix` | `""` | String appended after the value, e.g. `" kg"` |
+| `placeholder` | `"-"` | Text shown in the empty state when `value` is `null` |
 | `enabled` | `true` | Disables interaction and applies disabled styling |
 | `flexible` | `false` | When `true`, fills maximum available width |
 
@@ -117,7 +118,7 @@ Stepper.NudgerForm(
 The Input variant places an editable text field between the buttons. Users can type a
 value directly or use the buttons. Non-digit characters are rejected, and the value is
 clamped to the range on blur. An empty field has `value == null`; the field then shows
-a `-` placeholder. Long-pressing a button repeats with acceleration.
+the `placeholder`, which defaults to `-`. Long-pressing a button repeats with acceleration.
 
 ```kotlin
 var quantity by rememberSaveable { mutableStateOf<Int?>(3) }
@@ -154,6 +155,7 @@ Text(text = "Current value: ${state.value ?: "empty"}")
 | `range` | `0..10` | Accepted value bounds |
 | `step` | `1` | Increment/decrement amount |
 | `suffix` | `""` | Shown after the value inside the field, e.g. `kg` |
+| `placeholder` | `"-"` | Text shown in the empty state when `value` is `null` |
 | `enabled` | `true` | Disables interaction |
 | `status` | `null` | Validation state; tints the inner text field border |
 | `flexible` | `false` | When `true`, fills maximum available width |


### PR DESCRIPTION
## 📋 Changes

- Adds `placeholder: String = "-"` to all eight public `Stepper` overloads and passes it through to `SparkNudger`.
- Applies `sparkUsageOverlay()` to each overload, which was also absent from the public wrappers. 
- Docs and screenshot tests updated to match the changes and center the.

## 🤔 Context

`placeholder` existed on `SparkNudger` but was never forwarded by any of the public overloads, so callers had no way to override the text shown when `value` is `null`.

## ✅ Checklist

- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.
