### PR TITLE
docs(placeholder): add screenshots to KDoc for placeholder modifiers

### DIFF
--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/placeholder/PlaceholderDocumentationScreenshots.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/components/placeholder/PlaceholderDocumentationScreenshots.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.placeholder
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.DefaultTestDevices
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.paparazziRule
+import com.adevinta.spark.sparkDocSnapshot
+import com.android.ide.common.rendering.api.SessionParams.RenderingMode.SHRINK
+import org.junit.Rule
+import org.junit.Test
+
+/** Documentation screenshots for the placeholder modifiers, each shown in light and dark theme side by side. */
+internal class PlaceholderDocumentationScreenshots {
+
+    @get:Rule
+    val paparazzi = paparazziRule(
+        renderingMode = SHRINK,
+        deviceConfig = DefaultTestDevices.DocPhone,
+    )
+
+    @Test
+    fun placeholder() = paparazzi.sparkDocSnapshot {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp)
+                .placeholder(visible = true),
+        )
+    }
+
+    @Test
+    fun textPlaceholder() = paparazzi.sparkDocSnapshot {
+        Text(
+            text = "Text placeholder",
+            modifier = Modifier.textPlaceholder(visible = true),
+        )
+    }
+
+    @Test
+    fun illustrationPlaceholder() = paparazzi.sparkDocSnapshot {
+        Box(
+            modifier = Modifier
+                .size(128.dp)
+                .illustrationPlaceholder(visible = true, shape = SparkTheme.shapes.extraLarge),
+        )
+    }
+}

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.placeholder_PlaceholderDocumentationScreenshots_illustrationPlaceholder.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.placeholder_PlaceholderDocumentationScreenshots_illustrationPlaceholder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f006c02f949770beaf5e1d5233a3be76ebc78f2028af7a99119def029f284db
+size 12402

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.placeholder_PlaceholderDocumentationScreenshots_placeholder.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.placeholder_PlaceholderDocumentationScreenshots_placeholder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3131a0e63a48f7a66bb754b34a2b10ddfd5554d2c4b5dac7dc9c82d6c5339aea
+size 7999

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.placeholder_PlaceholderDocumentationScreenshots_textPlaceholder.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.components.placeholder_PlaceholderDocumentationScreenshots_textPlaceholder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e270a7cb7d124fd26148837d2d8b12cc7f433b214e4b4ee9f4a73a71b40a51b
+size 7944

--- a/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/Placeholder.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/Placeholder.kt
@@ -50,6 +50,8 @@ import com.adevinta.spark.components.text.Text
  * [Placeholder UI](https://material.io/design/communication/launch-screen.html#placeholder-ui)
  * guidelines.
  *
+ * ![Placeholder](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.placeholder_PlaceholderDocumentationScreenshots_placeholder.png)
+ *
  * @param visible whether the placeholder should be visible or not.
  */
 public fun Modifier.placeholder(visible: Boolean): Modifier = basePlaceholder(visible = visible)
@@ -67,6 +69,8 @@ public fun Modifier.placeholder(visible: Boolean): Modifier = basePlaceholder(vi
  * You can find more information on the pattern at the Material Theming
  * [Placeholder UI](https://material.io/design/communication/launch-screen.html#placeholder-ui)
  * guidelines.
+ *
+ * ![Text Placeholder](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.placeholder_PlaceholderDocumentationScreenshots_textPlaceholder.png)
  *
  * @param visible whether the placeholder should be visible or not.
  */
@@ -88,6 +92,8 @@ public fun Modifier.textPlaceholder(visible: Boolean): Modifier = basePlaceholde
  * You can find more information on the pattern at the Material Theming
  * [Placeholder UI](https://material.io/design/communication/launch-screen.html#placeholder-ui)
  * guidelines.
+ *
+ * ![Illustration Placeholder](https://leboncoin.github.io/spark-android/images/com.adevinta.spark.components.placeholder_PlaceholderDocumentationScreenshots_illustrationPlaceholder.png)
  *
  * @param visible whether the placeholder should be visible or not.
  * @param shape desired shape of the placeholder. If null is provided the placeholder


### PR DESCRIPTION
Adds documentation screenshots and KDoc image links for `placeholder`, `textPlaceholder`, and `illustrationPlaceholder`. Each modifier's KDoc had no preview, so the generated API docs gave no visual hint of the shimmer effect.

Verified the three screenshots render correctly in the Dokka output.
