### PR TITLE
fix(tabgroup): remove background

### DIFF
--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tab/TabsScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tab/TabsScreenshot.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowColumn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.VerticalDragHandleDefaults.sizes
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.DefaultTestDevices
@@ -43,8 +44,6 @@ import org.junit.Test
 
 internal class TabsScreenshot {
 
-    private val sizes = TabSize.entries
-
     private val intents = TabIntent.entries
 
     @get:Rule
@@ -57,61 +56,55 @@ internal class TabsScreenshot {
     @Test
     fun enabled() {
         paparazzi.sparkSnapshot {
-            sizes.forEach { size ->
-                FlowColumn {
-                    intents.forEach { intent ->
-                        Column {
-                            TabGroup(
-                                selectedTabIndex = 0,
+            FlowColumn {
+                intents.forEach { intent ->
+                    Column {
+                        TabGroup(
+                            selectedTabIndex = 0,
+                            intent = intent,
+                        ) {
+                            Tab(
+                                selected = true,
+                                onClick = {},
                                 intent = intent,
-                            ) {
-                                Tab(
-                                    selected = true,
-                                    onClick = {},
-                                    intent = intent,
-                                    size = size,
-                                    enabled = true,
-                                    text = "Home",
-                                )
-                                Tab(
-                                    selected = false,
-                                    onClick = {},
-                                    intent = intent,
-                                    size = size,
-                                    text = "Message",
-                                    enabled = true,
-                                    icon = LeboncoinIcons.BubbleTextOutline,
-                                    trailingContent = {
-                                        Badge(count = 5)
-                                    },
-                                )
-                            }
-                            TabGroup(
-                                selectedTabIndex = 0,
+                                enabled = true,
+                                text = "Home",
+                            )
+                            Tab(
+                                selected = false,
+                                onClick = {},
                                 intent = intent,
-                                spacedEvenly = false,
-                            ) {
-                                Tab(
-                                    selected = true,
-                                    onClick = {},
-                                    intent = intent,
-                                    size = size,
-                                    enabled = true,
-                                    text = "Home",
-                                )
-                                Tab(
-                                    selected = false,
-                                    onClick = {},
-                                    intent = intent,
-                                    size = size,
-                                    text = "Message",
-                                    enabled = true,
-                                    icon = LeboncoinIcons.BubbleTextOutline,
-                                    trailingContent = {
-                                        Badge(count = 5)
-                                    },
-                                )
-                            }
+                                text = "Message",
+                                enabled = true,
+                                icon = LeboncoinIcons.BubbleTextOutline,
+                                trailingContent = {
+                                    Badge(count = 5)
+                                },
+                            )
+                        }
+                        TabGroup(
+                            selectedTabIndex = 0,
+                            intent = intent,
+                            spacedEvenly = false,
+                        ) {
+                            Tab(
+                                selected = true,
+                                onClick = {},
+                                intent = intent,
+                                enabled = true,
+                                text = "Home",
+                            )
+                            Tab(
+                                selected = false,
+                                onClick = {},
+                                intent = intent,
+                                text = "Message",
+                                enabled = true,
+                                icon = LeboncoinIcons.BubbleTextOutline,
+                                trailingContent = {
+                                    Badge(count = 5)
+                                },
+                            )
                         }
                     }
                 }
@@ -123,63 +116,57 @@ internal class TabsScreenshot {
     @Test
     fun disabled() {
         paparazzi.sparkSnapshot {
-            sizes.forEach { size ->
-                FlowColumn(
-                    modifier = Modifier.padding(bottom = 8.dp),
-                ) {
-                    intents.forEach { intent ->
-                        Column {
-                            TabGroup(
-                                selectedTabIndex = 0,
+            FlowColumn(
+                modifier = Modifier.padding(bottom = 8.dp),
+            ) {
+                intents.forEach { intent ->
+                    Column {
+                        TabGroup(
+                            selectedTabIndex = 0,
+                            intent = intent,
+                        ) {
+                            Tab(
+                                selected = true,
+                                onClick = {},
                                 intent = intent,
-                            ) {
-                                Tab(
-                                    selected = true,
-                                    onClick = {},
-                                    intent = intent,
-                                    size = size,
-                                    text = "Home",
-                                    enabled = false,
-                                )
-                                Tab(
-                                    selected = false,
-                                    onClick = {},
-                                    intent = intent,
-                                    size = size,
-                                    text = "Message",
-                                    icon = LeboncoinIcons.BubbleTextOutline,
-                                    enabled = false,
-                                    trailingContent = {
-                                        Badge(count = 5)
-                                    },
-                                )
-                            }
-                            TabGroup(
-                                selectedTabIndex = 0,
+                                text = "Home",
+                                enabled = false,
+                            )
+                            Tab(
+                                selected = false,
+                                onClick = {},
                                 intent = intent,
-                                spacedEvenly = false,
-                            ) {
-                                Tab(
-                                    selected = true,
-                                    onClick = {},
-                                    intent = intent,
-                                    size = size,
-                                    text = "Home",
-                                    enabled = false,
-                                )
-                                Tab(
-                                    selected = false,
-                                    onClick = {},
-                                    intent = intent,
-                                    size = size,
-                                    text = "Message",
-                                    icon = LeboncoinIcons.BubbleTextOutline,
-                                    enabled = false,
-                                    trailingContent = {
-                                        Badge(count = 5)
-                                    },
-                                )
-                            }
+                                text = "Message",
+                                icon = LeboncoinIcons.BubbleTextOutline,
+                                enabled = false,
+                                trailingContent = {
+                                    Badge(count = 5)
+                                },
+                            )
+                        }
+                        TabGroup(
+                            selectedTabIndex = 0,
+                            intent = intent,
+                            spacedEvenly = false,
+                        ) {
+                            Tab(
+                                selected = true,
+                                onClick = {},
+                                intent = intent,
+                                text = "Home",
+                                enabled = false,
+                            )
+                            Tab(
+                                selected = false,
+                                onClick = {},
+                                intent = intent,
+                                text = "Message",
+                                icon = LeboncoinIcons.BubbleTextOutline,
+                                enabled = false,
+                                trailingContent = {
+                                    Badge(count = 5)
+                                },
+                            )
                         }
                     }
                 }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroup.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroup.kt
@@ -52,7 +52,6 @@ import com.adevinta.spark.InternalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.badge.Badge
 import com.adevinta.spark.components.divider.HorizontalDivider
-import com.adevinta.spark.components.surface.Surface
 import com.adevinta.spark.components.tab.TabGroupDefaults.tabIndicatorOffset
 import com.adevinta.spark.icons.BubbleTextOutline
 import com.adevinta.spark.icons.LeboncoinIcons
@@ -103,106 +102,102 @@ internal fun SparkTabGroup(
     },
     tabs: @Composable () -> Unit,
 ) {
-    Surface(
-        modifier = modifier,
-    ) {
-        val scrollState = rememberScrollState()
-        val coroutineScope = rememberCoroutineScope()
-        val scrollableTabData = remember(scrollState, coroutineScope) {
-            ScrollableTabData(
-                scrollState = scrollState,
-                coroutineScope = coroutineScope,
+    val scrollState = rememberScrollState()
+    val coroutineScope = rememberCoroutineScope()
+    val scrollableTabData = remember(scrollState, coroutineScope) {
+        ScrollableTabData(
+            scrollState = scrollState,
+            coroutineScope = coroutineScope,
+        )
+    }
+    var tabRowWidth by remember { mutableIntStateOf(Int.MAX_VALUE) }
+    BoxWithConstraints {
+        tabRowWidth = constraints.maxWidth
+    }
+    SubcomposeLayout(
+        modifier
+            .fillMaxWidth()
+            .wrapContentSize(align = Alignment.CenterStart)
+            .horizontalScroll(scrollState)
+            .selectableGroup()
+            .clipToBounds(),
+    ) { constraints ->
+        val minTabWidth = TabGroupDefaults.minTabWidth.roundToPx()
+        val tabMeasurables = subcompose(TabSlots.Tabs, tabs)
+        val layoutHeight = tabMeasurables.fold(initial = 0) { curr, measurable ->
+            maxOf(curr, measurable.maxIntrinsicHeight(Constraints.Infinity))
+        }
+        val tabCount = tabMeasurables.size
+        val tabWidth = (tabRowWidth / tabCount)
+        val tabConstraints = constraints.copy(
+            minWidth = minTabWidth,
+            minHeight = layoutHeight,
+            maxHeight = constraints.maxHeight.coerceAtLeast(layoutHeight),
+        )
+
+        var tabWidthList = tabMeasurables.map {
+            it.maxIntrinsicWidth(Constraints.Infinity).coerceAtLeast(minTabWidth)
+        }
+        val layoutWidth = tabWidthList.sum()
+
+        val scrollable = !(spacedEvenly && tabRowWidth >= layoutWidth)
+        if (scrollable.not()) {
+            val oversizedTabs = tabWidthList.filter { it > tabWidth }
+            val maxEqualTabWidth = (tabRowWidth - oversizedTabs.sum()) / (tabCount - oversizedTabs.size)
+            tabWidthList = tabWidthList.map { maxOf(maxEqualTabWidth, it) }
+        }
+        mutableListOf<Dp>()
+        val tabPlaceables = tabMeasurables.mapIndexed { i, tab ->
+            tab.measure(
+                if (scrollable) {
+                    tabConstraints
+                } else {
+                    tabConstraints.copy(
+                        minWidth = tabWidthList[i],
+                        maxWidth = tabWidthList[i],
+                    )
+                },
             )
         }
-        var tabRowWidth by remember { mutableIntStateOf(Int.MAX_VALUE) }
-        BoxWithConstraints {
-            tabRowWidth = constraints.maxWidth
-        }
-        SubcomposeLayout(
-            Modifier
-                .fillMaxWidth()
-                .wrapContentSize(align = Alignment.CenterStart)
-                .horizontalScroll(scrollState)
-                .selectableGroup()
-                .clipToBounds(),
-        ) { constraints ->
-            val minTabWidth = TabGroupDefaults.minTabWidth.roundToPx()
-            val tabMeasurables = subcompose(TabSlots.Tabs, tabs)
-            val layoutHeight = tabMeasurables.fold(initial = 0) { curr, measurable ->
-                maxOf(curr, measurable.maxIntrinsicHeight(Constraints.Infinity))
+
+        layout(if (scrollable) layoutWidth else tabRowWidth, layoutHeight) {
+            /* Tabs */
+            var left = 0
+            val tabPositions = mutableListOf<TabPosition>()
+            tabPlaceables.fastForEachIndexed { index, placeable ->
+                placeable.placeRelative(left, 0)
+                tabPositions.add(
+                    TabPosition(
+                        left = left.toDp(),
+                        width = placeable.width.toDp(),
+                    ),
+                )
+                left += placeable.width
             }
-            val tabCount = tabMeasurables.size
-            val tabWidth = (tabRowWidth / tabCount)
-            val tabConstraints = constraints.copy(
-                minWidth = minTabWidth,
-                minHeight = layoutHeight,
-                maxHeight = constraints.maxHeight.coerceAtLeast(layoutHeight),
+            /* Divider */
+            subcompose(TabSlots.Divider, divider).forEach {
+                val placeable = it.measure(
+                    constraints.copy(
+                        minHeight = 0,
+                        minWidth = if (scrollable) layoutWidth else tabRowWidth,
+                        maxWidth = if (scrollable) layoutWidth else tabRowWidth,
+                    ),
+                )
+                placeable.placeRelative(0, layoutHeight - placeable.height)
+            }
+            /* Indicator */
+            subcompose(TabSlots.Indicator) { indicator(tabPositions) }
+                .fastForEach {
+                    it.measure(Constraints.fixed(if (scrollable) layoutWidth else tabRowWidth, layoutHeight))
+                        .placeRelative(0, 0)
+                }
+
+            scrollableTabData.onLaidOut(
+                density = this@SubcomposeLayout,
+                edgeOffset = 0,
+                tabPositions = tabPositions,
+                selectedTab = selectedTabIndex,
             )
-
-            var tabWidthList = tabMeasurables.map {
-                it.maxIntrinsicWidth(Constraints.Infinity).coerceAtLeast(minTabWidth)
-            }
-            val layoutWidth = tabWidthList.sum()
-
-            val scrollable = !(spacedEvenly && tabRowWidth >= layoutWidth)
-            if (scrollable.not()) {
-                val oversizedTabs = tabWidthList.filter { it > tabWidth }
-                val maxEqualTabWidth = (tabRowWidth - oversizedTabs.sum()) / (tabCount - oversizedTabs.size)
-                tabWidthList = tabWidthList.map { maxOf(maxEqualTabWidth, it) }
-            }
-            mutableListOf<Dp>()
-            val tabPlaceables = tabMeasurables.mapIndexed { i, tab ->
-                tab.measure(
-                    if (scrollable) {
-                        tabConstraints
-                    } else {
-                        tabConstraints.copy(
-                            minWidth = tabWidthList[i],
-                            maxWidth = tabWidthList[i],
-                        )
-                    },
-                )
-            }
-
-            layout(if (scrollable) layoutWidth else tabRowWidth, layoutHeight) {
-                /* Tabs */
-                var left = 0
-                val tabPositions = mutableListOf<TabPosition>()
-                tabPlaceables.fastForEachIndexed { index, placeable ->
-                    placeable.placeRelative(left, 0)
-                    tabPositions.add(
-                        TabPosition(
-                            left = left.toDp(),
-                            width = placeable.width.toDp(),
-                        ),
-                    )
-                    left += placeable.width
-                }
-                /* Divider */
-                subcompose(TabSlots.Divider, divider).forEach {
-                    val placeable = it.measure(
-                        constraints.copy(
-                            minHeight = 0,
-                            minWidth = if (scrollable) layoutWidth else tabRowWidth,
-                            maxWidth = if (scrollable) layoutWidth else tabRowWidth,
-                        ),
-                    )
-                    placeable.placeRelative(0, layoutHeight - placeable.height)
-                }
-                /* Indicator */
-                subcompose(TabSlots.Indicator) { indicator(tabPositions) }
-                    .fastForEach {
-                        it.measure(Constraints.fixed(if (scrollable) layoutWidth else tabRowWidth, layoutHeight))
-                            .placeRelative(0, 0)
-                    }
-
-                scrollableTabData.onLaidOut(
-                    density = this@SubcomposeLayout,
-                    edgeOffset = 0,
-                    tabPositions = tabPositions,
-                    selectedTab = selectedTabIndex,
-                )
-            }
         }
     }
 }


### PR DESCRIPTION
## 📋 Changes

- Remove `Surface` from `TabGroup` to ensure the `TabGroup` doesn't have any background

## 🤔 Context

By using `Surface`, `TabGroup` used to have a background which renders fine on part theme but is problematic for pro theme

| Part Theme | Pro Theme |
| -------- | -------------- |
| <img width="270" height="600" alt="Screenshot_20260820_113838" src="https://github.com/user-attachments/assets/0acd4c68-4ee1-43a0-bcb7-4bb3995e4c7c" />  | <img width="270" height="600" alt="Screenshot_20260820_113830" src="https://github.com/user-attachments/assets/38a10111-01ea-4da6-a71d-74f67bed1eaa" /> |
| <img width="270" height="600" alt="Screenshot_20260820_113855" src="https://github.com/user-attachments/assets/a31f2cc9-31ad-4aa9-ac8f-d58f7080e1c5" /> | <img width="270" height="600" alt="Screenshot_20260820_113901" src="https://github.com/user-attachments/assets/53361ff4-c99b-41fb-8cee-7bab47f7c54f" /> |


By removing the `Surface`, the result looks as expected

| Part Theme | Pro Theme |
| -------- | -------------- |
| <img width="270" height="600" alt="Screenshot_20260820_114011" src="https://github.com/user-attachments/assets/2b1e9eb7-26b9-4e20-955f-0141306cb8bb" /> | <img width="270" height="600" alt="Screenshot_20260820_114018" src="https://github.com/user-attachments/assets/b6855c27-fb68-484f-9b91-9cc45c308cdb" /> |
| <img width="270" height="600" alt="Screenshot_20260820_114005" src="https://github.com/user-attachments/assets/d8e42b29-7ead-4930-b6aa-88a5cbf90e8b" /> | <img width="270" height="600" alt="Screenshot_20260820_113959" src="https://github.com/user-attachments/assets/439b2f29-2e25-466f-ac7c-7cde5d81c1c0" /> |





## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

