### PR TITLE
docs(contributing): update JDK requirement and KDoc URLs

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Url.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Url.kt
@@ -36,13 +36,13 @@ public const val GuidelinesUrl: String = "https://spark.adevinta.com"
 public const val ComponentGuidelinesUrl: String = "https://spark.adevinta.com/1186e1705"
 public const val StyleGuidelinesUrl: String = "https://m3.material.io/styles"
 public const val ReleasesUrl: String = "https://github.com/leboncoin/spark-android/releases"
-public const val DocsUrl: String = "https://adevinta.github.io/spark-android"
+public const val DocsUrl: String = "https://leboncoin.github.io/spark-android"
 public const val SourceUrl: String = "https://github.com/leboncoin/spark-android"
 public const val SparkSourceUrl: String = "https://github.com/leboncoin/spark-android/tree/main/spark/src/main"
 
 public const val SampleSourceUrl: String = "https://github.com/leboncoin/spark-android/blob/main/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples"
 
-public const val PackageSummaryUrl: String = "https://adevinta.github.io/spark-android/spark"
+public const val PackageSummaryUrl: String = "https://leboncoin.github.io/spark-android/spark"
 
 public const val IssueUrl: String = "https://github.com/leboncoin/spark-android/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc"
 public const val LicensesUrl: String = "https://github.com/leboncoin/spark-android/blob/main/LICENSE"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -93,21 +93,18 @@ Configure your development environment for Spark Android development. This secti
     git lfs install
     ```
 
-4. **[Java 17](https://github.com/leboncoin/spark-android/issues/74)**
+4. **Java Development Kit (JDK)**
 
-    We currently use a version of AGP which requires developers to use **JDK 17** on Gradle JDK.
+    **JDK 17 or later** is required to build the project and run the Gradle daemon.
 
-    _If you're on macOS, you can install it with [brew](https://formulae.brew.sh/formula/openjdk@17)_
+    _If you're on macOS, you can install it with [Homebrew](https://formulae.brew.sh/formula/openjdk@17)_:
 
     ```bash
     brew install openjdk@17
     ```
 
-    > ℹ️ If you're using a device with [Apple silicon (M1/M2)](https://support.apple.com/en-us/HT211814) then you might need to install
-    > a [zulu distribution](https://www.azul.com/downloads/zulu-community/?version=java-17-lts&architecture=x86-64-bit&package=jdk)
-
-    Alternatively, install it directly from **Android Studio**:  
-    `File` → `Settings` → `Build, Execution, Deployment` → `Build Tools` → `Gradle` → `Gradle JDK`
+    Alternatively, configure or download it directly from **Android Studio**:  
+    `Settings` → `Build, Execution, Deployment` → `Build Tools` → `Gradle` → `Gradle JDK`
 
 ---
 


### PR DESCRIPTION
## Problem
1. `docs/CONTRIBUTING.md` stated that developers must use JDK 17 based on an outdated AGP requirement from issue #74 (#2107).
2. `catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Url.kt` pointed `DocsUrl` and `PackageSummaryUrl` to `adevinta.github.io/spark-android` which causes 404s/wrong project links instead of the current `leboncoin.github.io/spark-android` deployment (#2105).

## Root Cause
- AGP has since been updated to 9.x (and CI runs on modern JDKs), making the hardcoded link to issue #74 stale and misleading.
- KDoc hosting moved to the `leboncoin` GitHub organization when repository ownership transitioned.

## Solution
- Updated `docs/CONTRIBUTING.md` to directly specify that JDK 17 or later is required to build the project and run the Gradle daemon, removing the stale issue #74 reference.
- Updated `DocsUrl` and `PackageSummaryUrl` in `Url.kt` to point to `https://leboncoin.github.io/spark-android` and `https://leboncoin.github.io/spark-android/spark`.

## Testing
- Verified Markdown formatting in `docs/CONTRIBUTING.md`.
- Verified URL validity in `Url.kt`.

## Risk
Zero runtime risk; documentation and catalog link update only.

## Issue
Closes #2107
Closes #2105
